### PR TITLE
PARJS-60 Run compiler after `init` command

### DIFF
--- a/.changeset/famous-tomatoes-cheat.md
+++ b/.changeset/famous-tomatoes-cheat.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Run compiler after `paraglide-js init` so that initial files are present


### PR DESCRIPTION
This PR updates the `paraglide-js init` command to run the compiler immediately after creating the project. This reduces the  setup friction since the compiled files are present without explicitly running the compiler