### PR TITLE
Bundle @inlang/language-tag into Paraglide

### DIFF
--- a/.changeset/hungry-turtles-deny.md
+++ b/.changeset/hungry-turtles-deny.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix broken dependency

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -51,7 +51,6 @@
 	},
 	"dependencies": {
 		"@inlang/detect-json-formatting": "workspace:*",
-		"@inlang/language-tag": "workspace:*",
 		"commander": "11.1.0",
 		"consola": "3.2.3",
 		"dedent": "1.5.1",
@@ -62,6 +61,7 @@
 	"devDependencies": {
 		"@inlang/env-variables": "workspace:*",
 		"@inlang/sdk": "workspace:*",
+		"@inlang/language-tag": "workspace:*",
 		"@inlang/telemetry": "workspace:*",
 		"@lix-js/client": "workspace:*",
 		"@lix-js/fs": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1057,9 +1057,6 @@ importers:
       '@inlang/detect-json-formatting':
         specifier: workspace:*
         version: link:../../detect-json-formatting
-      '@inlang/language-tag':
-        specifier: workspace:*
-        version: link:../../versioned-interfaces/language-tag
       commander:
         specifier: 11.1.0
         version: 11.1.0
@@ -1082,6 +1079,9 @@ importers:
       '@inlang/env-variables':
         specifier: workspace:*
         version: link:../../env-variables
+      '@inlang/language-tag':
+        specifier: workspace:*
+        version: link:../../versioned-interfaces/language-tag
       '@inlang/plugin-message-format':
         specifier: workspace:*
         version: link:../../plugins/inlang-message-format


### PR DESCRIPTION
This PR bundles `@inlang/language-tag` into paraglideJS