### PR TITLE
Paraglide Adapter Sveltekit: `dir` option & moe

### DIFF
--- a/.changeset/famous-socks-leave.md
+++ b/.changeset/famous-socks-leave.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-sveltekit": minor
+---
+
+breaking: move `noAlternateLinks` option from `<ParaglideJS>` component to `seo` option on `createI18n`

--- a/.changeset/purple-planets-grow.md
+++ b/.changeset/purple-planets-grow.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-sveltekit": minor
+---
+
+feat: Add `dir` option to `createI18n` for text-direction. If omitted, an automatically detected text-direction will be used.

--- a/.changeset/purple-planets-grow.md
+++ b/.changeset/purple-planets-grow.md
@@ -2,4 +2,4 @@
 "@inlang/paraglide-js-adapter-sveltekit": minor
 ---
 
-feat: Add `dir` option to `createI18n` for text-direction. If omitted, an automatically detected text-direction will be used.
+feat: Add `textDirection` option to `createI18n` for text-direction. If omitted, an automatically detected text-direction will be used.

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -326,8 +326,6 @@ import * as runtime from "../paraglide/runtime.js"
 export const i18n = createI18n(runtime, {
 	dir: {
 		en: "ltr",
-		de: "ltr",
-		fr: "ltr",
 		ar: "rtl",
 	},
 })

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -127,10 +127,10 @@ Additionally, you need to add the `lang` and `dir` attributes to your `html` tag
 The easiest way to do this is to set the `lang` and `dir` attributes in `src/app.html` with an easy to recognize placeholder.
 
 ```html
-<html lang="%paraglide.lang%" dir="%paraglide.dir%"> 
+<html lang="%paraglide.lang%" dir="%paraglide.textDirection%"> 
 ```
 
-Then, in your `src/hooks.server.js` file, you can use `i18n.handle()` to replace the placeholders with the correct values. `%paraglide.lang%` and `%paraglide.dir%` are the default placeholders. You can change them by passing the `langPlaceholder` and `dirPlaceholder` options to `handle`.
+Then, in your `src/hooks.server.js` file, you can use `i18n.handle()` to replace the placeholders with the correct values. `%paraglide.lang%` and `%paraglide.textDirection%` are the default placeholders. You can change them by passing the `langPlaceholder` and `textDirectionPlaceholder` options to `handle`.
 
 
 ```js
@@ -139,7 +139,7 @@ import { i18n } from '$lib/i18n.js'
 export const handle = i18n.handle()
 ```
 
-The handle hook will also make `lang` and `dir` available in `event.locals.paraglide`, so you can use them elsewhere in your app.
+The handle hook will also make `lang` and `textDirection` available in `event.locals.paraglide`, so you can use them elsewhere in your app.
 
 ### Excluding certain routes
 
@@ -317,14 +317,14 @@ This is also usefull for detecting which navigation item is currently active.
 
 ### Determining text direction
 
-Setting the text-direction correctly is very important. By default, Paragldie will try to guess the text direction based on the language using the `Intl.Locale` API. Unfortunately, this API is not supported in all browsers. If you want to make sure that the text direction is always correct, you can pass the `dir` option to `createI18n`.
+Setting the text-direction correctly is very important. By default, Paragldie will try to guess the text direction based on the language using the `Intl.Locale` API. Unfortunately, this API is not supported in all browsers. If you want to make sure that the text direction is always correct, you can pass the `textDirection` option to `createI18n`.
 
 ```js
 import { createI18n } from "@inlang/paraglide-js-adapter-sveltekit"
 import * as runtime from "../paraglide/runtime.js"
 
 export const i18n = createI18n(runtime, {
-	dir: {
+	textDirection: {
 		en: "ltr",
 		ar: "rtl",
 	},
@@ -332,7 +332,7 @@ export const i18n = createI18n(runtime, {
 ```
 
 
-### Accessing `lang` and `dir` 
+### Accessing `lang` and `textDirection` 
 
 You can access the current language and text direction on `event.locals.paraglide` anywhere on your server. On the client, you can use the `languageTag()` function from `./paraglide/runtime.js` to access the current language.  
 

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -331,6 +331,11 @@ export const i18n = createI18n(runtime, {
 })
 ```
 
+
+### Accessing `lang` and `dir` 
+
+You can access the current language and text direction on `event.locals.paraglide` anywhere on your server. On the client, you can use the `languageTag()` function from `./paraglide/runtime.js` to access the current language.  
+
 ## FAQ
 
 <doc-accordion

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -122,21 +122,24 @@ The `<ParaglideJS>` component automatically adds `rel="alternate"` links to your
 <link rel="alternate" hreflang="de" href="/de/uber-uns" />
 ```
 
