### PR TITLE
Fix JSDoc on Aliases

### DIFF
--- a/.changeset/quick-onions-count.md
+++ b/.changeset/quick-onions-count.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix JSDoc annotations on message aliases

--- a/inlang/source-code/paraglide/paraglide-js/example/project.inlang/settings.json
+++ b/inlang/source-code/paraglide/paraglide-js/example/project.inlang/settings.json
@@ -1,16 +1,15 @@
 {
-  "$schema": "https://inlang.com/schema/project-settings",
-  "sourceLanguageTag": "en",
-  "languageTags": [
-    "en",
-    "de",
-    "en-US"
-  ],
-  "modules": [
-    "../../../plugins/inlang-message-format/dist/index.js",
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js"
-  ],
-  "plugin.inlang.messageFormat": {
-    "pathPattern": "./messages/{languageTag}.json"
-  }
+	"$schema": "https://inlang.com/schema/project-settings",
+	"sourceLanguageTag": "en",
+	"languageTags": ["en", "de", "en-US"],
+	"modules": [
+		"../../../plugins/inlang-message-format/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js"
+	],
+	"plugin.inlang.messageFormat": {
+		"pathPattern": "./messages/{languageTag}.json"
+	},
+	"experimental": {
+		"aliases": true
+	}
 }

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
@@ -196,8 +196,11 @@ function reexportAliases(message: Message) {
  * @see inlang.com/link.
  * ---
  * @deprecated reference the message by id \`m.${message.id}()\` instead
+ * 
+ * @param {Parameters<typeof ${message.id}>} args
+ * @returns {ReturnType<typeof ${message.id}>}
  */
-export const ${message.alias["default"]} = ${message.id};
+export const ${message.alias["default"]} = (...args) => ${message.id}(...args);
 `
 	}
 


### PR DESCRIPTION
TIL VsCode Inherits JSDoc from the original value if you alias it.

```js
/**
* This is ignored
*/
export const alias = message;

/**
 * This is shown
**/
export const message;
```

This PR adds a workaround for that 