### PR TITLE
Fix `@inlang/language-tag` dependency issue

### DIFF
--- a/.changeset/mean-humans-roll.md
+++ b/.changeset/mean-humans-roll.md
@@ -1,0 +1,5 @@
+---
+"@inlang/language-tag": patch
+---
+
+fix `@sinclair/typebox` dependency

--- a/inlang/source-code/versioned-interfaces/language-tag/package.json
+++ b/inlang/source-code/versioned-interfaces/language-tag/package.json
@@ -21,8 +21,10 @@
 		"format": "prettier ./src --write",
 		"clean": "rm -rf ./dist ./node_modules"
 	},
+	"dependencies": {
+		"@sinclair/typebox": "^0.31.17"
+	},
 	"devDependencies": {
-		"@sinclair/typebox": "^0.31.17",
 		"tsd": "0.28.1",
 		"typescript": "5.2.2",
 		"vitest": "0.34.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2048,10 +2048,11 @@ importers:
         version: 0.34.6(jsdom@22.1.0)
 
   inlang/source-code/versioned-interfaces/language-tag:
-    devDependencies:
+    dependencies:
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
+    devDependencies:
       tsd:
         specifier: 0.28.1
         version: 0.28.1


### PR DESCRIPTION
This PR promotes `@sinclair/typebox` from a `devDependecy` to a `dependency`, since it's used at runtime