### PR TITLE
Simplify sdk loadSettings

### DIFF
--- a/.changeset/perfect-nails-love.md
+++ b/.changeset/perfect-nails-love.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Simplify sdk loadSettings

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,16 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"name": "debug paraglide example",
+			"program": "${workspaceFolder}/inlang/source-code/paraglide/paraglide-js/bin/run.js",
+			"request": "launch",
+			"skipFiles": [],
+			"args": ["compile", "--project", "./project.inlang"],
+			"cwd": "${workspaceFolder}/inlang/source-code/paraglide/paraglide-js/example",
+			"type": "node",
+			"console": "integratedTerminal"
+		},
+		{
 			"name": "debug current vitest",
 			"type": "node",
 			"request": "launch",

--- a/inlang/source-code/sdk/src/loadProject.test.ts
+++ b/inlang/source-code/sdk/src/loadProject.test.ts
@@ -10,7 +10,11 @@ import type {
 } from "./versionedInterfaces.js"
 import type { ImportFunction } from "./resolve-modules/index.js"
 import type { InlangModule } from "@inlang/module"
-import { LoadProjectInvalidArgument, ProjectSettingsInvalidError } from "./errors.js"
+import {
+	LoadProjectInvalidArgument,
+	ProjectSettingsFileJSONSyntaxError,
+	ProjectSettingsInvalidError,
+} from "./errors.js"
 import { normalizePath } from "@lix-js/fs"
 import { createMessage } from "./test-utilities/createMessage.js"
 import { tryCatch } from "@inlang/result"
@@ -276,8 +280,7 @@ describe("initialization", () => {
 				_import,
 			})
 
-			const errors = project.errors()
-			expect(errors[0]).toBeInstanceOf(SyntaxError)
+			expect(project.errors()![0]).toBeInstanceOf(ProjectSettingsFileJSONSyntaxError)
 		})
 
 		it("should return an error if settings file is does not match schema", async () => {

--- a/inlang/source-code/sdk/src/loadProject.test.ts
+++ b/inlang/source-code/sdk/src/loadProject.test.ts
@@ -10,12 +10,7 @@ import type {
 } from "./versionedInterfaces.js"
 import type { ImportFunction } from "./resolve-modules/index.js"
 import type { InlangModule } from "@inlang/module"
-import {
-	LoadProjectInvalidArgument,
-	ProjectSettingsFileJSONSyntaxError,
-	ProjectSettingsFileNotFoundError,
-	ProjectSettingsInvalidError,
-} from "./errors.js"
+import { LoadProjectInvalidArgument, ProjectSettingsInvalidError } from "./errors.js"
 import { normalizePath } from "@lix-js/fs"
 import { createMessage } from "./test-utilities/createMessage.js"
 import { tryCatch } from "@inlang/result"
@@ -264,7 +259,9 @@ describe("initialization", () => {
 				_import,
 			})
 
-			expect(project.errors()![0]).toBeInstanceOf(ProjectSettingsFileNotFoundError)
+			const errors = project.errors()
+			// @ts-ignore
+			expect(errors[0].code).toBe("ENOENT")
 		})
 
 		it("should return an error if settings file is not a valid JSON", async () => {
@@ -279,7 +276,8 @@ describe("initialization", () => {
 				_import,
 			})
 
-			expect(project.errors()![0]).toBeInstanceOf(ProjectSettingsFileJSONSyntaxError)
+			const errors = project.errors()
+			expect(errors[0]).toBeInstanceOf(SyntaxError)
 		})
 
 		it("should return an error if settings file is does not match schema", async () => {

--- a/inlang/source-code/sdk/src/loadProject.ts
+++ b/inlang/source-code/sdk/src/loadProject.ts
@@ -8,8 +8,6 @@ import type {
 import { type ImportFunction, resolveModules } from "./resolve-modules/index.js"
 import { TypeCompiler, ValueErrorType } from "@sinclair/typebox/compiler"
 import {
-	ProjectSettingsFileJSONSyntaxError,
-	ProjectSettingsFileNotFoundError,
 	ProjectSettingsInvalidError,
 	PluginLoadMessagesError,
 	PluginSaveMessagesError,
@@ -329,24 +327,10 @@ const loadSettings = async (args: {
 	settingsFilePath: string
 	nodeishFs: NodeishFilesystemSubset
 }) => {
-	const { data: settingsFile, error: settingsFileError } = await tryCatch(
-		async () => await args.nodeishFs.readFile(args.settingsFilePath, { encoding: "utf-8" })
-	)
-	if (settingsFileError)
-		throw new ProjectSettingsFileNotFoundError({
-			cause: settingsFileError,
-			path: args.settingsFilePath,
-		})
-
-	const json = tryCatch(() => JSON.parse(settingsFile!))
-
-	if (json.error) {
-		throw new ProjectSettingsFileJSONSyntaxError({
-			cause: json.error,
-			path: args.settingsFilePath,
-		})
-	}
-	return parseSettings(json.data)
+	// caller should handle errors
+	const settingsFile = await args.nodeishFs.readFile(args.settingsFilePath, { encoding: "utf-8" })
+	const json = JSON.parse(settingsFile)
+	return parseSettings(json)
 }
 
 const parseSettings = (settings: unknown) => {


### PR DESCRIPTION
Fixes #2328 

@janfjohannes could you try this with your Lix setup.
Errors should now be relayed back directly, without wrapping. 

The tryCatch and extra error wrappers in the loadProject code were not adding much value, so I removed them.
 
This PR includes the paraglide VS Code debug configuration, which I used to debug the flow.
It should be useful for others.
