### PR TITLE
Update & commit lockfile after release

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -43,3 +43,18 @@ jobs:
           title: Version Packages [skip preview]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get current branch
+        id: get_branch
+        run: echo "CURRENT_BRANCH=$(git branch --show-current)" >> $GITHUB_ENV
+
+      - name: Update lock file
+        if: env.CURRENT_BRANCH == 'changeset-release/main'
+        run: pnpm install --lockfile-only
+
+      - name: Commit lock file
+        if: env.CURRENT_BRANCH == 'changeset-release/main'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update lock file"
+          branch: changeset-release/main

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
 		"----- CI ---- used to test the codebase on every commit": "",
 		"ci": "pnpm install && pnpm check-all",
 		"check-all": "pnpm audit --audit-level=high && pnpm format && pnpm lint && pnpm build && pnpm test",
-		"ci:publish": "pnpm --filter !vs-code-extension publish -r",
-		"ci:version": "pnpm exec changeset version && pnpm install --lockfile-only"
+		"ci:publish": "pnpm --filter !vs-code-extension publish -r"
 	},
 	"engines": {
 		"npm": ">=8.0.0",


### PR DESCRIPTION
Closes #2234 

This PR adds steps to the versioning Action to automatically update & fix the lockfile. It also removes the `ci:version` command from the workspace `package.json`, as that seems to be unused