### PR TITLE
Paraglide Hotifx

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @inlang/paraglide-js
 
+## 1.0.0-prerelease.25
+
+Update dependencies
+
 ## 1.0.0-prerelease.24
 
 feat: Support language Fallbacks according to BCP 47 specification

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-js",
 	"type": "module",
-	"version": "1.0.0-prerelease.24",
+	"version": "1.0.0-prerelease.25",
 	"license": "Apache-2.0",
 	"publishConfig": {
 		"access": "public"
@@ -42,7 +42,6 @@
 		"@inlang/language-tag": "workspace:*",
 		"@inlang/detect-json-formatting": "workspace:*",
 		"@inlang/sdk": "workspace:*",
-		"@lix-js/fs": "workspace:*",
 		"commander": "11.1.0",
 		"consola": "3.2.3",
 		"dedent": "1.5.1",
@@ -58,6 +57,7 @@
 		"@ts-morph/bootstrap": "0.20.0",
 		"@types/minimist": "1.2.3",
 		"@vitest/coverage-v8": "0.34.3",
+		"@lix-js/fs": "workspace:*",
 		"cross-env": "^7.0.3",
 		"esbuild": "^0.19.7",
 		"memfs": "4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,9 +1065,6 @@ importers:
       '@inlang/sdk':
         specifier: workspace:*
         version: link:../../sdk
-      '@lix-js/fs':
-        specifier: workspace:*
-        version: link:../../../../lix/source-code/fs
       commander:
         specifier: 11.1.0
         version: 11.1.0
@@ -1093,6 +1090,9 @@ importers:
       '@inlang/telemetry':
         specifier: workspace:*
         version: link:../../telemetry
+      '@lix-js/fs':
+        specifier: workspace:*
+        version: link:../../../../lix/source-code/fs
       '@rollup/plugin-terser':
         specifier: 0.4.3
         version: 0.4.3(rollup@3.29.1)


### PR DESCRIPTION
This PR moves @lix-js/fs to dev dependencies. Apparently loading lix-fs in an ESM environment breaks. 