### PR TITLE
recommend vitest.exporer extension for monorepo

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
 		"dbaeumer.vscode-eslint",
 		"esbenp.prettier-vscode",
 		"inlang.vs-code-extension",
-		"zixuanchen.vitest-explorer",
+		"vitest.explorer",
 		"aaron-bond.better-comments"
 	]
 }


### PR DESCRIPTION
The old zixuanchen.vitest-explorer extension is deprecated.

![Screenshot 2024-02-20 at 18 12 39](https://github.com/opral/monorepo/assets/849592/ea7c200f-4ce6-453f-8631-326442778206)

This one is working better for me - console.log messages don't get lost when running tests in the debugger using the vitest buttons.

![Screenshot 2024-02-20 at 18 08 01](https://github.com/opral/monorepo/assets/849592/4d1dc176-84c9-4b09-acb0-66b43621a529)
