### PR TITLE
Bump Fink to `solid-js@1.8.16` to un-break SolidStart in the monorepo

### DIFF
--- a/inlang/source-code/editor/package.json
+++ b/inlang/source-code/editor/package.json
@@ -54,7 +54,7 @@
 		"prosemirror-history": "^1.3.0",
 		"shiki": "^0.11.1",
 		"sirv": "^2.0.2",
-		"solid-js": "1.7.11",
+		"solid-js": "^1.8.16",
 		"solid-slider": "1.3.15",
 		"solid-tiptap": "^0.6.0",
 		"throttle-debounce": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,16 +297,16 @@ importers:
         version: 0.31.28
       '@solid-primitives/i18n':
         specifier: ^1.4.0
-        version: 1.4.1(solid-js@1.7.11)
+        version: 1.4.1(solid-js@1.8.16)
       '@solid-primitives/intersection-observer':
         specifier: ^2.0.5
-        version: 2.1.6(solid-js@1.7.11)
+        version: 2.1.6(solid-js@1.8.16)
       '@solid-primitives/scroll':
         specifier: 2.0.20
-        version: 2.0.20(solid-js@1.7.11)
+        version: 2.0.20(solid-js@1.8.16)
       '@solidjs/meta':
         specifier: 0.28.2
-        version: 0.28.2(solid-js@1.7.11)
+        version: 0.28.2(solid-js@1.8.16)
       '@tiptap/core':
         specifier: 2.0.3
         version: 2.0.3(@tiptap/pm@2.0.3)
@@ -389,14 +389,14 @@ importers:
         specifier: ^2.0.2
         version: 2.0.4
       solid-js:
-        specifier: 1.7.11
-        version: 1.7.11
+        specifier: ^1.8.16
+        version: 1.8.16
       solid-slider:
         specifier: 1.3.15
         version: 1.3.15
       solid-tiptap:
         specifier: ^0.6.0
-        version: 0.6.0(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)(solid-js@1.7.11)
+        version: 0.6.0(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)(solid-js@1.8.16)
       throttle-debounce:
         specifier: ^5.0.0
         version: 5.0.0
@@ -520,7 +520,7 @@ importers:
         version: 0.17.0(vite@4.5.2)
       vite-plugin-solid:
         specifier: 2.7.0
-        version: 2.7.0(solid-js@1.7.11)(vite@4.5.2)
+        version: 2.7.0(solid-js@1.8.16)(vite@4.5.2)
       vite-plugin-watch:
         specifier: 0.2.0
         version: 0.2.0
@@ -8657,6 +8657,14 @@ packages:
       solid-js: 1.7.11
     dev: false
 
