### PR TITLE
Fix path normalizing + make API more flexible for `cross-sell-sherlock`

### DIFF
--- a/.changeset/ninety-bears-bathe.md
+++ b/.changeset/ninety-bears-bathe.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Update dependency

--- a/.changeset/slow-terms-visit.md
+++ b/.changeset/slow-terms-visit.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cross-sell-sherlock": patch
+---
+
+update API of cross-sell package to be more flexible + fix bugs

--- a/inlang/source-code/cross-sell/cross-sell-sherlock/src/index.ts
+++ b/inlang/source-code/cross-sell/cross-sell-sherlock/src/index.ts
@@ -4,13 +4,24 @@ import {
 	isInWorkspaceRecommendation,
 } from "./recommendation/recommendation.js"
 
-export async function isAdopted(
-	fs: NodeishFilesystem,
-	workingDirectory?: string
-): Promise<boolean> {
-	return isInWorkspaceRecommendation(fs, workingDirectory)
+/**
+ * Checks if the Sherlock app is adopted within the workspace recommendations.
+ * @param {Object} args - The arguments object.
+ * @param {NodeishFilesystem} args.fs - The filesystem to use for operations.
+ * @param {string} [args.workingDirectory] - The working directory path. Defaults to the current directory.
+ * @returns {Promise<boolean>} - A promise that resolves to true if the project is adopted, otherwise false.
+ */
+export async function isAdopted(args: { fs: NodeishFilesystem, workingDirectory?: string }): Promise<boolean> {
+    return isInWorkspaceRecommendation(args.fs, args.workingDirectory);
 }
 
-export async function add(fs: NodeishFilesystem, workingDirectory?: string): Promise<void> {
-	await addRecommendationToWorkspace(fs, workingDirectory)
+/**
+ * Adds the Sherlock app to the workspace recommendations.
+ * @param {Object} args - The arguments object.
+ * @param {NodeishFilesystem} args.fs - The filesystem to use for operations.
+ * @param {string} [args.workingDirectory] - The working directory path. Defaults to the current directory.
+ * @returns {Promise<void>} - A promise that resolves when the project is successfully added.
+ */
+export async function add(args: { fs: NodeishFilesystem, workingDirectory?: string }): Promise<void> {
+    await addRecommendationToWorkspace(args.fs, args.workingDirectory);
 }

--- a/inlang/source-code/cross-sell/cross-sell-sherlock/src/recommendation/recommendation.ts
+++ b/inlang/source-code/cross-sell/cross-sell-sherlock/src/recommendation/recommendation.ts
@@ -5,11 +5,15 @@ import { parse, type CommentJSONValue, stringify } from "comment-json"
 import { type ExtensionsJson as ExtensionsJsonType, ExtensionsJson } from "./utils/types.js"
 import { pathExists } from "./utils/exists.js"
 
+const vsCodePath = "./.vscode"
+
 export async function addRecommendationToWorkspace(
 	fs: NodeishFilesystem,
 	workingDirectory?: string
 ): Promise<void> {
-	const vscodeFolderPath = normalizePath(joinPath(workingDirectory ?? "", "./.vscode"))
+	const vscodeFolderPath = workingDirectory
+		? normalizePath(joinPath(workingDirectory ?? "", vsCodePath))
+		: vsCodePath
 	const extensionsJsonPath = joinPath(vscodeFolderPath, "extensions.json")
 
 	if (!(await pathExists(vscodeFolderPath, fs))) {
@@ -42,7 +46,9 @@ export async function isInWorkspaceRecommendation(
 	fs: NodeishFilesystem,
 	workingDirectory?: string
 ): Promise<boolean> {
-	const vscodeFolderPath = normalizePath(joinPath(workingDirectory ?? "", "./.vscode"))
+	const vscodeFolderPath = workingDirectory
+		? normalizePath(joinPath(workingDirectory ?? "", vsCodePath))
+		: vsCodePath
 	const extensionsJsonPath = joinPath(vscodeFolderPath, "extensions.json")
 
 	if (!(await pathExists(extensionsJsonPath, fs)) || !(await pathExists(vscodeFolderPath, fs))) {

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.test.ts
@@ -346,17 +346,20 @@ describe("existingProjectFlow()", () => {
 describe("maybeAddVsCodeExtension()", () => {
 	test("it should add the Visual Studio Code extension (Sherlock) if the user uses vscode", async () => {
 		const fs = mockFiles({
-			"/project.inlang/settings.json": JSON.stringify(newProjectTemplate),
+			"/folder/project.inlang/settings.json": JSON.stringify(newProjectTemplate),
 		})
-		const repo = await openRepository("file://", { nodeishFs: fs })
+
+		process.cwd = () => "/folder"
+
+		const repo = await openRepository("file://folder/", { nodeishFs: fs })
 
 		mockUserInput([
 			// user uses vscode
 			true,
 		])
-		await maybeAddVsCodeExtension({ projectPath: "/project.inlang" }, { logger, repo })
+		await maybeAddVsCodeExtension({ projectPath: "/folder/project.inlang" }, { logger, repo })
 		expect(consola.prompt).toHaveBeenCalledOnce()
-		const extensions = await fs.readFile("/.vscode/extensions.json", {
+		const extensions = await fs.readFile("/folder/.vscode/extensions.json", {
 			encoding: "utf-8",
 		})
 		expect(extensions).toBe(

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -147,8 +147,8 @@ export const maybeAddVsCodeExtension = async (args: { projectPath: string }, ctx
 	}
 
 	try {
-		if (!(await Sherlock.isAdopted(ctx.repo.nodeishFs))) {
-			await Sherlock.add(ctx.repo.nodeishFs)
+		if (!(await Sherlock.isAdopted({ fs: ctx.repo.nodeishFs }))) {
+			await Sherlock.add({ fs: ctx.repo.nodeishFs })
 
 			ctx.logger.success(
 				"Added the inlang Visual Studio Code extension (Sherlock) to the workspace recommendations."


### PR DESCRIPTION
- fix 
<img width="619" alt="Bildschirmfoto 2024-03-13 um 10 25 38" src="https://github.com/opral/monorepo/assets/34959078/4c5dec5e-7594-4cc8-95f0-e33e23cd9f83">

- make API more flexible @LorisSigrist this is a breaking change.

```js
add(fs, workingDirectory) -> add({fs, workingDirectory})
isAdopted(fs, workingDirectory) -> isAdopted({fs, workingDirectory})
```