### PR TITLE
Document more caveats in the SvelteKit Adapter

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -396,6 +396,26 @@ Because we are using a Preprocessor for link localisation there are a few caveat
 2. Using a `{...speread}` operator on an element will cause the preprocessor to place all props on that element into one giant `{...spread}`. If you are using proxies that may cause issues.
 3. If you are using a function-call as the value to `hreflang` the function will be called twice per render. If it has side-effects this may cause issues.
 
+### Using messages in `+layout.svelte`
+
+The language state during rendering get's set when the `<ParaglideJS>` component is mounted. Since you usually place it in `+layout.svelte`, using messages in the `<script>` of `+layout.svelte` itself can cause issues.
+
+```svelte
+<script>
+    import { ParaglideJS } from '@inlang/paraglide-js-adapter-sveltekit'
+	import { i18n } from '$lib/i18n.js'
+
+	//using messages here can cause hydration issues
+</script>
+
+<ParaglideJS {i18n}>
+	<!-- Using messages here is fine -->
+    <slot />
+</ParaglideJS>
+```
+
+Try moving any logic that uses messages into a different component. 
+
 ### Issues on Vercel
 
 SvelteKit's `reroute` hook currently doens't play well with Vercel (see [sveltejs/kit#11879](https://github.com/sveltejs/kit/issues/11879)), which means that we need to slightly adapt the adapter setup to make it work when deployed to vercel.

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -396,6 +396,16 @@ Because we are using a Preprocessor for link localisation there are a few caveat
 2. Using a `{...speread}` operator on an element will cause the preprocessor to place all props on that element into one giant `{...spread}`. If you are using proxies that may cause issues.
 3. If you are using a function-call as the value to `hreflang` the function will be called twice per render. If it has side-effects this may cause issues.
 
+### Issues on Vercel
+
+SvelteKit's `reroute` hook currently doens't play well with Vercel (see [sveltejs/kit#11879](https://github.com/sveltejs/kit/issues/11879)), which means that we need to slightly adapt the adapter setup to make it work when deployed to vercel.
+
+1. Remove the `reroute` hook from `src/hooks.js`
+2. Move the routes you want to localise `routes` into a `[locale]` folder
+3. Don't use translated `pathnames`
+
+We are actively working on contributing a fix for [sveltejs/kit#11879](https://github.com/sveltejs/kit/issues/11879), so this workaround will hopefully not be needed much longer.
+
 ## FAQ
 
 <doc-accordion


### PR DESCRIPTION
This PR documents caveats & workarounds for deploying to Vercel & for using messages in the root `+layout.svelte`