-Additionally, you need to add the `lang` attribute to your `html` tag. This is important for screen readers. Unfortunately, Svelte doesn't offer a way to do this from inside a component. You need to set it in your `src/hooks.server.js` file. 
+Additionally, you need to add the `lang` and `dir` attributes to your `html` tag. This is important for screen readers. Unfortunately, Svelte doesn't offer a way to do this from inside a component. You need to set it in your `src/hooks.server.js` file. 
 
-The easiest way to do this is to set the `lang` attribute in `src/app.html` with an easy to recognize placeholder.
+The easiest way to do this is to set the `lang` and `dir` attributes in `src/app.html` with an easy to recognize placeholder.
 
 ```html
-<html lang="__LANG__">
+<html lang="%paraglide.lang%" dir="%paraglide.dir%"> 
 ```
 
-Then, in your `src/hooks.server.js` file, replace the placeholder with the current language. Again, the `i18n` instance can help you with that.
+Then, in your `src/hooks.server.js` file, you can use `i18n.handle()` to replace the placeholders with the correct values. `%paraglide.lang%` and `%paraglide.dir%` are the default placeholders. You can change them by passing the `langPlaceholder` and `dirPlaceholder` options to `handle`.
+
 
 ```js
 import { i18n } from '$lib/i18n.js'
 
-export const handle = i18n.handle({ langPlaceholder: "__LANG__" })
+export const handle = i18n.handle()
 ```
+
+The handle hook will also make `lang` and `dir` available in `event.locals.paraglide`, so you can use them elsewhere in your app.
 
 ### Excluding certain routes
 
@@ -310,6 +313,24 @@ This is also usefull for detecting which navigation item is currently active.
 <li aria-current={i18n.route($page.url.pathname) === "/about" ? "page" : undefined}>
 	<a href="/about">{m.about()}</a>
 </li>
