### PR TITLE
Improve `Link` header handling

### DIFF
--- a/.changeset/nasty-steaks-grab.md
+++ b/.changeset/nasty-steaks-grab.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-next": patch
+---
+
+fix: Use fully qualified hrefs in `Link` headers

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/next.config.js
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/next.config.js
@@ -1,9 +1,0 @@
-const { paraglide } = require("@inlang/paraglide-js-adapter-next/plugin")
-
-/** @type {import('next').NextConfig} */
-module.exports = paraglide({
-	paraglide: {
-		project: "./project.inlang",
-		outdir: "./src/paraglide",
-	},
-})

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/next.config.mjs
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/next.config.mjs
@@ -1,0 +1,8 @@
+import { paraglide } from "@inlang/paraglide-js-adapter-next/plugin"
+
+export default paraglide({
+	paraglide: {
+		project: "./project.inlang",
+		outdir: "./src/paraglide",
+	},
+})

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/src/lib/i18n.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/src/lib/i18n.ts
@@ -2,11 +2,18 @@ import { AvailableLanguageTag } from "@/paraglide/runtime"
 import { createI18n } from "@inlang/paraglide-js-adapter-next"
 import * as m from "@/paraglide/messages"
 
-export const { Link, middleware, useRouter, usePathname, redirect, permanentRedirect } =
-	createI18n<AvailableLanguageTag>({
-		pathnames: {
-			"/about": m.about_path,
-		},
+export const {
+	Link,
+	middleware,
+	useRouter,
+	usePathname,
+	redirect,
+	permanentRedirect,
+	localizePath,
+} = createI18n<AvailableLanguageTag>({
+	pathnames: {
+		"/about": m.about_path,
+	},
 
-		exclude: ["/not-translated"], //makes sure that the /not-translated page is not translated
-	})
+	exclude: ["/not-translated"], //makes sure that the /not-translated page is not translated
+})

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/src/middleware.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/src/middleware.ts
@@ -1,6 +1,1 @@
 export { middleware } from "@/lib/i18n"
-
-export const config = {
-	//Must be hardcoded string
-	matcher: ["/", `/:path*`],
-}

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"build": "node ./build.mjs",
 		"clean": "rm -rf dist && rm -rf node_modules",
