### PR TITLE
Fix `createI18n` types

### DIFF
--- a/.changeset/lazy-students-protect.md
+++ b/.changeset/lazy-students-protect.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-sveltekit": patch
+---
+
+fix `seo` type not being optional on `createI18n`

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
@@ -98,7 +98,7 @@ export type I18nUserConfig<T extends string> = {
 	/**
 	 * SEO related options.
 	 */
-	seo: {
+	seo?: {
 		/**
 		 * Whether to generate alternate links for each page & language and add them to the head.
 		 * @default true


### PR DESCRIPTION
With this PR, the `seo` property on `createI18n` is optional, as it should be