+```
+
+### Determining text direction
+
+Setting the text-direction correctly is very important. By default, Paragldie will try to guess the text direction based on the language using the `Intl.Locale` API. Unfortunately, this API is not supported in all browsers. If you want to make sure that the text direction is always correct, you can pass the `dir` option to `createI18n`.
+
+```js
+import { createI18n } from "@inlang/paraglide-js-adapter-sveltekit"
+import * as runtime from "../paraglide/runtime.js"
+
+export const i18n = createI18n(runtime, {
+	dir: {
+		en: "ltr",
+		de: "ltr",
+		fr: "ltr",
+		ar: "rtl",
+	},
+})
 ```
 
 ## FAQ

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/app.html
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/app.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- Added Placeholders for lang & dir attributes. These get replaced in `hooks.server.ts` -->
-<html lang="%lang%">
+<html lang="%paraglide.lang%" dir="%paraglide.dir%">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/app.html
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/app.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- Added Placeholders for lang & dir attributes. These get replaced in `hooks.server.ts` -->
-<html lang="%paraglide.lang%" dir="%paraglide.dir%">
+<html lang="%paraglide.lang%" dir="%paraglide.textDirection%">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/hooks.server.js
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/hooks.server.js
@@ -1,3 +1,3 @@
 import { i18n } from "$lib/i18n"
 
-export const handle = i18n.handle({ langPlaceholder: "%lang%" })
+export const handle = i18n.handle()

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/lib/i18n.js
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/lib/i18n.js
@@ -30,4 +30,9 @@ export const i18n = createI18n(runtime, {
 		},
 	},
 	exclude: ["/base/not-translated"],
+	dir: {
+		en: "ltr",
+		de: "ltr",
+		fr: "ltr",
+	},
 })

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/ParaglideJS.svelte
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/ParaglideJS.svelte
@@ -45,6 +45,7 @@
 	$: lang = languageTag ?? autodetectedLanguage
 	$: i18n.config.runtime.setLanguageTag(lang)
 	$: if (browser) document.documentElement.lang = lang
+	$: if (browser) document.documentElement.dir = i18n.config.dir[lang]
 
 	function translateHref(href: string, hreflang: string | undefined): string {
 		const from = new URL($page.url)

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/ParaglideJS.svelte
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/ParaglideJS.svelte
@@ -40,7 +40,7 @@
 	$: lang = languageTag ?? autodetectedLanguage
 	$: i18n.config.runtime.setLanguageTag(lang)
 	$: if (browser) document.documentElement.lang = lang
-	$: if (browser) document.documentElement.dir = i18n.config.dir[lang]
+	$: if (browser) document.documentElement.dir = i18n.config.textDirection[lang] ?? "ltr"
 
 	function translateHref(href: string, hreflang: string | undefined): string {
 		const from = new URL($page.url)

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/ParaglideJS.svelte
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/ParaglideJS.svelte
@@ -34,11 +34,6 @@
 	export let i18n: I18n<T>
 
 	/**
-	 * If true, no alternate links will be added to the head.
-	 */
-	export let noAlternateLinks = false
-
-	/**
 	 * The language tag that was autodetected from the URL.
 	 */
 	$: autodetectedLanguage = i18n.getLanguageFromUrl($page.url)
@@ -89,7 +84,7 @@
 </script>
 
 <svelte:head>
-	{#if !noAlternateLinks && !i18n.config.exclude($page.url.pathname)}
+	{#if !i18n.config.seo.noAlternateLinks && !i18n.config.exclude($page.url.pathname)}
 		<!-- If there is more than one language, add alternate links -->
 		{#if i18n.config.runtime.availableLanguageTags.length >= 1}
 			{#each i18n.config.runtime.availableLanguageTags as lang}

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
@@ -12,6 +12,7 @@ import type { PathTranslations } from "./path-translations/types.js"
 import type { Paraglide } from "./runtime.js"
 import { resolve } from "./utils/path.js"
 import { createExclude, type ExcludeConfig } from "./exclude.js"
+import { guessTextDirMap } from "./utils/text-dir.js"
 
 export type I18nUserConfig<T extends string> = {
 	/**
@@ -76,6 +77,23 @@ export type I18nUserConfig<T extends string> = {
 	 * @default "never"
 	 */
 	prefixDefaultLanguage?: "always" | "never"
+
+	/**
+	 * The associated text-direction for each language. It's recommended to set this to avoid
+	 * any direction-detection differences between different browsers.
+	 *
+	 * @default Guesses the direction based on the language tag using `Intl.Locale`
+	 *
+	 * @example
+	 * ```ts
+	 * dir: {
+	 *  en: "ltr",
+	 *  de: "ltr",
+	 *  ar: "rtl",
+	 * }
+	 * ```
+	 */
+	dir?: Record<T, "ltr" | "rtl">
 }
 
 /**
@@ -87,6 +105,7 @@ export type I18nConfig<T extends string> = {
 	exclude: (path: string) => boolean
 	defaultLanguageTag: T
 	prefixDefaultLanguage: "always" | "never"
+	dir: Record<T, "ltr" | "rtl">
 }
 
 /**
@@ -117,6 +136,7 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 		exclude: createExclude(excludeConfig),
 		defaultLanguageTag,
 		prefixDefaultLanguage: options?.prefixDefaultLanguage ?? "never",
+		dir: options?.dir ?? guessTextDirMap(runtime.availableLanguageTags),
 	}
 
 	// We don't want the translations to be mutable
@@ -146,7 +166,7 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 		 * Returns a `handle` hook that set's the correct `lang` attribute
 		 * on the `html` element
 		 */
-		handle: (options: HandleOptions) => createHandle(config, options),
+		handle: (options: HandleOptions = {}) => createHandle(config, options),
 
 		/**
 		 * Takes in a URL and returns the language that should be used for it.

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
@@ -93,7 +93,7 @@ export type I18nUserConfig<T extends string> = {
 	 * }
 	 * ```
 	 */
