### PR TITLE
Improve camel case regex

### DIFF
--- a/inlang/source-code/message-lint-rules/camelCaseId/src/isCamelCaseId.test.ts
+++ b/inlang/source-code/message-lint-rules/camelCaseId/src/isCamelCaseId.test.ts
@@ -7,6 +7,8 @@ describe("isCamelCaseId", () => {
 		expect(isCamelCaseId("myVariable")).toBe(true)
 		expect(isCamelCaseId("anotherVariable")).toBe(true)
 		expect(isCamelCaseId("mixedCaseIdentifier")).toBe(true)
+		expect(isCamelCaseId("a11yCamelCase")).toBe(true)
+		expect(isCamelCaseId("contactBudget10k")).toBe(true)
 	})
 
 	// Test case: invalid camelCase identifiers
@@ -15,6 +17,10 @@ describe("isCamelCaseId", () => {
 		expect(isCamelCaseId("123Variable")).toBe(false) // starts with a number
 		expect(isCamelCaseId("special-Variable")).toBe(false) // contains special character
 		expect(isCamelCaseId("snake_case")).toBe(false) // not camelCase
+		expect(isCamelCaseId("PascalCase")).toBe(false) // not camelCase
+		expect(isCamelCaseId("kebab-case")).toBe(false) // not camelCase
+		expect(isCamelCaseId("homeCTASubtitle")).toBe(false) // contains multiple uppercase letters
+		expect(isCamelCaseId("homeSubtitleCTA")).toBe(false) // contains multiple uppercase letters
 	})
 
 	// Test case: edge cases

--- a/inlang/source-code/message-lint-rules/camelCaseId/src/isCamelCaseId.ts
+++ b/inlang/source-code/message-lint-rules/camelCaseId/src/isCamelCaseId.ts
@@ -1,3 +1,3 @@
 export const isCamelCaseId = (id: string) => {
-	return /^[a-z]+([A-Z][a-z]+)*$/.test(id)
+	return /^[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?$/.test(id)
 }


### PR DESCRIPTION
As discussed on Discord, improve camel case regex to handle numbers and fit the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html#s5.3-camel-case). Based on a [StackOverflow answer](https://stackoverflow.com/questions/1128305/regex-for-pascalcased-words-aka-camelcased-with-leading-uppercase-letter/47591707#47591707).