+  /@solid-primitives/context@0.2.3(solid-js@1.8.16):
+    resolution: {integrity: sha512-6/e8qu9qJf48FJ+sxc/B782NdgFw5TvI8+r6U0gHizumfZcWZg8FAJqvRZAiwlygkUNiTQOGTeO10LVbMm0kvg==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      solid-js: 1.8.16
+    dev: false
+
   /@solid-primitives/event-listener@2.3.3(solid-js@1.7.11):
     resolution: {integrity: sha512-DAJbl+F0wrFW2xmcV8dKMBhk9QLVLuBSW+TR4JmIfTaObxd13PuL7nqaXnaYKDWOYa6otB00qcCUIGbuIhSUgQ==}
     peerDependencies:
@@ -8664,6 +8672,15 @@ packages:
     dependencies:
       '@solid-primitives/utils': 6.2.3(solid-js@1.7.11)
       solid-js: 1.7.11
+    dev: false
+
+  /@solid-primitives/event-listener@2.3.3(solid-js@1.8.16):
+    resolution: {integrity: sha512-DAJbl+F0wrFW2xmcV8dKMBhk9QLVLuBSW+TR4JmIfTaObxd13PuL7nqaXnaYKDWOYa6otB00qcCUIGbuIhSUgQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/utils': 6.2.3(solid-js@1.8.16)
+      solid-js: 1.8.16
     dev: false
 
   /@solid-primitives/i18n@1.4.1(solid-js@1.7.11):
@@ -8675,6 +8692,15 @@ packages:
       solid-js: 1.7.11
     dev: false
 
+  /@solid-primitives/i18n@1.4.1(solid-js@1.8.16):
+    resolution: {integrity: sha512-lUUb/hmI77O9oMH8Jj4pPta/pAV21gRgN52UJ7cCXVdv1QkiyzX586gDDU+Tj8NsK/U6OrmMk2tClPwqHAk/xA==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/context': 0.2.3(solid-js@1.8.16)
+      solid-js: 1.8.16
+    dev: false
+
   /@solid-primitives/intersection-observer@2.1.6(solid-js@1.7.11):
     resolution: {integrity: sha512-SeiCmN/R46Z+o9+5HhIQzSor0DqVPyo4ROLQMvCI8AsGZl/5nHlWzHTTbWPeukVUXTgb04wfC3DUo9IzF/XloA==}
     peerDependencies:
@@ -8684,6 +8710,15 @@ packages:
       solid-js: 1.7.11
     dev: false
 
+  /@solid-primitives/intersection-observer@2.1.6(solid-js@1.8.16):
+    resolution: {integrity: sha512-SeiCmN/R46Z+o9+5HhIQzSor0DqVPyo4ROLQMvCI8AsGZl/5nHlWzHTTbWPeukVUXTgb04wfC3DUo9IzF/XloA==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/utils': 6.2.3(solid-js@1.8.16)
+      solid-js: 1.8.16
+    dev: false
+
   /@solid-primitives/rootless@1.4.5(solid-js@1.7.11):
     resolution: {integrity: sha512-GFJE9GC3ojx0aUKqAUZmQPyU8fOVMtnVNrkdk2yS4kd17WqVSpXpoTmo9CnOwA+PG7FTzdIkogvfLQSLs4lrww==}
     peerDependencies:
@@ -8691,6 +8726,15 @@ packages:
     dependencies:
       '@solid-primitives/utils': 6.2.3(solid-js@1.7.11)
       solid-js: 1.7.11
+    dev: false
+
+  /@solid-primitives/rootless@1.4.5(solid-js@1.8.16):
+    resolution: {integrity: sha512-GFJE9GC3ojx0aUKqAUZmQPyU8fOVMtnVNrkdk2yS4kd17WqVSpXpoTmo9CnOwA+PG7FTzdIkogvfLQSLs4lrww==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/utils': 6.2.3(solid-js@1.8.16)
+      solid-js: 1.8.16
     dev: false
 
   /@solid-primitives/script-loader@2.1.2(solid-js@1.7.11):
@@ -8712,6 +8756,17 @@ packages:
       solid-js: 1.7.11
     dev: false
 
+  /@solid-primitives/scroll@2.0.20(solid-js@1.8.16):
+    resolution: {integrity: sha512-Om19Sehb1MD02aAViNexXfSOfbUQOfDA41W5DpORxgty/7GeE7RIVPzoNGDdNOEdmM7K0Yw3roxa9d9jb/dL7Q==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/event-listener': 2.3.3(solid-js@1.8.16)
+      '@solid-primitives/rootless': 1.4.5(solid-js@1.8.16)
+      '@solid-primitives/static-store': 0.0.5(solid-js@1.8.16)
+      solid-js: 1.8.16
+    dev: false
+
   /@solid-primitives/static-store@0.0.5(solid-js@1.7.11):
     resolution: {integrity: sha512-ssQ+s/wrlFAEE4Zw8GV499yBfvWx7SMm+ZVc11wvao4T5xg9VfXCL9Oa+x4h+vPMvSV/Knv5LrsLiUa+wlJUXQ==}
     peerDependencies:
@@ -8721,20 +8776,29 @@ packages:
       solid-js: 1.7.11
     dev: false
 
-  /@solid-primitives/timer@1.3.9(solid-js@1.8.15):
+  /@solid-primitives/static-store@0.0.5(solid-js@1.8.16):
+    resolution: {integrity: sha512-ssQ+s/wrlFAEE4Zw8GV499yBfvWx7SMm+ZVc11wvao4T5xg9VfXCL9Oa+x4h+vPMvSV/Knv5LrsLiUa+wlJUXQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/utils': 6.2.3(solid-js@1.8.16)
+      solid-js: 1.8.16
+    dev: false
+
+  /@solid-primitives/timer@1.3.9(solid-js@1.8.16):
     resolution: {integrity: sha512-uD+4+boV7k+5W+hL5d30eodUXSwOfOQz8AfbMPVmLOHaTmd0mdfpw0NkYhyn1rgcx1bSn/nHTd8lraHiMhO/6w==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
-      solid-js: 1.8.15
+      solid-js: 1.8.16
     dev: false
 
-  /@solid-primitives/utils@4.0.1(solid-js@1.8.15):
+  /@solid-primitives/utils@4.0.1(solid-js@1.8.16):
     resolution: {integrity: sha512-06fSyBair7ZxCquMjIqJes29aNg65X776TVw4EUN7PBtdWsGUeIZ9F/H4ek7yrDSxaSDaPHeye5knEYsYAq2gA==}
     peerDependencies:
       solid-js: ^1.6.0
     dependencies:
-      solid-js: 1.8.15
+      solid-js: 1.8.16
     dev: false
 
   /@solid-primitives/utils@6.2.3(solid-js@1.7.11):
@@ -8745,12 +8809,28 @@ packages:
       solid-js: 1.7.11
     dev: false
 
+  /@solid-primitives/utils@6.2.3(solid-js@1.8.16):
+    resolution: {integrity: sha512-CqAwKb2T5Vi72+rhebSsqNZ9o67buYRdEJrIFzRXz3U59QqezuuxPsyzTSVCacwS5Pf109VRsgCJQoxKRoECZQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      solid-js: 1.8.16
+    dev: false
+
   /@solidjs/meta@0.28.2(solid-js@1.7.11):
     resolution: {integrity: sha512-avlLgBPdk4KVxzRGFlYp/MIJo8B5jVgXPgk6OUnUP8km21Z+ovO+DUd7ZPA7ejv8PBdWi9GE3zCzw8RU2YuV2Q==}
     peerDependencies:
       solid-js: '>=1.4.0'
     dependencies:
       solid-js: 1.7.11
+    dev: false
+
+  /@solidjs/meta@0.28.2(solid-js@1.8.16):
+    resolution: {integrity: sha512-avlLgBPdk4KVxzRGFlYp/MIJo8B5jVgXPgk6OUnUP8km21Z+ovO+DUd7ZPA7ejv8PBdWi9GE3zCzw8RU2YuV2Q==}
+    peerDependencies:
+      solid-js: '>=1.4.0'
+    dependencies:
+      solid-js: 1.8.16
     dev: false
 
   /@solidjs/router@0.10.10(solid-js@1.8.15):
@@ -8761,12 +8841,12 @@ packages:
       solid-js: 1.8.15
     dev: false
 
-  /@solidjs/router@0.8.4(solid-js@1.8.15):
+  /@solidjs/router@0.8.4(solid-js@1.8.16):
     resolution: {integrity: sha512-Gi/WVoVseGMKS1DBdT3pNAMgOzEOp6Q3dpgNd2mW9GUEnVocPmtyBjDvXwN6m7tjSGsqqfqJFXk7bm1hxabSRw==}
     peerDependencies:
       solid-js: ^1.5.3
     dependencies:
-      solid-js: 1.8.15
+      solid-js: 1.8.16
     dev: false
 
   /@solidjs/start@0.4.11(solid-js@1.8.15)(vinxi@0.1.10)(vite@4.5.2):
@@ -10938,11 +11018,11 @@ packages:
     resolution: {integrity: sha512-/A7X1hoNBsgC2n7nKOWbIa4cTt9dJq9nehyLGdNxgjEcGzbsaJrofUDrFLt+0YJlyb7OOhFEPYHRCat3tsrytw==}
     dependencies:
       '@preact/preset-vite': 2.8.2(@babel/core@7.24.1)(preact@10.19.7)(vite@4.5.2)
-      '@solidjs/router': 0.8.4(solid-js@1.8.15)
+      '@solidjs/router': 0.8.4(solid-js@1.8.16)
       birpc: 0.2.17
-      solid-js: 1.8.15
+      solid-js: 1.8.16
       vite-plugin-inspect: 0.7.42(vite@4.5.2)
-      vite-plugin-solid: 2.7.0(solid-js@1.8.15)(vite@4.5.2)
+      vite-plugin-solid: 2.7.0(solid-js@1.8.16)(vite@4.5.2)
       ws: 8.16.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -23345,7 +23425,6 @@ packages:
       seroval: ^1.0
     dependencies:
       seroval: 1.0.5
-    dev: false
 
   /seroval@0.5.1:
     resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
@@ -23354,7 +23433,6 @@ packages:
   /seroval@1.0.5:
     resolution: {integrity: sha512-TM+Z11tHHvQVQKeNlOUonOWnsNM+2IBwZ4vwoi4j3zKzIpc5IDw8WPwCfcc8F17wy6cBcJGbZbFOR0UCuTZHQA==}
     engines: {node: '>=10'}
-    dev: false
 
   /serve-placeholder@2.0.1:
     resolution: {integrity: sha512-rUzLlXk4uPFnbEaIz3SW8VISTxMuONas88nYWjAWaM2W9VDbt9tyFOr3lq8RhVOFrT3XISoBw8vni5una8qMnQ==}
@@ -23667,6 +23745,13 @@ packages:
       seroval-plugins: 1.0.5(seroval@1.0.5)
     dev: false
 
+  /solid-js@1.8.16:
+    resolution: {integrity: sha512-rja94MNU9flF3qQRLNsu60QHKBDKBkVE1DldJZPIfn2ypIn3NV2WpSbGTQIvsyGPBo+9E2IMjwqnqpbgfWuzeg==}
+    dependencies:
+      csstype: 3.1.3
+      seroval: 1.0.5
+      seroval-plugins: 1.0.5(seroval@1.0.5)
+
   /solid-refresh@0.5.3(solid-js@1.7.11):
     resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
     peerDependencies:
@@ -23678,7 +23763,7 @@ packages:
       solid-js: 1.7.11
     dev: true
 
-  /solid-refresh@0.5.3(solid-js@1.8.15):
+  /solid-refresh@0.5.3(solid-js@1.8.16):
     resolution: {integrity: sha512-Otg5it5sjOdZbQZJnvo99TEBAr6J7PQ5AubZLNU6szZzg3RQQ5MX04oteBIIGDs0y2Qv8aXKm9e44V8z+UnFdw==}
     peerDependencies:
       solid-js: ^1.3
@@ -23686,8 +23771,7 @@ packages:
       '@babel/generator': 7.24.1
       '@babel/helper-module-imports': 7.24.1
       '@babel/types': 7.24.0
-      solid-js: 1.8.15
-    dev: false
+      solid-js: 1.8.16
 
   /solid-refresh@0.6.3(solid-js@1.7.11):
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -23714,10 +23798,10 @@ packages:
   /solid-slider@1.3.15:
     resolution: {integrity: sha512-5VdpvBOaP3OrMcgDpG0NxozQjsPDMDxQIAseyKon9+S4I/508TdQnUoDJllP2ED0qlNdOl++88cfvFXOKg+xKg==}
     dependencies:
-      '@solid-primitives/timer': 1.3.9(solid-js@1.8.15)
-      '@solid-primitives/utils': 4.0.1(solid-js@1.8.15)
+      '@solid-primitives/timer': 1.3.9(solid-js@1.8.16)
+      '@solid-primitives/utils': 4.0.1(solid-js@1.8.16)
       keen-slider: 6.8.6
-      solid-js: 1.8.15
+      solid-js: 1.8.16
     dev: false
 
   /solid-tiptap@0.6.0(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)(solid-js@1.7.11):
@@ -23731,6 +23815,19 @@ packages:
       '@tiptap/core': 2.0.3(@tiptap/pm@2.0.3)
       '@tiptap/pm': 2.0.3(@tiptap/core@2.0.3)
       solid-js: 1.7.11
+    dev: false
+
+  /solid-tiptap@0.6.0(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)(solid-js@1.8.16):
+    resolution: {integrity: sha512-79soXY4lSGkCdlfKalawGyvPE0kOvrKd7w9Zy3o3MY4dppti5Yd2RUVqyNPtYPpvCyqaLg+kofq81RRGl/Ql4Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@tiptap/core': ^2
+      '@tiptap/pm': ^2
+      solid-js: ^1.7
+    dependencies:
+      '@tiptap/core': 2.0.3(@tiptap/pm@2.0.3)
+      '@tiptap/pm': 2.0.3(@tiptap/core@2.0.3)
+      solid-js: 1.8.16
     dev: false
 
   /solid-use@0.8.0(solid-js@1.8.15):
@@ -26255,7 +26352,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-solid@2.7.0(solid-js@1.8.15)(vite@4.5.2):
+  /vite-plugin-solid@2.7.0(solid-js@1.8.16)(vite@4.5.2):
     resolution: {integrity: sha512-avp/Jl5zOp/Itfo67xtDB2O61U7idviaIp4mLsjhCa13PjKNasz+IID0jYTyqUp9SFx6/PmBr6v4KgDppqompg==}
     peerDependencies:
       solid-js: ^1.7.2
@@ -26266,13 +26363,12 @@ packages:
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.7.7(@babel/core@7.24.1)
       merge-anything: 5.1.7
-      solid-js: 1.8.15
-      solid-refresh: 0.5.3(solid-js@1.8.15)
-      vite: 4.5.2(@types/node@20.11.30)
+      solid-js: 1.8.16
+      solid-refresh: 0.5.3(solid-js@1.8.16)
+      vite: 4.5.2(@types/node@20.5.9)
       vitefu: 0.2.5(vite@4.5.2)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /vite-plugin-watch@0.2.0:
     resolution: {integrity: sha512-MBlqIuL8OW6YBgsDuIq39/2HPOjz9E1na595k3EoFQVFJiL3IfnKGKrqNe6OYj+LIA67opun13YvgterMWSqgA==}


### PR DESCRIPTION
For some reason we cant have any SolidStart projects in the monorepo unless fink uses solid-js 1.8 or higher. Don't ask my why. 

I found this by randomly removing stuff from the repo until I found what was breaking the solid-start projects. 

Build & dev seem to both work perfectly fine, so no code-changes seem to be necessary