-	dir?: Record<T, "ltr" | "rtl">
+	textDirection?: Record<T, "ltr" | "rtl">
 
 	/**
 	 * SEO related options.
@@ -116,7 +116,7 @@ export type I18nConfig<T extends string> = {
 	exclude: (path: string) => boolean
 	defaultLanguageTag: T
 	prefixDefaultLanguage: "always" | "never"
-	dir: Record<T, "ltr" | "rtl">
+	textDirection: Record<T, "ltr" | "rtl">
 	seo: {
 		noAlternateLinks: boolean
 	}
@@ -150,7 +150,7 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 		exclude: createExclude(excludeConfig),
 		defaultLanguageTag,
 		prefixDefaultLanguage: options?.prefixDefaultLanguage ?? "never",
-		dir: options?.dir ?? guessTextDirMap(runtime.availableLanguageTags),
+		textDirection: options?.textDirection ?? guessTextDirMap(runtime.availableLanguageTags),
 		seo: {
 			noAlternateLinks: options?.seo?.noAlternateLinks ?? true,
 		},

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
@@ -94,6 +94,17 @@ export type I18nUserConfig<T extends string> = {
 	 * ```
 	 */
 	dir?: Record<T, "ltr" | "rtl">
+
+	/**
+	 * SEO related options.
+	 */
+	seo: {
+		/**
+		 * Whether to generate alternate links for each page & language and add them to the head.
+		 * @default true
+		 */
+		noAlternateLinks?: boolean
+	}
 }
 
 /**
@@ -106,6 +117,9 @@ export type I18nConfig<T extends string> = {
 	defaultLanguageTag: T
 	prefixDefaultLanguage: "always" | "never"
 	dir: Record<T, "ltr" | "rtl">
+	seo: {
+		noAlternateLinks: boolean
+	}
 }
 
 /**
@@ -137,6 +151,9 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 		defaultLanguageTag,
 		prefixDefaultLanguage: options?.prefixDefaultLanguage ?? "never",
 		dir: options?.dir ?? guessTextDirMap(runtime.availableLanguageTags),
+		seo: {
+			noAlternateLinks: options?.seo?.noAlternateLinks ?? true,
+		},
 	}
 
 	// We don't want the translations to be mutable

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/handle.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/handle.ts
@@ -71,6 +71,7 @@ export const createHandle = <T extends string>(
 }
 
 declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
 	namespace App {
 		interface Locals {
 			paraglide: {

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/handle.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/handle.ts
@@ -34,10 +34,10 @@ export type HandleOptions = {
 	 * <html dir="%paraglide.dir%">
 	 * ```
 	 * ```ts
-	 * { dirPlaceholder: "%paraglide.dir%" }
+	 * { textDirectionPlaceholder: "%paraglide.textDirection%" }
 	 * ```
 	 */
