### PR TITLE
Paraglide Fix messageID fallback formatting

### DIFF
--- a/.changeset/sixty-rules-cross.md
+++ b/.changeset/sixty-rules-cross.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix: better formatting of messageID fallbacks

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
@@ -151,7 +151,9 @@ function reexportMessage(messageId: string, fromLanguageTag: string) {
 
 function messageIdFallback(messageId: string, languageTag: string) {
 	return `/**
-	* Failed to resolve message ${messageId} for languageTag "${languageTag}". 
-	*/
-	export const ${messageId} = () => "${escapeForDoubleQuoteString(messageId)}"`
+* Failed to resolve message ${messageId} for languageTag "${languageTag}". 
+* @returns {string}
+*/
+/* @__NO_SIDE_EFFECTS__ */
+export const ${messageId} = () => "${escapeForDoubleQuoteString(messageId)}"`
 }


### PR DESCRIPTION
This PR fixes the formatting on messageID fallbacks. It really annoyed me and it took like 2 seconds to fix