### PR TITLE
update `statusBar` display of prefix for `languageTag` in Sherlock 🕵️‍♂️

### DIFF
--- a/.changeset/strange-queens-add.md
+++ b/.changeset/strange-queens-add.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+update statusbar item

--- a/inlang/source-code/ide-extension/src/utilities/settings/statusBar.ts
+++ b/inlang/source-code/ide-extension/src/utilities/settings/statusBar.ts
@@ -38,7 +38,7 @@ export const showStatusBar = async () => {
 
 	const preferredLanguageTag = previewLanguageTag.length ? previewLanguageTag : sourceLanguageTag
 
-	statusBarItem.text = `Inlang: ${preferredLanguageTag}`
+	statusBarItem.text = `Sherlock: ${preferredLanguageTag}`
 	statusBarItem.tooltip = "Switch preview language"
 	statusBarItem.show()
 }


### PR DESCRIPTION
- fixes a bug in which the wrong branding name appeared as `languageTag` prefix in the process of setting a `previewLanguageTag` setting in VS Code