-	dirPlaceholder?: string
+	textDirectionPlaceholder?: string
 }
 
 export const createHandle = <T extends string>(
@@ -45,7 +45,7 @@ export const createHandle = <T extends string>(
 	options: HandleOptions
 ): Handle => {
 	const langPlaceholder = options.langPlaceholder ?? "%paraglide.lang%"
-	const dirPlaceholder = options.dirPlaceholder ?? "%paraglide.dir%"
+	const dirPlaceholder = options.textDirectionPlaceholder ?? "%paraglide.textDirection%"
 
 	return ({ resolve, event }) => {
 		const { lang } = getPathInfo(event.url.pathname, {
@@ -54,17 +54,17 @@ export const createHandle = <T extends string>(
 			base,
 		})
 
-		const dir = i18n.dir[lang as T] ?? "ltr"
+		const textDirection = i18n.textDirection[lang as T] ?? "ltr"
 
 		event.locals.paraglide = {
 			lang,
-			dir,
+			textDirection,
 		}
 
 		return resolve(event, {
 			transformPageChunk({ html, done }) {
 				if (!done) return html
-				return html.replace(langPlaceholder, lang).replace(dirPlaceholder, dir)
+				return html.replace(langPlaceholder, lang).replace(dirPlaceholder, textDirection)
 			},
 		})
 	}
@@ -76,7 +76,7 @@ declare global {
 		interface Locals {
 			paraglide: {
 				lang: string
-				dir: "ltr" | "rtl"
+				textDirection: "ltr" | "rtl"
 			}
 		}
 	}

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/handle.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/handle.ts
@@ -8,35 +8,75 @@ export type HandleOptions = {
 	 * Which placeholder to find and replace with the language tag.
 	 * Use this placeholder as the lang atrribute in your `src/app.html` file.
 	 *
+	 *
+	 * @default "%paraglide.lang%"
+	 *
 	 * @example
 	 * ```html
 	 * <!-- src/app.html -->
-	 * <html lang="%lang%">
+	 * <html lang="%paraglide.lang%">
 	 * ```
 	 * ```ts
-	 * { langPlaceholder: "%lang%" }
+	 * { langPlaceholder: "%paraglide.lang%" }
 	 * ```
 	 *
 	 */
-	langPlaceholder: string
+	langPlaceholder?: string
+
+	/**
+	 * Which placeholder to find and replace with the text-direction of the current language.
+	 *
+	 * @default "%paraglide.dir%"
+	 *
+	 * @example
+	 * ```html
+	 * <!-- src/app.html -->
+	 * <html dir="%paraglide.dir%">
+	 * ```
+	 * ```ts
+	 * { dirPlaceholder: "%paraglide.dir%" }
+	 * ```
+	 */
+	dirPlaceholder?: string
 }
 
 export const createHandle = <T extends string>(
-	{ runtime, defaultLanguageTag }: I18nConfig<T>,
-	options: HandleOptions,
+	i18n: I18nConfig<T>,
+	options: HandleOptions
 ): Handle => {
+	const langPlaceholder = options.langPlaceholder ?? "%paraglide.lang%"
+	const dirPlaceholder = options.dirPlaceholder ?? "%paraglide.dir%"
+
 	return ({ resolve, event }) => {
 		const { lang } = getPathInfo(event.url.pathname, {
-			availableLanguageTags: runtime.availableLanguageTags,
-			defaultLanguageTag,
+			availableLanguageTags: i18n.runtime.availableLanguageTags,
+			defaultLanguageTag: i18n.defaultLanguageTag,
 			base,
 		})
 
+		const dir = i18n.dir[lang as T] ?? "ltr"
+
+		event.locals.paraglide = {
+			lang,
+			dir,
+		}
+
 		return resolve(event, {
 			transformPageChunk({ html, done }) {
-				if (done) return html.replace(options.langPlaceholder, lang)
-				return html
+				if (!done) return html
+				return html.replace(langPlaceholder, lang).replace(dirPlaceholder, dir)
 			},
 		})
+	}
+}
+
+declare global {
+	namespace App {
+		interface Locals {
+			paraglide: {
+				lang: string
+				dir: "ltr" | "rtl"
+			}
+		}
 	}
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/text-dir.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/text-dir.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest"
+import { guessTextDir, guessTextDirMap } from "./text-dir"
+
+describe("guessTextDir", () => {
+	it("should guess the text direction in Node", () => {
+		expect(guessTextDir("ar")).toBe("rtl")
+		expect(guessTextDir("en")).toBe("ltr")
+		expect(guessTextDir("de")).toBe("ltr")
+		expect(guessTextDir("")).toBe("ltr")
+	})
+})
+
+describe("guessTextDirMap", () => {
+	it("should guess the text direction for each language", () => {
+		expect(guessTextDirMap(["ar", "en", "de"])).toEqual({
+			ar: "rtl",
+			en: "ltr",
+			de: "ltr",
+		})
+	})
+})

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/text-dir.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/text-dir.ts
@@ -1,0 +1,22 @@
+export function guessTextDir(lang: string): "rtl" | "ltr" {
+	// this is super unreliable across browsers, so we expect errors
+	try {
+		const locale = new Intl.Locale(lang)
+
+		if ("textInfo" in locale) {
+			// @ts-ignore - Chrome & Node only
+			return locale.textInfo.direction === "rtl" ? "rtl" : "ltr"
+		}
+
+		// @ts-ignore - Safari only
+		return locale.getTextInfo().direction === "rtl" ? "rtl" : "ltr"
+	} catch (e) {
+		//Firefox lmao
+		return "ltr"
+	}
+}
+
+export function guessTextDirMap<T extends string>(langs: readonly T[]): Record<T, "rtl" | "ltr"> {
+	const entries: [T, "rtl" | "ltr"][] = langs.map((lang) => [lang, guessTextDir(lang)])
+	return Object.fromEntries(entries) as Record<T, "rtl" | "ltr">
+}


### PR DESCRIPTION
This PR adds a few QOL features to Paraglide & cleans up the configuration:
- Adds a `dir` option to `createI18n` where the text-direction can be configured.
- Adds default `%paraglide.lang%` and `%paraglide.dir%` string replacements for `app.html`
- Sets `lang` and `dir` on `event.locals.paraglide`, so the values can easily be used throughout the App
- Consolidates the config so that all config goes through `createI18n`