### PR TITLE
Improve SvelteKit Adapter Docs

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -214,6 +214,7 @@ import * as runtime from "../paraglide/runtime.js"
 import * as m from "../paraglide/messages.js"
 
 export const i18n = createI18n(runtime, {
+	// do not call the function - pass a reference
 	"/about" : m.about_path
 })
 ```


### PR DESCRIPTION
Closes #2217

This PR clarifies that message functions need to be passed _by reference_ when passing them to path translations