### PR TITLE
Defensively code in paraglide unplugin plugin

### DIFF
--- a/.changeset/small-shoes-hear.md
+++ b/.changeset/small-shoes-hear.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-unplugin": patch
+---
+
+fix edge-case with hashing function

--- a/inlang/source-code/paraglide/paraglide-js-adapter-unplugin/src/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-unplugin/src/index.ts
@@ -30,7 +30,7 @@ export const paraglide = createUnplugin((config: UserConfig) => {
 	let previousMessagesHash: string | undefined = undefined
 
 	async function triggerCompile(messages: readonly Message[], settings: ProjectSettings) {
-		const currentMessagesHash = hashMessages(messages, settings)
+		const currentMessagesHash = hashMessages(messages ?? [], settings)
 		if (currentMessagesHash === previousMessagesHash) return
 
 		if (messages.length === 0) {
@@ -109,7 +109,7 @@ export const paraglide = createUnplugin((config: UserConfig) => {
 
 function hashMessages(messages: readonly Message[], settings: ProjectSettings): string {
 	const hash = crypto.createHash("sha256")
-	hash.update(JSON.stringify(messages))
-	hash.update(JSON.stringify(settings))
+	hash.update(JSON.stringify(messages) || "")
+	hash.update(JSON.stringify(settings) || "")
 	return hash.digest("hex")
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-unplugin/src/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-unplugin/src/index.ts
@@ -108,8 +108,12 @@ export const paraglide = createUnplugin((config: UserConfig) => {
 })
 
 function hashMessages(messages: readonly Message[], settings: ProjectSettings): string {
-	const hash = crypto.createHash("sha256")
-	hash.update(JSON.stringify(messages) || "")
-	hash.update(JSON.stringify(settings) || "")
-	return hash.digest("hex")
+	try {
+		const hash = crypto.createHash("sha256")
+		hash.update(JSON.stringify(messages) || "")
+		hash.update(JSON.stringify(settings) || "")
+		return hash.digest("hex")
+	} catch (e) {
+		return crypto.randomUUID()
+	}
 }


### PR DESCRIPTION
Sometimes the @opral/inlang-sdk returns `undefined` instead of a message array from `project.query.messages.getAll()`, which isn't reflected in the types. If this happens the hash-function in the unplugin plugin would crash. 

This PR fixes the symptom by defending against this case in the unplugin plugin. 

See opral/inlang-paraglide-js#54