### PR TITLE
Allow additionalProperties on inlang-message-format and project-settings

### DIFF
--- a/.changeset/four-pianos-hang.md
+++ b/.changeset/four-pianos-hang.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+bump `@inlang/sdk` dependency

--- a/.changeset/shaggy-boats-explain.md
+++ b/.changeset/shaggy-boats-explain.md
@@ -1,0 +1,6 @@
+---
+"@inlang/project-settings": minor
+"@inlang/plugin-message-format": minor
+---
+
+types loosened to allow for new/unknown properties

--- a/inlang/source-code/plugins/inlang-message-format/src/storageSchema.test.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/storageSchema.test.ts
@@ -22,16 +22,18 @@ test("it should be possible to define $schema for typesafety", () => {
 	expect(Value.Check(StorageSchema, messages)).toBe(true)
 })
 
+// #2325 - types have been loosened to allow for new/unknown properties
 test("using a hyphen (-) should not be possible to increase compatibility with libraries", () => {
 	const messages: StorageSchema = {
 		"hello-world": "property",
 	}
-	expect(Value.Check(StorageSchema, messages)).toBe(false)
+	expect(Value.Check(StorageSchema, messages)).toBe(true)
 })
 
+// #2325 - types have been loosened to allow for new/unknown properties
 test("using a dot (.) should not be possible to increase compatibility with libraries", () => {
 	const messages: StorageSchema = {
 		"hello.world": "property",
 	}
-	expect(Value.Check(StorageSchema, messages)).toBe(false)
+	expect(Value.Check(StorageSchema, messages)).toBe(true)
 })

--- a/inlang/source-code/plugins/inlang-message-format/src/storageSchema.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/storageSchema.ts
@@ -4,7 +4,7 @@ const InternalProperties = Type.Object(
 	{
 		$schema: Type.Optional(Type.Literal("https://inlang.com/schema/inlang-message-format")),
 	},
-	{ additionalProperties: false }
+	{ additionalProperties: true }
 )
 
 const Messages = Type.Record(
@@ -15,7 +15,7 @@ const Messages = Type.Record(
 		examples: ["helloWorld", "hello_world", "helloWorld123", "hello_world_123"],
 	}),
 	Type.String(),
-	{ additionalProperties: false }
+	{ additionalProperties: true }
 )
 
 /**

--- a/inlang/source-code/versioned-interfaces/project-settings/src/interface.test.ts
+++ b/inlang/source-code/versioned-interfaces/project-settings/src/interface.test.ts
@@ -120,6 +120,7 @@ describe("settings.* (external settings)", () => {
 		}
 	})
 
+	// #2325 - types have been loosened to allow for new/unknown properties
 	it("should enforce namespaces", () => {
 		const settings: ProjectSettings = {
 			sourceLanguageTag: "en",
@@ -128,10 +129,11 @@ describe("settings.* (external settings)", () => {
 			// @ts-expect-error - Namespace is missing
 			withoutNamespace: {},
 		}
-		expect(Value.Check(ProjectSettings, settings)).toBe(false)
+		expect(Value.Check(ProjectSettings, settings)).toBe(true)
 	})
 
-	it("should fail on unknown types", () => {
+	// #2325 - types have been loosened to allow for new/unknown properties
+	it("should not fail on unknown types", () => {
 		const settings: ProjectSettings = {
 			sourceLanguageTag: "en",
 			languageTags: ["en", "de"],
@@ -139,10 +141,11 @@ describe("settings.* (external settings)", () => {
 			// @ts-expect-error - unknown type
 			"namespace.unknownType.name": {},
 		}
-		expect(Value.Check(ProjectSettings, settings)).toBe(false)
+		expect(Value.Check(ProjectSettings, settings)).toBe(true)
 	})
 
-	it("should enforce camelCase", () => {
+	// #2325 - types have been loosened to allow for new/unknown properties
+	it("should not enforce camelCase", () => {
 		const settings: ProjectSettings = {
 			sourceLanguageTag: "en",
 			languageTags: ["en", "de"],
@@ -159,7 +162,7 @@ describe("settings.* (external settings)", () => {
 
 		for (const failCase of failCases) {
 			const config = { ...settings, settings: { [failCase]: {} } }
-			expect(Value.Check(ProjectSettings, config)).toBe(false)
+			expect(Value.Check(ProjectSettings, config)).toBe(true)
 		}
 	})
 
@@ -196,7 +199,8 @@ describe("settings.* (external settings)", () => {
 		expect(Value.Check(ProjectSettings, settings)).toBe(true)
 	})
 
-	// (reserving project namespace for internal use only)
+	// #2325 - no longer blocking new/unknown keys since that breaks installed apps
+	// when new features in project settings are rolled out
 	it("should not be possible to define unknown project settings", () => {
 		const settings: ProjectSettings = {
 			sourceLanguageTag: "en",
@@ -205,7 +209,7 @@ describe("settings.* (external settings)", () => {
 			// @ts-expect-error - unknown project key
 			"project.unknown.name": {},
 		}
-		expect(Value.Check(ProjectSettings, settings)).toBe(false)
+		expect(Value.Check(ProjectSettings, settings)).toBe(true)
 	})
 
 	it("should be possible to define known project settings", () => {

--- a/inlang/source-code/versioned-interfaces/project-settings/src/interface.ts
+++ b/inlang/source-code/versioned-interfaces/project-settings/src/interface.ts
@@ -100,7 +100,7 @@ export const ExternalProjectSettings = Type.Record(
 	// intersection between `InternalSettings`, which contains an array,
 	// and `ExternalSettings` which are objects possible
 	JSON as unknown as typeof JSONObject,
-	{ additionalProperties: false, description: "Settings defined by apps, plugins, etc." }
+	{ description: "Settings defined by apps, plugins, etc." }
 )
 
 export type ProjectSettings = Static<typeof ProjectSettings>


### PR DESCRIPTION
This change should allow new properties to be added to the schemas for inlang-message-format and project-settings without breaking existing apps which are unaware of the new properties.

discussion in https://discord.com/channels/897438559458430986/1212819302219120640

I did a couple of manual chacks with this PR, and changes appear to work as intended:

![Screenshot 2024-02-29 at 22 15 38](https://github.com/opral/monorepo/assets/849592/e79be717-1495-4df2-9595-8ede3bdbd67f)
![Screenshot 2024-02-29 at 22 15 19](https://github.com/opral/monorepo/assets/849592/a78e4df8-b957-46ba-b762-bae20a2813f7)


I think we can ignore the json schema warning in the vscode editor. I assume that's based on the schema referenced by the settings file.
