### PR TITLE
Bump Paraglide version to 1.0

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @inlang/paraglide-js
 
+## 1.0.0
+
+Bump Version to 1.0 as no more breaking changes are expected.
+
 ## 1.0.0-prerelease.26
 
 Hotfix: Bundle SDK

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-js",
 	"type": "module",
-	"version": "1.0.0-prerelease.27",
+	"version": "1.0.0",
 	"license": "Apache-2.0",
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
This PR bumps the Paraglide Version to 1.0, because no more breaking changes are planned & the current release is pretty robust. This also means I can finally start using changesets to manage releases