### PR TITLE
Fix PARJS-47 - Astro-adapter `languageTag()` not being set properly on windows

### DIFF
--- a/.changeset/lucky-eagles-guess.md
+++ b/.changeset/lucky-eagles-guess.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-astro": patch
+---
+
+fix: `languageTag()` not being set properly on windows. This bug was caused by duplicate module instantiation.

--- a/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/integration.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/integration.ts
@@ -3,7 +3,7 @@ import { paraglide } from "@inlang/paraglide-js-adapter-vite"
 import path from "node:path"
 import { alias } from "./alias.js"
 import { fileURLToPath } from "node:url"
-import { normaizePath } from "./utilts.js"
+import { normalizePath } from "./utilts.js"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -38,7 +38,7 @@ export function integration(integrationConfig: {
 								//normalizing the path is very important!
 								//otherwise you get duplicate modules on windows
 								//learned that one the hard way (parjs-47)
-								"paraglide-js-adapter-astro:runtime": normaizePath(runtimePath),
+								"paraglide-js-adapter-astro:runtime": normalizePath(runtimePath),
 							}),
 						],
 					},

--- a/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/integration.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/integration.ts
@@ -3,6 +3,7 @@ import { paraglide } from "@inlang/paraglide-js-adapter-vite"
 import path from "node:path"
 import { alias } from "./alias.js"
 import { fileURLToPath } from "node:url"
+import { normaizePath } from "./utilts.js"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -23,6 +24,8 @@ export function integration(integrationConfig: {
 					entrypoint: middlewarePath,
 				})
 
+				const runtimePath = path.resolve(process.cwd(), integrationConfig.outdir, "runtime.js")
+
 				//Register the vite plugin
 				updateConfig({
 					vite: {
@@ -32,11 +35,10 @@ export function integration(integrationConfig: {
 								outdir: integrationConfig.outdir,
 							}),
 							alias({
-								"paraglide-js-adapter-astro:runtime": path.resolve(
-									process.cwd(),
-									integrationConfig.outdir,
-									"runtime.js"
-								),
+								//normalizing the path is very important!
+								//otherwise you get duplicate modules on windows
+								//learned that one the hard way (parjs-47)
+								"paraglide-js-adapter-astro:runtime": normaizePath(runtimePath),
 							}),
 						],
 					},

--- a/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/middleware.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/middleware.ts
@@ -3,18 +3,19 @@ import {
 	setLanguageTag,
 	sourceLanguageTag,
 } from "paraglide-js-adapter-astro:runtime"
-import type { MiddlewareHandler } from "astro"
+import { type MiddlewareHandler } from "astro"
 
 export const onRequest: MiddlewareHandler = async ({ url, locals, currentLocale }, next) => {
 	const locale = currentLocale ?? getLangFromPath(url.pathname)
 	const dir = guessTextDirection(locale)
+
+	setLanguageTag(locale)
 
 	locals.paraglide = {
 		lang: locale,
 		dir,
 	}
 
-	setLanguageTag(locale)
 	return await next()
 }
 

--- a/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/utilts.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/utilts.ts
@@ -1,0 +1,13 @@
+// vendored in from vite
+import path from "node:path"
+
+const windowsSlashRE = /\\/g
+function slash(p: string): string {
+	return p.replace(windowsSlashRE, "/")
+}
+
+const isWindows = typeof process !== "undefined" && process.platform === "win32"
+
+export function normaizePath(id: string) {
+	return path.posix.normalize(isWindows ? slash(id) : id)
+}

--- a/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/utilts.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-astro/src/utilts.ts
@@ -8,6 +8,6 @@ function slash(p: string): string {
 
 const isWindows = typeof process !== "undefined" && process.platform === "win32"
 
-export function normaizePath(id: string) {
+export function normalizePath(id: string) {
 	return path.posix.normalize(isWindows ? slash(id) : id)
 }


### PR DESCRIPTION
This PR fixes https://github.com/opral/inlang-paraglide-js/issues/45

The issue was caused by the `runtime.js` module being instantiated twice. The middleware would correctly set the language, but in a separate instance of the module. The rest of the app didn't get the memo. 

This is fixed by normalizing the path passed to the internal import-alias plugin.