### PR TITLE
Update Astro Adapter metadata

### DIFF
--- a/.changeset/perfect-ducks-think.md
+++ b/.changeset/perfect-ducks-think.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-astro": patch
+---
+
+update `package.json` metadata

--- a/inlang/source-code/paraglide/paraglide-js-adapter-astro/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-astro/package.json
@@ -2,7 +2,7 @@
     "name": "@inlang/paraglide-js-adapter-astro",
     "version": "0.1.3",
     "author": "inlang <hello@inlang.com> (https://inlang.com/)",
-    "description": "Inlang adapter for Astro",
+    "description": "A fully type-safe i18n library specifically designed for partial hydration patterns like Astro's islands.",
     "homepage": "https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-astro",
     "repository": {
         "type": "git",
@@ -36,11 +36,14 @@
         "l10n",
         "translation",
         "internationalization",
+        "internationalisation",
         "localization",
         "lint",
         "astro-integration",
         "astro",
         "astro i18n",
+        "seo",
+        "accessibility",
         "withastro"
     ]
 }


### PR DESCRIPTION
This PR updates the `package.json` metadata of the Astro Adapter to get it listed on Astro's integration page. 
Also triggers a changeset to see if the CI versioning changes are working