### PR TITLE
fix: assign string to _languageTag instead of function

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-svelte/example/src/ParaglideJsProvider.svelte
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-svelte/example/src/ParaglideJsProvider.svelte
@@ -2,7 +2,7 @@
   import { languageTag, onSetLanguageTag } from '@inlang/paraglide-js/svelte-example';
 
   // initialize the language tag
-  $: _languageTag = languageTag;
+  $: _languageTag = languageTag();
 
   onSetLanguageTag((newLanguageTag) => {
     _languageTag = newLanguageTag;


### PR DESCRIPTION
Svelte example shows a type error when converting to TS.

`Type 'string' is not assignable to type '() => "bg" | "cs" | "de" | "en" | "es" | "fr" | "hu" | "pl" | "ro" | "sk" | "tr" | "uk"'.`

Assigning the string value to _languageTag, instead of the function itself, solves this issue.