### PR TITLE
refactor: isValidLanguageTag function in languageTag module [skip preview]

### DIFF
--- a/.changeset/wild-jeans-do.md
+++ b/.changeset/wild-jeans-do.md
@@ -1,0 +1,6 @@
+---
+"@inlang/language-tag": minor
+"@inlang/manage": minor
+---
+
+Add isValidLanguageTag function

--- a/inlang/source-code/editor/src/pages/@host/@owner/@repository/Layout.tsx
+++ b/inlang/source-code/editor/src/pages/@host/@owner/@repository/Layout.tsx
@@ -18,7 +18,7 @@ import IconSettings from "~icons/material-symbols/settings-outline"
 import IconDescription from "~icons/material-symbols/description-outline"
 import { WarningIcon } from "./components/Notification/NotificationHint.jsx"
 import { showToast } from "#src/interface/components/Toast.jsx"
-import type { LanguageTag } from "@inlang/sdk"
+import { isValidLanguageTag, type LanguageTag } from "@inlang/sdk"
 import { sortLanguageTags } from "./helper/sortLanguageTags.js"
 import EditorLayout from "#src/interface/editor/EditorLayout.jsx"
 import Link from "#src/renderer/Link.jsx"
@@ -53,13 +53,6 @@ export function Layout(props: { children: JSXElement }) {
 
 	const [addLanguageModalOpen, setAddLanguageModalOpen] = createSignal(false)
 	const [addLanguageText, setAddLanguageText] = createSignal("")
-
-	// check if the type matches the LanguageTag type
-	const isValidLanguageTag = (): boolean => {
-		const languageTagRegex =
-			/^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?))(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*))$/
-		return languageTagRegex.test(addLanguageText())
-	}
 
 	const [filterOptions, setFilterOptions] = createSignal<Filter[]>([
 		{
@@ -299,7 +292,7 @@ export function Layout(props: { children: JSXElement }) {
 					prop:placeholder={"Add a language tag"}
 					prop:helpText={
 						!(
-							(!isValidLanguageTag() && addLanguageText().length > 0) ||
+							(!isValidLanguageTag(addLanguageText()) && addLanguageText().length > 0) ||
 							project()?.settings().languageTags.includes(addLanguageText())
 						)
 							? "Unique tags for languages (e.g. -> en, de, fr)"
@@ -309,7 +302,7 @@ export function Layout(props: { children: JSXElement }) {
 					onPaste={(e) => setAddLanguageText(e.currentTarget.value)}
 					onInput={(e) => setAddLanguageText(e.currentTarget.value)}
 				/>
-				<Show when={!isValidLanguageTag() && addLanguageText().length > 0}>
+				<Show when={!isValidLanguageTag(addLanguageText()) && addLanguageText().length > 0}>
 					<p class="text-xs leading-5 text-danger max-sm:hidden pt-1 pb-0.5">
 						Please enter a valid{" "}
 						<a
@@ -336,7 +329,8 @@ export function Layout(props: { children: JSXElement }) {
 					prop:size={"small"}
 					prop:variant={"primary"}
 					prop:disabled={
-						!isValidLanguageTag() || project()?.settings().languageTags.includes(addLanguageText())
+						!isValidLanguageTag(addLanguageText()) ||
+						project()?.settings().languageTags.includes(addLanguageText())
 					}
 					onClick={() => {
 						addLanguageTag(addLanguageText())

--- a/inlang/source-code/manage/src/components/InlangManage.ts
+++ b/inlang/source-code/manage/src/components/InlangManage.ts
@@ -6,7 +6,7 @@ import { z } from "zod"
 import "./InlangUninstall"
 import "./InlangInstall"
 import { createNodeishMemoryFs, openRepository } from "@lix-js/client"
-import { listProjects } from "@inlang/sdk"
+import { listProjects, isValidLanguageTag } from "@inlang/sdk"
 import { publicEnv } from "@inlang/env-variables"
 import { browserAuth, getUser } from "@lix-js/server"
 import { tryCatch } from "@inlang/result"
@@ -193,14 +193,6 @@ export class InlangManage extends TwLitElement {
 			.url()
 			.regex(/github/)
 			.safeParse(this.repoURL).success
-
-	isValidLanguageTag = () =>
-		z
-			.string()
-			.regex(
-				/^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?))(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*))$/
-			)
-			.safeParse(this.newLanguageTag).success
 
 	override async connectedCallback() {
 		super.connectedCallback()
@@ -1112,7 +1104,7 @@ ${
 															if (
 																e.key === "Enter" &&
 																!this.newLanguageTagLoading &&
-																this.isValidLanguageTag()
+																isValidLanguageTag(this.newLanguageTag)
 															) {
 																;(
 																	this.shadowRoot?.querySelector(
@@ -1123,7 +1115,8 @@ ${
 															}
 														}}
 														class=${"px-3 py-1 focus:outline-0 focus:ring-0 bg-white border w-44 pr-6 truncate border-slate-200 rounded-xl flex items-center justify-between gap-2 " +
-														(this.newLanguageTag.length > 0 && !this.isValidLanguageTag()
+														(this.newLanguageTag.length > 0 &&
+														!isValidLanguageTag(this.newLanguageTag)
 															? "focus-within:border-red-500"
 															: "focus-within:border-[#098DAC]")}
 														placeholder="Add languageTag"
@@ -1133,7 +1126,7 @@ ${
 																<div class="h-5 w-5 border-2 border-[#098DAC] rounded-full"></div>
 																<div class="h-1/2 w-1/2 absolute top-0 left-0 z-5 bg-white"></div>
 														  </div>`
-														: !this.isValidLanguageTag()
+														: !isValidLanguageTag(this.newLanguageTag)
 														? ""
 														: html`<button
 																@click=${async () => await this.addLanguageTag()}

--- a/inlang/source-code/versioned-interfaces/language-tag/src/index.ts
+++ b/inlang/source-code/versioned-interfaces/language-tag/src/index.ts
@@ -1,2 +1,3 @@
 export { LanguageTag } from "./interface.js"
 export { lookup } from "./lookup.js"
+export { isValidLanguageTag } from "./validate.js"

--- a/inlang/source-code/versioned-interfaces/language-tag/src/interface.ts
+++ b/inlang/source-code/versioned-interfaces/language-tag/src/interface.ts
@@ -11,8 +11,11 @@ export type LanguageTag = Static<typeof LanguageTag>
  * Follows the IETF BCP 47 language tag schema with modifications.
  * @see REAMDE.md file for more information on the validation.
  */
+
+export const pattern =
+	"^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?))(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*))$"
+
 export const LanguageTag = Type.String({
-	pattern:
-		"^((?<grandfathered>(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?<language>([A-Za-z]{2,3}(-(?<extlang>[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?))(-(?<script>[A-Za-z]{4}))?(-(?<region>[A-Za-z]{2}|[0-9]{3}))?(-(?<variant>[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*))$",
+	pattern: pattern,
 	examples: ["en", "de", "en-US", "zh-Hans", "es-419"],
 })

--- a/inlang/source-code/versioned-interfaces/language-tag/src/validate.test.ts
+++ b/inlang/source-code/versioned-interfaces/language-tag/src/validate.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest"
+import { isValidLanguageTag } from "./validate.js"
+
+describe("validate language tags", () => {
+	test("should pass valid language tags", () => {
+		const validLanguageTags = [
+			"en",
+			"de",
+			"pt-BR",
+			"en-US",
+			"zh-Hans",
+			"de-DE",
+			"es-419",
+			"de-DE-1991",
+			"i-default",
+		]
+		for (const tag of validLanguageTags) {
+			const result = isValidLanguageTag(tag)
+			expect(result).toBe(true)
+		}
+	})
+	test("should detect invalid language tags", () => {
+		const invalidLanguageTags = [
+			"invalid",
+			"_US",
+			"en.US",
+			"en–US",
+			"en|US",
+			"de-",
+			"enUS",
+			"en_US",
+			"en-Testoooooo",
+			"fr-CA-QUÉ",
+			"en-US-InvalidVariant-12345",
+		]
+		for (const tag of invalidLanguageTags) {
+			const result = isValidLanguageTag(tag)
+			expect(result).toBe(false)
+		}
+	})
+})

--- a/inlang/source-code/versioned-interfaces/language-tag/src/validate.ts
+++ b/inlang/source-code/versioned-interfaces/language-tag/src/validate.ts
@@ -1,0 +1,4 @@
+import { pattern } from "./interface.js"
+
+export const isValidLanguageTag = (languageTag: string): boolean =>
+	RegExp(`${pattern}`).test(languageTag)


### PR DESCRIPTION
Changes:
- moves the `isValidLanguageTag` function to the `@inlang/language-tag` module
- refactor Fink and manage accordingly
- minor version bumb for `@inlang/language-tag` & `@inlang/manage`