### PR TITLE
Fix double loads in SvelteKit adapter

### DIFF
--- a/.changeset/friendly-cherries-relax.md
+++ b/.changeset/friendly-cherries-relax.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-sveltekit": patch
+---
+
+fix: double-execution of `load` on initial load

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/ParaglideJS.svelte
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/ParaglideJS.svelte
@@ -43,7 +43,10 @@
 	$: i18n.config.runtime.setLanguageTag(lang)
 	$: if (browser) document.documentElement.lang = lang
 	$: if (browser) document.documentElement.dir = i18n.config.textDirection[lang] ?? "ltr"
-	$: if(browser && lang) invalidate(LANGUAGE_CHANGE_INVALIDATION_KEY)
+
+	let numberOfLanugageChanges = 0
+	$: if(lang)numberOfLanugageChanges += 1;
+	$: if(browser && lang && numberOfLanugageChanges > 1) invalidate(LANGUAGE_CHANGE_INVALIDATION_KEY)
 	
 
 	function translateHref(href: string, hreflang: string | undefined): string {


### PR DESCRIPTION
Closes #2294 

This PR fixes an issue causing `load` functions that `depend` on the language running twice on initial page load