### PR TITLE
Paraglide: Throw runtime error if `languageTag()` returns a non-language tag value

### DIFF
--- a/.changeset/soft-impalas-tease.md
+++ b/.changeset/soft-impalas-tease.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+Throw runtime error if `languageTag()` returns a non-language tag value

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -263,6 +263,20 @@ describe("e2e", async () => {
 		runtime.setLanguageTag("en-US")
 		expect(m.missingInGerman()).toBe("A simple message.")
 	})
+
+	test("throws an error if languageTag() returns a non-languageTag value", async () => {
+		const { m, runtime } = await import(
+			`data:application/javascript;base64,${Buffer.from(
+				compiledBundle.output[0].code,
+				"utf8"
+			).toString("base64")}`
+		)
+
+		expect(() => {
+			runtime.setLanguageTag("dsklfgj")
+			runtime.languageTag()
+		}).toThrow()
+	})
 })
 
 describe("tree-shaking", () => {

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -265,7 +265,7 @@ describe("e2e", async () => {
 	})
 
 	test("throws an error if languageTag() returns a non-languageTag value", async () => {
-		const { m, runtime } = await import(
+		const { runtime } = await import(
 			`data:application/javascript;base64,${Buffer.from(
 				compiledBundle.output[0].code,
 				"utf8"

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
@@ -133,13 +133,28 @@ export let languageTag = () => sourceLanguageTag
  */
 export const setLanguageTag = (tag) => {
 	if (typeof tag === "function") {
-		languageTag = tag
+		languageTag = enforceLanguageTag(tag)
 	} else {
-		languageTag = () => tag
+		languageTag = enforceLanguageTag(() => tag)
 	}
 	// call the callback function if it has been defined
 	if (_onSetLanguageTag !== undefined) {
 		_onSetLanguageTag(languageTag())
+	}
+}
+
+/**
+ * Wraps an untrusted function and enforces that it returns a language tag.
+ * @param {() => AvailableLanguageTag} unsafeLanguageTag
+ * @returns {() => AvailableLanguageTag}
+ */
+function enforceLanguageTag(unsafeLanguageTag) {
+	return () => {
+		const tag = unsafeLanguageTag()
+		if(!isAvailableLanguageTag(tag)) {
+			throw new Error(\`languageTag() didn't return a valid language tag. Check your setLanguageTag call\`)
+		}
+		return tag
 	}
 }
 


### PR DESCRIPTION
This PR enforces that `languageTag()` returns a valid language Tag. Not doing that can lead to some difficult-to-debug issues, so having a descriptive Runtime error makes sense here. TypeScript is supposed to enforce it, but if someone type-casts incorrectly it won't help them. 