### PR TITLE
[Lix fs] Add encoding option to `writeFile` type

### DIFF
--- a/lix/source-code/fs/src/NodeishFilesystemApi.ts
+++ b/lix/source-code/fs/src/NodeishFilesystemApi.ts
@@ -11,7 +11,11 @@
 export type NodeishFilesystem = {
 	// we need to expose internal state _State to the snapshotter without adding it to code completions
 	[x: string]: any
-	writeFile(path: string, data: string | Uint8Array, options?: { mode: number }): Promise<void>
+	writeFile(
+		path: string,
+		data: string | Uint8Array,
+		options?: { mode?: number; encoding?: "utf-8" }
+	): Promise<void>
 	readFile(path: string): Promise<Uint8Array>
 	readFile(path: string, options: { encoding: "utf-8" | "binary" }): Promise<string>
 	readdir(path: string): Promise<string[]>


### PR DESCRIPTION
This tripped me up when updating the Paraglide tests to use `NodeishFilesystem`. In regular node, you can specify the encoding when writing a file like so: `fs.writeFile("./file.txt", "I'm some content", {  encoding: "utf-8" })`. `utf-8` is the default, so this doesn't actually do anything, but being explicit is nice. 

This PR updates the type-definition of `NodeishFilesystem.writeFile` to also accept this encoding options. Only `utf-8` is allowed, so no behaviour changes are needed.