### PR TITLE
chore(paraglide-js): add `repository` entry in `package.json`

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -7,6 +7,11 @@
 		"access": "public"
 	},
 	"author": "inlang <hello@inlang.com> (https://inlang.com/)",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/opral/monorepo.git",
+		"directory": "inlang/source-code/paraglide/paraglide-js"
+	},
 	"keywords": [
 		"paraglide",
 		"javascript i18n",


### PR DESCRIPTION
This will allow Renovate to get the CHANGELOG hopefully