-		"test": "vitest run --passWithNoTests",
+		"test": "NODE_ENV=development vitest run && NODE_ENV=production vitest run",
 		"lint": "eslint ./src --fix"
 	},
 	"main": "dist/app/index.server.js",

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/Link.test.tsx
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/Link.test.tsx
@@ -10,9 +10,8 @@ import {
 import { createLink } from "./Link"
 import { prefixStrategy } from "./routing/prefix"
 
-describe("<Link>", () => {
+describe.skipIf(() => process.env.NODE_ENV !== "development")("<Link>", () => {
 	beforeEach(() => {
-		//known starting state
 		setLanguageTag(sourceLanguageTag)
 		process.env.__NEXT_ROUTER_BASE_PATH = ""
 	})
@@ -115,6 +114,4 @@ describe("<Link>", () => {
 		render(<Link href="/about?param=1" data-testid="english-link" />)
 		expect(screen.getByTestId("english-link").getAttribute("href")).toEqual("/about?param=1")
 	})
-
-
 })

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/createI18n.client.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/createI18n.client.ts
@@ -32,6 +32,7 @@ export function createI18n<T extends string = string>(options: I18nOptions<T> = 
 	return {
 		Link,
 		usePathname,
+		localizePath: strategy.getLocalisedPath,
 		middleware,
 		useRouter,
 		redirect,

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/createI18n.server.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/createI18n.server.ts
@@ -59,6 +59,7 @@ export function createI18n<T extends string = string>(options: I18nOptions<T> = 
 		Link,
 		usePathname,
 		middleware,
+		localizePath: strategy.getLocalisedPath,
 		useRouter,
 		redirect,
 		permanentRedirect,

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/middleware.tsx
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/middleware.tsx
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server"
 import { sourceLanguageTag, availableLanguageTags } from "$paraglide/runtime.js"
 import { HeaderNames } from "../constants"
 import type { RoutingStrategy } from "./routing/prefix"
+import { addBasePath } from "./routing/basePath"
 
 export function createMiddleware<T extends string>(
 	exclude: (path: string) => boolean,
@@ -21,28 +22,31 @@ export function createMiddleware<T extends string>(
 		if (exclude(canonicalPath)) return NextResponse.next()
 
 		const headers = new Headers(request.headers)
-
 		headers.set(HeaderNames.ParaglideLanguage, locale)
 
-		//set Link header for alternate language versions
-		const linkHeader = generateLinkHeader({
-			availableLanguageTags: availableLanguageTags as T[],
-			canonicalPath,
-		})
-		headers.set(HeaderNames.Link, linkHeader)
+		if (shouldAddLinkHeader(request)) {
+			//set Link header for alternate language versions
+			const linkHeader = generateLinkHeader({
+				availableLanguageTags: availableLanguageTags as T[],
+				canonicalPath,
+				request,
+			})
+
+			headers.set(HeaderNames.Link, linkHeader)
+		}
 
 		if (canonicalPath !== request.nextUrl.pathname) {
 			request.nextUrl.pathname = canonicalPath
 			return NextResponse.rewrite(request.nextUrl, {
 				headers,
 			})
+		} else {
+			return NextResponse.next({
+				request: {
+					headers,
+				},
+			})
 		}
-
-		return NextResponse.next({
-			request: {
-				headers,
-			},
-		})
 	}
 
 	/**
@@ -51,18 +55,31 @@ export function createMiddleware<T extends string>(
 	function generateLinkHeader({
 		canonicalPath,
 		availableLanguageTags,
+		request,
 	}: {
 		canonicalPath: string
 		availableLanguageTags: readonly T[]
+		request: NextRequest
 	}): string {
 		const alternates: string[] = []
 
 		for (const lang of availableLanguageTags) {
 			const translatedPathname = strategy.translatePath(canonicalPath, lang)
 			const encodedPathname = encodeURI(translatedPathname)
-			alternates.push(`<${encodedPathname}>; rel="alternate"; hreflang="${lang}"`)
+
+			const withBase = addBasePath(encodedPathname, true)
+
+			//withBase should be an absolute path, so this should never do relative path resolution
+			const fullHref = new URL(withBase, request.nextUrl.href).href
+
+			alternates.push(`<${fullHref}>; rel="alternate"; hreflang="${lang}"`)
 		}
 
 		return alternates.join(", ")
 	}
+}
+
+function shouldAddLinkHeader(request: NextRequest) {
+	const acceptHeader = request.headers.get("accept")
+	return acceptHeader?.includes("text/html")
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/pathnames/validatePathTranslations.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/pathnames/validatePathTranslations.test.ts
@@ -37,6 +37,18 @@ describe("validatePathTranslations", () => {
 		expect(result.length).toBe(1)
 	})
 
+	it("does not complain if there are extra languages", () => {
+		const pathTranslations = {
+			"/about": {
+				en: "/about",
+				de: "/ueber-uns",
+			},
+		}
+		// @ts-ignore
+		const result = validatePathTranslations(pathTranslations, ["en"])
+		expect(result.length).toBe(0)
+	})
+
 	it("complains if not all variants have the same parameters", () => {
 		const pathTranslations = {
 			"/about/[id]": {

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/pathnames/validatePathTranslations.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/pathnames/validatePathTranslations.ts
@@ -50,7 +50,7 @@ export function validatePathTranslations<T extends string>(
 
 		//Check that all languages are translated
 		const translatedLanguages = new Set(Object.keys(translations))
-		if (!setsEqual(expectedLanguages, translatedLanguages)) {
+		if (!isSubset(expectedLanguages, translatedLanguages)) {
 			const missingLanguages = new Set(expectedLanguages)
 			for (const lang of translatedLanguages) {
 				missingLanguages.delete(lang as T)
@@ -84,6 +84,13 @@ function getParams(path: string): Set<string> {
 
 function setsEqual(a: Set<any>, b: Set<any>): boolean {
 	if (a.size !== b.size) return false
+	for (const value of a) {
+		if (!b.has(value)) return false
+	}
+	return true
+}
+
+function isSubset<T>(a: Set<T>, b: Set<T>): boolean {
 	for (const value of a) {
 		if (!b.has(value)) return false
 	}


### PR DESCRIPTION
The NextJS Adapter adds a `Link` header to pages with all the alternate language versions of pages. 
To be spec compliant these must be full hrefs, no relative paths allowed. 

This PR makes the `Link` headers spec compliant