### PR TITLE
[fix] Run Paraglide compile during test command in Paraglide Example

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/example/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/example/package.json
@@ -6,7 +6,7 @@
 		"_dev": "paraglide-js compile --project ./project.inlang --watch",
 		"build": "paraglide-js compile --project ./project.inlang && tsc",
 		"pretest": "paraglide-js compile --project ./project.inlang",
-		"test": "vitest run"
+		"test": "pnpm build && vitest run"
 	},
 	"dependencies": {
 		"@inlang/paraglide-js": "workspace:*"


### PR DESCRIPTION
This PR also runs `paraglide-js compile` during the `test` script of the paraglide example. This avoids a race condition