### PR TITLE
CLI: Fix broken dependency

### DIFF
--- a/.changeset/weak-lizards-shout.md
+++ b/.changeset/weak-lizards-shout.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cli": patch
+---
+
+fix broken dependency

--- a/inlang/source-code/cli/package.json
+++ b/inlang/source-code/cli/package.json
@@ -58,7 +58,8 @@
 		"node-fetch": "^3.3.2",
 		"prompts": "^2.4.2",
 		"typescript": "5.2.2",
-		"vitest": "0.34.3"
+		"vitest": "0.34.3",
+		"@inlang/telemetry": "workspace:*"
 	},
 	"license": "Apache-2.0",
 	"__comment__": "the esbuild-wasm dependency must be a regular dependency to be resolved by the host system. otherwise, esbuild throws errors",
@@ -69,7 +70,6 @@
 		"@inlang/result": "workspace:*",
 		"@inlang/rpc": "workspace:*",
 		"@inlang/sdk": "workspace:*",
-		"@inlang/telemetry": "workspace:*",
 		"@lix-js/fs": "workspace:*",
 		"@lix-js/client": "workspace:*"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,9 +127,6 @@ importers:
       '@inlang/sdk':
         specifier: workspace:*
         version: link:../sdk
-      '@inlang/telemetry':
-        specifier: workspace:*
-        version: link:../telemetry
       '@lix-js/client':
         specifier: workspace:*
         version: link:../../../lix/source-code/client
@@ -143,6 +140,9 @@ importers:
         specifier: 11.1.1
         version: 11.1.1
     devDependencies:
+      '@inlang/telemetry':
+        specifier: workspace:*
+        version: link:../telemetry
       '@sentry/node':
         specifier: ^7.64.0
         version: 7.81.0


### PR DESCRIPTION
With this pr `@inlang/telemetry` is no longer listed as a dependency in `@inlang/cli`