### PR TITLE
Document page-data sideeffect quirk

### DIFF
--- a/.changeset/mighty-brooms-leave.md
+++ b/.changeset/mighty-brooms-leave.md
@@ -1,0 +1,6 @@
+---
+"@inlang/paraglide-js-adapter-unplugin": patch
+"@inlang/paraglide-js": patch
+---
+
+fix `openRepository` crash in non-git environments

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -309,13 +309,11 @@ export async function load({ depends }) {
 }
 ```
 
-There currently is a caveat with this. When switching languages, any side-effects triggererd by `data` changing will be run twice if the data is language dependent. Once with the new language + old data and then with the new language + new data. We're working to fix this.
-
 ## Caveats
 
 1. Links in the same Layout Component as `<ParagldieJS>` will not be translated. This will also log a warngin in development.
 2. Messages are not reactive. Don't use them in server-side module scope.
-3. Sideeffects triggered by `data` changing will be run twice if the data is language dependent. 
+3. Sideeffects triggered by `data` will run on language changes even if the data didn't change. If the data is language-dependent the sideeffect will run twice. 
 
 ### Using messages in `+layout.svelte`
 

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/README.md
@@ -309,10 +309,13 @@ export async function load({ depends }) {
 }
 ```
 
+There currently is a caveat with this. When switching languages, any side-effects triggererd by `data` changing will be run twice if the data is language dependent. Once with the new language + old data and then with the new language + new data. We're working to fix this.
+
 ## Caveats
 
 1. Links in the same Layout Component as `<ParagldieJS>` will not be translated. This will also log a warngin in development.
 2. Messages are not reactive. Don't use them in server-side module scope.
+3. Sideeffects triggered by `data` changing will be run twice if the data is language dependent. 
 
 ### Using messages in `+layout.svelte`
 

--- a/inlang/source-code/paraglide/paraglide-js-adapter-unplugin/src/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-unplugin/src/index.ts
@@ -64,7 +64,7 @@ export const paraglide = createUnplugin((config: UserConfig) => {
 
 		const repoRoot = await findRepoRoot({ nodeishFs: fs, path: projectPath })
 
-		const repo = await openRepository(repoRoot || process.cwd(), {
+		const repo = await openRepository(repoRoot || "file://" + process.cwd(), {
 			nodeishFs: fs,
 		})
 

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init.ts
@@ -44,7 +44,7 @@ export const initCommand = new Command()
 		// We are risking that there is no git repo. As long as we only use FS features and no Git features
 		// from the SDK we should be fine.
 		// Basic operations like `loadProject` should always work without a repo since it's used in CI.
-		const repo = await openRepository(repoRoot ?? process.cwd(), {
+		const repo = await openRepository(repoRoot ?? "file://" + process.cwd(), {
 			nodeishFs: nodeFsPromises,
 		})
 


### PR DESCRIPTION
There currently is an issue with the SvelteKit Adapter where side-effects of page `data` are triggered on language changes, even if the data isn't language dependent.

This is unfixable without breaking API changes, so for now we just document it.
