### PR TITLE
Use p-limit to constrain rpc concurrency in cli translate

### DIFF
--- a/.changeset/curvy-bees-check.md
+++ b/.changeset/curvy-bees-check.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cli": patch
+---
+
+Use p-limit to constrain rpc concurrency in cli translate

--- a/inlang/source-code/cli/package.json
+++ b/inlang/source-code/cli/package.json
@@ -67,6 +67,7 @@
 	"dependencies": {
 		"esbuild-wasm": "^0.19.2",
 		"fs-extra": "11.1.1",
+		"p-limit": "^5.0.0",
 		"@inlang/language-tag": "workspace:*",
 		"@inlang/result": "workspace:*",
 		"@inlang/sdk": "workspace:*",

--- a/inlang/source-code/cli/src/commands/machine/translate.ts
+++ b/inlang/source-code/cli/src/commands/machine/translate.ts
@@ -3,10 +3,11 @@ import { Command } from "commander"
 import { rpc } from "@inlang/rpc"
 import { getInlangProject } from "../../utilities/getInlangProject.js"
 import { log } from "../../utilities/log.js"
-import { type InlangProject, ProjectSettings } from "@inlang/sdk"
+import { type InlangProject, ProjectSettings, Message } from "@inlang/sdk"
 import prompts from "prompts"
 import { projectOption } from "../../utilities/globalFlags.js"
 import progessBar from "cli-progress"
+import plimit from "p-limit"
 
 export const translate = new Command()
 	.command("translate")
@@ -103,8 +104,7 @@ export async function translateCommandAction(args: { project: InlangProject }) {
 
 		const logs: Array<() => void> = []
 
-		// parallelize in the future
-		const promises = messageIds.map(async (id) => {
+		const rpcTranslate = async (id: Message["id"]) => {
 			const toBeTranslatedMessage = args.project.query.messages.get({ where: { id } })!
 			const { data: translatedMessage, error } = await rpc.machineTranslateMessage({
 				message: toBeTranslatedMessage,
@@ -122,7 +122,10 @@ export async function translateCommandAction(args: { project: InlangProject }) {
 				logs.push(() => log.info(`Machine translated message "${id}"`))
 			}
 			bar.increment()
-		})
+		}
+		// parallelize rpcTranslate calls with a limit of 100 concurrent calls
+		const limit = plimit(100)
+		const promises = messageIds.map((id) => limit(() => rpcTranslate(id)))
 		await Promise.all(promises)
 
 		bar.stop()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       fs-extra:
         specifier: 11.1.1
         version: 11.1.1
+      p-limit:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@inlang/rpc':
         specifier: workspace:*


### PR DESCRIPTION
Resolves #2239 by limiting concurrent rpcs for machine translate to 100.
Introduces [sindresorhus/p-limit](https://github.com/sindresorhus/p-limit#readme)

I used a manual test with ~1000 already-translated messages to repro, and then to validate this change.
(TODO automated test)