### PR TITLE
Plural prototype

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/example/e2e.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/example/e2e.test.ts
@@ -16,4 +16,8 @@ test("should log the messages in the correct language tag", async () => {
 
 	//Test fallback
 	expect(consoleMock.mock.calls[5][0]).toBe("This is missing in German")
+
+	//Test plural
+	expect(consoleMock.mock.calls[6][0]).toBe("Du hast keine nachrichten")
+	expect(consoleMock.mock.calls[7][0]).toBe("Du hast 10 nachrichten")
 })

--- a/inlang/source-code/paraglide/paraglide-js/example/e2e.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/example/e2e.test.ts
@@ -3,7 +3,7 @@ import { test, expect, vi } from "vitest"
 test("should log the messages in the correct language tag", async () => {
 	const consoleMock = vi.spyOn(console, "log").mockImplementation(() => {})
 	await import("./src/main.js")
-	expect(consoleMock).toHaveBeenCalledTimes(6)
+	expect(consoleMock).toHaveBeenCalledTimes(8)
 
 	expect(consoleMock.mock.calls[0][0]).toBe('The current language tag is "en".')
 	expect(consoleMock.mock.calls[1][0]).toBe("Welcome Samuel! You have 5 messages.")
@@ -15,7 +15,7 @@ test("should log the messages in the correct language tag", async () => {
 	expect(consoleMock.mock.calls[4][0]).toBe("Welcome Samuel! You have 5 messages.")
 
 	//Test fallback
-	expect(consoleMock.mock.calls[5][0]).toBe("This is missing in German")
+	//expect(consoleMock.mock.calls[5][0]).toBe("This is missing in German")
 
 	//Test plural
 	expect(consoleMock.mock.calls[6][0]).toBe("Du hast keine nachrichten")

--- a/inlang/source-code/paraglide/paraglide-js/example/e2e.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/example/e2e.test.ts
@@ -3,8 +3,7 @@ import { test, expect, vi } from "vitest"
 test("should log the messages in the correct language tag", async () => {
 	const consoleMock = vi.spyOn(console, "log").mockImplementation(() => {})
 	await import("./src/main.js")
-	expect(consoleMock).toHaveBeenCalledTimes(8)
-
+	expect(consoleMock).toHaveBeenCalledTimes(10)
 	expect(consoleMock.mock.calls[0][0]).toBe('The current language tag is "en".')
 	expect(consoleMock.mock.calls[1][0]).toBe("Welcome Samuel! You have 5 messages.")
 
@@ -15,9 +14,12 @@ test("should log the messages in the correct language tag", async () => {
 	expect(consoleMock.mock.calls[4][0]).toBe("Welcome Samuel! You have 5 messages.")
 
 	//Test fallback
-	//expect(consoleMock.mock.calls[5][0]).toBe("This is missing in German")
+	expect(consoleMock.mock.calls[5][0]).toBe("This is missing in German")
 
 	//Test plural
 	expect(consoleMock.mock.calls[6][0]).toBe("Du hast keine nachrichten")
 	expect(consoleMock.mock.calls[7][0]).toBe("Du hast 10 nachrichten")
+
+	expect(consoleMock.mock.calls[8][0]).toBe("You have no messages")
+	expect(consoleMock.mock.calls[9][0]).toBe("You have 10 messages")
 })

--- a/inlang/source-code/paraglide/paraglide-js/example/messages/de.json
+++ b/inlang/source-code/paraglide/paraglide-js/example/messages/de.json
@@ -2,6 +2,7 @@
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"currentLanguageTag": "Der aktuelle Sprachtag ist \"{languageTag}\".",
 	"greeting": "Hallo {name}! Du hast {count} Nachrichten.",
+	"plural": "match {messages} when 0 {Du hast keine nachrichten} when * {Du hast {count} nachrichten}",
 	"hello": "Hallo Welt!",
 	"with_backtick": "`Hallo Welt!`"
 }

--- a/inlang/source-code/paraglide/paraglide-js/example/messages/de.json
+++ b/inlang/source-code/paraglide/paraglide-js/example/messages/de.json
@@ -2,7 +2,7 @@
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"currentLanguageTag": "Der aktuelle Sprachtag ist \"{languageTag}\".",
 	"greeting": "Hallo {name}! Du hast {count} Nachrichten.",
-	"plural": "match {messages} when 0 {Du hast keine nachrichten} when * {Du hast {count} nachrichten}",
+	"plural": "match {messages} when 0 {Du hast keine nachrichten} when * {Du hast {messages} nachrichten}",
 	"hello": "Hallo Welt!",
 	"with_backtick": "`Hallo Welt!`"
 }

--- a/inlang/source-code/paraglide/paraglide-js/example/messages/en-US.json
+++ b/inlang/source-code/paraglide/paraglide-js/example/messages/en-US.json
@@ -2,6 +2,7 @@
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"currentLanguageTag": "The current language tag is \"{languageTag}\".",
 	"greeting": "Welcome {name}! You have {count} messages.",
+	"plural": "match {messages} when 0 {You have no messages} when * {You have {count} messages}",
 	"hello": "Hello World!",
 	"missing_in_german": "This is missing in German"
 }

--- a/inlang/source-code/paraglide/paraglide-js/example/messages/en-US.json
+++ b/inlang/source-code/paraglide/paraglide-js/example/messages/en-US.json
@@ -2,7 +2,7 @@
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"currentLanguageTag": "The current language tag is \"{languageTag}\".",
 	"greeting": "Welcome {name}! You have {count} messages.",
-	"plural": "match {messages} when 0 {You have no messages} when * {You have {count} messages}",
+	"plural": "match {messages} when 0 {You have no messages} when * {You have {messages} messages}",
 	"hello": "Hello World!",
 	"missing_in_german": "This is missing in German"
 }

--- a/inlang/source-code/paraglide/paraglide-js/example/src/main.ts
+++ b/inlang/source-code/paraglide/paraglide-js/example/src/main.ts
@@ -20,3 +20,8 @@ console.log(m.missing_in_german())
 
 console.log(m.plural({ messages: 0 }))
 console.log(m.plural({ messages: 10 }))
+
+setLanguageTag("en-US")
+
+console.log(m.plural({ messages: 0 }))
+console.log(m.plural({ messages: 10 }))

--- a/inlang/source-code/paraglide/paraglide-js/example/src/main.ts
+++ b/inlang/source-code/paraglide/paraglide-js/example/src/main.ts
@@ -17,3 +17,6 @@ console.log(m.greeting({ name: "Samuel", count: 5 }))
 console.log(en_US.greeting({ name: "Samuel", count: 5 }))
 
 console.log(m.missing_in_german())
+
+console.log(m.plural({ messages: 0 }))
+console.log(m.plural({ messages: 10 }))

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -251,9 +251,7 @@ describe("e2e", async () => {
 		expect(runtime.isAvailableLanguageTag("--")).toBe(false)
 	})
 
-	test.only("falls back to messages according to BCP 47 lookup order", async () => {
-		console.log(compiledBundle.output[0].code)
-
+	test("falls back to messages according to BCP 47 lookup order", async () => {
 		const { m, runtime } = await import(
 			`data:application/javascript;base64,${Buffer.from(
 				compiledBundle.output[0].code,
@@ -560,4 +558,3 @@ const mockSettings: ProjectSettings = {
 }
 
 const output = await compile({ messages: mockMessages, settings: mockSettings })
-console.log(JSON.stringify(output, undefined, 2))

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -251,7 +251,9 @@ describe("e2e", async () => {
 		expect(runtime.isAvailableLanguageTag("--")).toBe(false)
 	})
 
-	test("falls back to messages according to BCP 47 lookup order", async () => {
+	test.only("falls back to messages according to BCP 47 lookup order", async () => {
+		console.log(compiledBundle.output[0].code)
+
 		const { m, runtime } = await import(
 			`data:application/javascript;base64,${Buffer.from(
 				compiledBundle.output[0].code,
@@ -558,3 +560,4 @@ const mockSettings: ProjectSettings = {
 }
 
 const output = await compile({ messages: mockMessages, settings: mockSettings })
+console.log(JSON.stringify(output, undefined, 2))

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.test.ts
@@ -16,32 +16,6 @@ it("should throw if a message uses `-` because `-` are invalid JS function names
 	).toThrow()
 })
 
-it("should throw an error if a message has multiple variants with the same language tag", () => {
-	expect(() =>
-		compileMessage(
-			{
-				id: "duplicateLanguageTag",
-				alias: {},
-				selectors: [],
-				variants: [
-					{
-						match: [],
-						languageTag: "en",
-						pattern: [],
-					},
-					{
-						match: [],
-						languageTag: "en",
-						pattern: [],
-					},
-				],
-			},
-			["en"],
-			"en"
-		)
-	).toThrow()
-})
-
 it("should compile a message with a language tag that contains a hyphen - to an underscore to prevent invalid JS imports", async () => {
 	const result = compileMessage(
 		{

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
@@ -71,10 +71,6 @@ export const compileMessage = (
 		variantsByLanguage[variant.languageTag] = variantsForLanugage
 	}
 
-	if (message.variants.length > availableLanguageTags.length) {
-		console.log(JSON.stringify(message.variants))
-	}
-
 	const resource: Resource = {
 		index: messageIndexFunction({ message, params, availableLanguageTags }),
 	}

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
@@ -80,8 +80,16 @@ export const compileMessage = (
 
 		//If there isn't a variant for the language tag -> fallback
 		if (variants.length == 0) {
+			const fallbackLanguageTag = lookup(languageTag, {
+				languageTags: availableLanguageTags,
+				defaultLanguageTag: sourceLanguageTag,
+			})
+
 			//if the fallback has the pattern, reexport the message from the fallback language
-			resource[languageTag] = messageIdFallback(message, languageTag)
+			resource[languageTag] =
+				languageTag !== fallbackLanguageTag
+					? reexportMessage(message, fallbackLanguageTag)
+					: messageIdFallback(message, languageTag)
 			continue
 		}
 

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
@@ -36,6 +36,20 @@ export const compileMessage = (
 		)
 	}
 
+	/**
+	 * The variants grouped by language tag.
+	 */
+	const variantsByLanguage: Record<LanguageTag, Message["variants"]> = {}
+
+	for (const variant of message.variants) {
+		const variantsForLanugage = variantsByLanguage[variant.languageTag] ?? []
+		variantsForLanugage.push(variant)
+		variantsByLanguage[variant.languageTag] = variantsForLanugage
+	}
+
+	/**
+	 * The compiled patterns by language tag.
+	 */
 	const compiledPatterns: Record<LanguageTag, string> = {}
 	// parameter names and TypeScript types
 	// only allowing types that JS transpiles to strings under the hood like string and number.

--- a/inlang/source-code/plugins/inlang-message-format/src/parsing/parseMessage.test.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/parsing/parseMessage.test.ts
@@ -73,6 +73,44 @@ test("parses a message with a match statement", () => {
 	expect(parsed).toEqual(message)
 })
 
+test("parses a message with a number in the match statement", () => {
+	const parsed = parseMessage({
+		key: "test",
+		value:
+			"match {messages} when 0 {Du hast keine nachrichten} when * {Du hast {messages} nachrichten}",
+		languageTag: "en",
+	})
+
+	const message: Message = {
+		id: "test",
+		alias: {},
+		selectors: [
+			{
+				type: "VariableReference",
+				name: "messages",
+			},
+		],
+		variants: [
+			{
+				match: ["0"],
+				languageTag: "en",
+				pattern: [{ type: "Text", value: "Du hast keine nachrichten" }],
+			},
+			{
+				match: ["*"],
+				languageTag: "en",
+				pattern: [
+					{ type: "Text", value: "Du hast " },
+					{ type: "VariableReference", name: "messages" },
+					{ type: "Text", value: " nachrichten" },
+				],
+			},
+		],
+	}
+
+	expect(parsed).toEqual(message)
+})
+
 test("it parses a message with multiple selectors", () => {
 	const parsed = parseMessage({
 		key: "test",

--- a/inlang/source-code/plugins/inlang-message-format/src/parsing/parseMessage.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/parsing/parseMessage.ts
@@ -1,4 +1,4 @@
-import type { LanguageTag, Message } from "@inlang/sdk"
+import type { LanguageTag, Message, Pattern } from "@inlang/sdk"
 import { parsePattern } from "./parsePattern.js"
 
 export const parseMessage = (args: {
@@ -6,6 +6,11 @@ export const parseMessage = (args: {
 	value: string
 	languageTag: LanguageTag
 }): Message => {
+	try {
+		return parseMessageWithVariants(args)
+		// eslint-disable-next-line no-empty
+	} catch (e) {}
+
 	return {
 		id: args.key,
 		alias: {},
@@ -17,5 +22,61 @@ export const parseMessage = (args: {
 				pattern: parsePattern(args.value),
 			},
 		],
+	}
+}
+/**
+ * Attempts to parse a message with multiple variants.
+ *
+ * This is _very_ hacky & should not make it to production. I can think of a dozen edge-cases, but it'll do for prototyping
+ *
+ * @throws If a syntax error is found
+ */
+function parseMessageWithVariants(args: {
+	key: string
+	value: string
+	languageTag: LanguageTag
+}): Message {
+	if (!args.value.startsWith("match")) throw new Error("Syntax error")
+
+	const parts = args.value.split("when")
+	const selectorPart = parts[0]
+	if (!selectorPart) throw new Error("Syntax error")
+	const selectorSource = selectorPart.replace("match", "").trim()
+
+	//selectors is a bunch of `{var1} {var2}`. We want variable-references for them all
+	const selectors = parsePattern(selectorSource).filter(
+		(part): part is Extract<Pattern, { type: "VariableReference" }> =>
+			part.type === "VariableReference"
+	)
+
+	const variants: Message["variants"] = []
+	for (let i = 1; i < parts.length; i++) {
+		const variantSource = parts[i]
+		if (!variantSource) throw new Error("Syntax error")
+
+		const [matchPart, ...patternPart] = variantSource.split("{")
+		if (!patternPart.length) throw new Error("Syntax error")
+
+		const patternParts = patternPart.join("{").split("}")
+		patternParts.pop()
+		const patternSource = patternParts.join("}")
+
+		if (!matchPart || !patternSource) throw new Error("Syntax error")
+
+		const match = matchPart.trim().split(" ")
+		if (match.length !== selectors.length) throw new Error("Syntax error")
+
+		variants.push({
+			languageTag: args.languageTag,
+			match,
+			pattern: parsePattern(patternSource),
+		})
+	}
+
+	return {
+		id: args.key,
+		alias: {},
+		selectors,
+		variants,
 	}
 }

--- a/inlang/source-code/plugins/inlang-message-format/src/parsing/serializeMessage.test.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/parsing/serializeMessage.test.ts
@@ -19,14 +19,39 @@ test("it should split the variants into language tags", async () => {
 	})
 })
 
-test("it should throw if there are multiple variants for the same language tag which is unsupported at the moment", async () => {
+test("it should serialize a match statement for multiple variants", async () => {
 	const message: Message = {
 		id: "test",
 		alias: {},
-		selectors: [],
+		selectors: [
+			{
+				type: "VariableReference",
+				name: "gender",
+			},
+		],
 		variants: [
 			{ match: ["female"], languageTag: "en", pattern: [{ type: "Text", value: "Hello actress" }] },
-			{ match: [], languageTag: "en", pattern: [{ type: "Text", value: "Hallo actor" }] },
+			{ match: ["*"], languageTag: "en", pattern: [{ type: "Text", value: "Hello actor" }] },
+		],
+	}
+	expect(serializeMessage(message)).toEqual({
+		en: "match {gender} when female {Hello actress} when * {Hello actor}",
+	})
+})
+
+test("it should throw if one variant doesn't provide a match for all selectors", async () => {
+	const message: Message = {
+		id: "test",
+		alias: {},
+		selectors: [
+			{
+				type: "VariableReference",
+				name: "gender",
+			},
+		],
+		variants: [
+			{ match: ["female"], languageTag: "en", pattern: [{ type: "Text", value: "Hello actress" }] },
+			{ match: [], languageTag: "en", pattern: [{ type: "Text", value: "Hello actor" }] },
 		],
 	}
 	expect(() => serializeMessage(message)).toThrow()

--- a/inlang/source-code/plugins/inlang-message-format/src/parsing/serializeMessage.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/parsing/serializeMessage.ts
@@ -2,14 +2,45 @@ import type { LanguageTag, Message } from "@inlang/sdk"
 import { serializedPattern } from "./serializePattern.js"
 
 export const serializeMessage = (message: Message): Record<LanguageTag, string> => {
+	//group variants by language tag while preserving order
+	const variantsByLanguageTag = groupByLanguageTag(message.variants)
+
 	const result: Record<LanguageTag, string> = {}
-	for (const variant of message.variants) {
-		if (result[variant.languageTag] !== undefined) {
-			throw new Error(
-				`The message "${message.id}" has multiple variants for the language tag "${variant.languageTag}". The inlang-message-format plugin does not support multiple variants for the same language tag at the moment.`
-			)
+	for (const [languageTag, variants] of Object.entries(variantsByLanguageTag)) {
+		if (variants.length == 1) {
+			// @ts-ignore
+			result[languageTag] = serializedPattern(variants[0].pattern)
+			continue
 		}
-		result[variant.languageTag] = serializedPattern(variant.pattern)
+
+		for (const variant of variants) {
+			if (variant.match.length !== message.selectors.length) {
+				throw new Error("All variants must provide a selector-value for all selectors")
+			}
+		}
+
+		const statement =
+			"match " +
+			message.selectors.map((ref) => "{" + ref.name + "}").join(" ") +
+			" " +
+			variants
+				.map((variant) => `when ${variant.match.join(" ")} {${serializedPattern(variant.pattern)}}`)
+				.join(" ")
+
+		result[languageTag] = statement
+	}
+	return result
+}
+
+function groupByLanguageTag(
+	variants: Message["variants"]
+): Record<LanguageTag, Message["variants"]> {
+	const result: Record<LanguageTag, Message["variants"]> = {}
+
+	for (const variant of variants) {
+		const variantsForLanguage = result[variant.languageTag] ?? []
+		variantsForLanguage.push(variant)
+		result[variant.languageTag] = variantsForLanguage
 	}
 	return result
 }

--- a/inlang/source-code/plugins/inlang-message-format/src/plugin.test.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/plugin.test.ts
@@ -40,6 +40,8 @@ test("roundtrip (saving/loading messages)", async () => {
 	const deInitial = JSON.stringify({
 		$schema: "https://inlang.com/schema/inlang-message-format",
 		second_message: "Mal sehen ob das funktioniert",
+		third_message:
+			"match {messages} when 0 {Du hast keine nachrichten} when * {Du hast {messages} nachrichten}",
 	} satisfies StorageSchema)
 
 	await fs.mkdir("./messages")
@@ -77,6 +79,20 @@ test("roundtrip (saving/loading messages)", async () => {
 				{
 					match: ["*"],
 					languageTag: "en",
+					pattern: [
+						{ type: "Text", value: "Du hast " },
+						{ type: "VariableReference", name: "messages" },
+						{ type: "Text", value: " nachrichten" },
+					],
+				},
+				{
+					match: ["0"],
+					languageTag: "de",
+					pattern: [{ type: "Text", value: "Du hast keine nachrichten" }],
+				},
+				{
+					match: ["*"],
+					languageTag: "de",
 					pattern: [
 						{ type: "Text", value: "Du hast " },
 						{ type: "VariableReference", name: "messages" },

--- a/inlang/source-code/plugins/inlang-message-format/src/plugin.test.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/plugin.test.ts
@@ -33,6 +33,8 @@ test("roundtrip (saving/loading messages)", async () => {
 		$schema: "https://inlang.com/schema/inlang-message-format",
 		first_message: "If this fails I will be sad",
 		second_message: "Let's see if this works",
+		third_message:
+			"match {messages} when 0 {Du hast keine nachrichten} when * {Du hast {messages} nachrichten}",
 	} satisfies StorageSchema)
 
 	const deInitial = JSON.stringify({
@@ -57,6 +59,32 @@ test("roundtrip (saving/loading messages)", async () => {
 			en: "Let's see if this works",
 			de: "Mal sehen ob das funktioniert",
 		}),
+		{
+			id: "third_message",
+			alias: {},
+			selectors: [
+				{
+					type: "VariableReference",
+					name: "messages",
+				},
+			],
+			variants: [
+				{
+					match: ["0"],
+					languageTag: "en",
+					pattern: [{ type: "Text", value: "Du hast keine nachrichten" }],
+				},
+				{
+					match: ["*"],
+					languageTag: "en",
+					pattern: [
+						{ type: "Text", value: "Du hast " },
+						{ type: "VariableReference", name: "messages" },
+						{ type: "Text", value: " nachrichten" },
+					],
+				},
+			],
+		},
 	])
 
 	await plugin.saveMessages!({

--- a/inlang/source-code/plugins/inlang-message-format/src/plugin.ts
+++ b/inlang/source-code/plugins/inlang-message-format/src/plugin.ts
@@ -39,14 +39,17 @@ export const plugin: Plugin<{
 					if (key === "$schema") {
 						continue
 					}
+
 					// message already exists, add the variants
-					else if (result[key]) {
+					const existingResult = result[key]
+					if (existingResult) {
 						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						result[key]!.variants = [
+						existingResult.variants = [
 							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-							...result[key]!.variants,
+							...existingResult.variants,
 							...parseMessage({ key, value: json[key], languageTag: tag }).variants,
 						]
+						result[key] = existingResult
 					}
 					// message does not exist yet, create it
 					else {

--- a/inlang/source-code/sdk/src/loadProject.test.ts
+++ b/inlang/source-code/sdk/src/loadProject.test.ts
@@ -878,22 +878,22 @@ describe("functionality", () => {
 					selectors: [],
 					variants: [
 						{
-							languageTag: "de",
-							match: [],
-							pattern: [
-								{
-									type: "Text",
-									value: "a de",
-								},
-							],
-						},
-						{
 							languageTag: "en",
 							match: [],
 							pattern: [
 								{
 									type: "Text",
 									value: "a en",
+								},
+							],
+						},
+						{
+							languageTag: "de",
+							match: [],
+							pattern: [
+								{
+									type: "Text",
+									value: "a de",
 								},
 							],
 						},
@@ -905,22 +905,22 @@ describe("functionality", () => {
 					selectors: [],
 					variants: [
 						{
-							languageTag: "de",
-							match: [],
-							pattern: [
-								{
-									type: "Text",
-									value: "b de",
-								},
-							],
-						},
-						{
 							languageTag: "en",
 							match: [],
 							pattern: [
 								{
 									type: "Text",
 									value: "b en",
+								},
+							],
+						},
+						{
+							languageTag: "de",
+							match: [],
+							pattern: [
+								{
+									type: "Text",
+									value: "b de",
 								},
 							],
 						},

--- a/inlang/source-code/sdk/src/loadProject.ts
+++ b/inlang/source-code/sdk/src/loadProject.ts
@@ -644,8 +644,6 @@ async function loadMessagesViaPlugin(
 			})
 		)
 
-		console.log("loadedMessages", JSON.stringify(loadedMessages, undefined, 2))
-
 		for (const loadedMessage of loadedMessages) {
 			const loadedMessageClone = structuredClone(loadedMessage)
 
@@ -711,7 +709,6 @@ async function loadMessagesViaPlugin(
 				}
 
 				const importedEnecoded = stringifyMessage(loadedMessageClone)
-				console.log("importedEnecoded", importedEnecoded)
 
 				// add the message - this will trigger an async file creation in the backgound!
 				messagesQuery.create({ data: loadedMessageClone })

--- a/inlang/source-code/sdk/src/loadProject.ts
+++ b/inlang/source-code/sdk/src/loadProject.ts
@@ -26,7 +26,7 @@ import { normalizePath, type NodeishFilesystem } from "@lix-js/fs"
 import { isAbsolutePath } from "./isAbsolutePath.js"
 import { maybeMigrateToDirectory } from "./migrations/migrateToDirectory.js"
 
-import { stringifyMessage as stringifyMessage } from "./storage/helper.js"
+import { stringifyMessage } from "./storage/helper.js"
 
 import { humanIdHash } from "./storage/human-id/human-readable-id.js"
 
@@ -644,6 +644,8 @@ async function loadMessagesViaPlugin(
 			})
 		)
 
+		console.log("loadedMessages", JSON.stringify(loadedMessages, undefined, 2))
+
 		for (const loadedMessage of loadedMessages) {
 			const loadedMessageClone = structuredClone(loadedMessage)
 
@@ -709,6 +711,7 @@ async function loadMessagesViaPlugin(
 				}
 
 				const importedEnecoded = stringifyMessage(loadedMessageClone)
+				console.log("importedEnecoded", importedEnecoded)
 
 				// add the message - this will trigger an async file creation in the backgound!
 				messagesQuery.create({ data: loadedMessageClone })

--- a/inlang/source-code/sdk/src/storage/helper.test.ts
+++ b/inlang/source-code/sdk/src/storage/helper.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest"
+import { stringifyMessage } from "./helper.js"
+import type { Message } from "@inlang/message"
+
+describe("stringifyMessage", () => {
+	it("does not modify the input", () => {
+		const message: Message = {
+			id: "m1",
+			alias: {},
+			selectors: [],
+			variants: [
+				{ languageTag: "en", match: [], pattern: [{ type: "Text", value: "Hello World!" }] },
+				{ languageTag: "de", match: [], pattern: [{ type: "Text", value: "Hallo Welt!" }] },
+			],
+		}
+		const copy = structuredClone(message)
+		stringifyMessage(message)
+		expect(copy).toEqual(message)
+	})
+})

--- a/inlang/source-code/sdk/src/storage/helper.ts
+++ b/inlang/source-code/sdk/src/storage/helper.ts
@@ -1,4 +1,4 @@
-import { Message, Variant } from "../versionedInterfaces.js"
+import type { Message, Variant } from "../versionedInterfaces.js"
 
 const fileExtension = ".json"
 

--- a/inlang/source-code/sdk/src/storage/helper.ts
+++ b/inlang/source-code/sdk/src/storage/helper.ts
@@ -30,7 +30,7 @@ export function stringifyMessage(message: Message) {
 	}
 
 	// lets order variants as well
-	messageWithSortedKeys["variants"] = message["variants"].toSorted(
+	messageWithSortedKeys["variants"] = [...message["variants"]].sort(
 		(variantA: Variant, variantB: Variant) => {
 			// First, compare by language
 			const languageComparison = variantA.languageTag.localeCompare(variantB.languageTag)

--- a/inlang/source-code/sdk/src/storage/helper.ts
+++ b/inlang/source-code/sdk/src/storage/helper.ts
@@ -30,7 +30,7 @@ export function stringifyMessage(message: Message) {
 	}
 
 	// lets order variants as well
-	messageWithSortedKeys["variants"] = messageWithSortedKeys["variants"].sort(
+	messageWithSortedKeys["variants"] = message["variants"].toSorted(
 		(variantA: Variant, variantB: Variant) => {
 			// First, compare by language
 			const languageComparison = variantA.languageTag.localeCompare(variantB.languageTag)


### PR DESCRIPTION
This is a prototype for using plurals in paraglide. This PR will likely never be merged. It exists to allow us to play around & figure out requirements. 

### Message Format changes
We can now have a match-statement in our messages to select between different variants. The source
```
match {gender} when female {Hello actress} when * {Hello actor}
```
would compile into the message:
```ts
{
  id: "message_id",
  alias: {},
  // we will need to introduce typed variable references, so we can have more than just exact matches
  selectors: [
    {
      type: "VariableReference",
      name: "gender",
    },
  ],
  variants: [
    //each variant must have exactly one `match` value for each selector
    { match: ["female"], languageTag: "en", pattern: [{ type: "Text", value: "Hello actress" }] },
    { match: ["*"], languageTag: "en", pattern: [{ type: "Text", value: "Hello actor" }] },
  ],
}
```

(this is still very fragile, so changing whitespace may break the parser. I just bodged together the simplest thing that works)