### PR TITLE
Category items grid responsive styling

### DIFF
--- a/inlang/source-code/website/src/pages/c/@category/+Page.tsx
+++ b/inlang/source-code/website/src/pages/c/@category/+Page.tsx
@@ -386,7 +386,7 @@ export default function Page(props: {
 
 const Gallery = (props: { items: any; hideBuildYourOwn?: boolean }) => {
 	return (
-		<div class="mb-10 grid grid-cols-4 gap-4">
+		<div class="mb-10 grid md:grid-cols-2 lg:grid-cols-4 gap-4">
 			<Show when={props.items && props.items.length > 0}>
 				<For each={props.items}>
 					{(item) => {


### PR DESCRIPTION
The category items grid is missing responsive classes and displays broken on mobile. It has been updated with classes from the front page.

<img width="375" alt="Screenshot 2024-02-04 at 11 52 32" src="https://github.com/opral/monorepo/assets/30520456/1d540e96-b0da-4b17-bcb9-158c1e282b48">