### PR TITLE
Fix incorrect attribute stringification

### DIFF
--- a/.changeset/chatty-pianos-lick.md
+++ b/.changeset/chatty-pianos-lick.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-sveltekit": patch
+---
+
+fix: Don't stringify value-only attributes

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/index.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/index.test.ts
@@ -190,6 +190,19 @@ describe.concurrent("preprocessor", () => {
 		expect(linkHtml).toBe(`<a href="/rewritten/de" hreflang="de"></a>`)
 	})
 
+	it("ignores the href value if it isn't a string", async () => {
+		const code = `
+		<script>
+		  let href = undefined
+		</script>
+
+		<a href={href} />
+		`
+
+		const html = await renderComponent(code)
+		expect(html).toBe(`<a></a>`)
+	})
+
 	it("translates the action attribute of forms", async () => {
 		const code = `<form action="/test" />`
 
@@ -258,7 +271,7 @@ async function renderComponent(svelteCode: string, props: Record<string, any> = 
 		filename: "src/Component.svelte",
 	})
 
-	//console.log(preprocessedComponent.code)
+	console.log(preprocessedComponent.code)
 
 	const bundle = await rollup({
 		input: "src/Entry.svelte",

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/index.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/index.test.ts
@@ -191,7 +191,7 @@ describe.concurrent("preprocessor", () => {
 	})
 
 	it("ignores the href value if it isn't a string", async () => {
-		const code = `
+		const attributeCode = `
 		<script>
 		  let href = undefined
 		</script>
@@ -199,8 +199,16 @@ describe.concurrent("preprocessor", () => {
 		<a href={href} />
 		`
 
-		const html = await renderComponent(code)
-		expect(html).toBe(`<a></a>`)
+		const shorthandCode = `
+		<script>
+		  let href = undefined
+		</script>
+
+		<a {href} />
+		`
+
+		expect(await renderComponent(attributeCode)).toBe(`<a></a>`)
+		expect(await renderComponent(shorthandCode)).toBe(`<a></a>`)
 	})
 
 	it("translates the action attribute of forms", async () => {
@@ -271,7 +279,7 @@ async function renderComponent(svelteCode: string, props: Record<string, any> = 
 		filename: "src/Component.svelte",
 	})
 
-	console.log(preprocessedComponent.code)
+	//console.log(preprocessedComponent.code)
 
 	const bundle = await rollup({
 		input: "src/Entry.svelte",

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/rewrite.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/rewrite.ts
@@ -168,6 +168,7 @@ export const rewrite = ({
              * @param {string | undefined} lang_value
              */
             function ${i("translateAttribute")}(value, lang_value) {
+				if(typeof value !== "string") return value;
                 if(!${i("context")}) return value;
                 return ${i("context")}.translateHref(value, lang_value);
             }
@@ -196,7 +197,7 @@ export const rewrite = ({
                 }
 
                 return attrs;
-            }`,
+            }`
 	)
 
 	return {

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/utils/attributes-to-values.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/utils/attributes-to-values.test.ts
@@ -35,7 +35,7 @@ describe("attributesToValues", () => {
 		]
 
 		const result = attrubuteValuesToJSValue(attributeValues, originalCode)
-		expect(result).toBe("`${hello}`")
+		expect(result).toBe("hello")
 	})
 
 	it("stringifies an interweaved text and mustache tag", () => {

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/utils/attributes-to-values.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/utils/attributes-to-values.ts
@@ -9,7 +9,7 @@ import { escapeForTemplateString } from "./escape.js"
  */
 export function attrubuteValuesToJSValue(
 	values: AttributeValue[] | boolean | string,
-	originalCode: string,
+	originalCode: string
 ): string {
 	if (typeof values === "boolean") return values.toString()
 	if (typeof values === "string") return "`" + escapeForTemplateString(values) + "`"
@@ -18,6 +18,15 @@ export function attrubuteValuesToJSValue(
 
 	if (!(Symbol.iterator in Object(values))) {
 		console.error(values)
+	}
+
+	//If all values are AttributeShorthand or MustacheTag we don't need to stringify them
+	if (noTextNodes(values)) {
+		let code = ""
+		for (const value of values) {
+			code += originalCode.slice(value.expression.start, value.expression.end)
+		}
+		return code
 	}
 
 	for (const value of values) {
@@ -38,4 +47,10 @@ export function attrubuteValuesToJSValue(
 
 	templateString += "`"
 	return templateString
+}
+
+function noTextNodes(
+	values: AttributeValue[]
+): values is Exclude<AttributeValue, { type: "Text" }>[] {
+	return !values.some((value) => value.type === "Text") as any
 }


### PR DESCRIPTION
Closes #2141

This PR fixes an issue where non-string `href` attributes were accidentally stringified, causing nonsensical output