### PR TITLE
Protect against NBSP breaking Markdown headings

### DIFF
--- a/inlang/source-code/markdown/src/convert.ts
+++ b/inlang/source-code/markdown/src/convert.ts
@@ -11,6 +11,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings"
 import rehypeRewrite from "rehype-rewrite"
 import addClasses from "rehype-class-names"
 import { rehypeAccessibleEmojis } from "rehype-accessible-emojis"
+import { preprocess } from "./preprocess.js"
 
 /* Converts the markdown with remark and the html with rehype to be suitable for being rendered */
 export async function convert(markdown: string): Promise<string> {
@@ -44,7 +45,7 @@ export async function convert(markdown: string): Promise<string> {
 				"doc-pricing",
 				"doc-important",
 				"doc-video",
-				...defaultSchema.tagNames!,
+				...(defaultSchema.tagNames ?? []),
 			],
 			attributes: {
 				"doc-figure": ["src", "alt", "caption"],
@@ -184,14 +185,9 @@ export async function convert(markdown: string): Promise<string> {
 		.use(rehypeAccessibleEmojis)
 		/* @ts-ignore */
 		.use(rehypeStringify)
-		.process(preSanitize(markdown))
+		.process(preprocess(markdown))
 
 	return String(`<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark-dimmed.min.css">
 	${content}`)
 }
 
-/* Some emojis can't be rendered in the font the website provides, therefore presanitization is needed */
-function preSanitize(markdown: string): string {
-	markdown = markdown.replaceAll("1️⃣", "1").replaceAll("2️⃣", "2").replaceAll("3️⃣", "3")
-	return markdown
-}

--- a/inlang/source-code/markdown/src/preprocess.test.ts
+++ b/inlang/source-code/markdown/src/preprocess.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest"
+import { preprocess } from "./preprocess.js"
+
+describe("preprocess", () => {
+	it("removes nbsp if it's part of a heading", () => {
+		const markdown = `#\u{00a0}Hello\n##\u{00a0}World`
+		expect(preprocess(markdown)).toBe(`# Hello\n## World`)
+	})
+
+	it("replaces emojis that can't be rendered with text-equivalents", () => {
+		const markdown = `1️⃣ 2️⃣ 3️⃣`
+		expect(preprocess(markdown)).toBe(`1 2 3`)
+	})
+})

--- a/inlang/source-code/markdown/src/preprocess.ts
+++ b/inlang/source-code/markdown/src/preprocess.ts
@@ -1,0 +1,19 @@
+/**
+ * Does basic string-preprocessing of the markdown
+ */
+export function preprocess(markdown: string): string {
+	return (
+		markdown
+			// If a # is followed by a nbsp, replace it with a regular space
+			// It's inconsitent between renderers if nbsps are allowed there or not
+			// this causes inconsistencies on the website
+			.replaceAll("#\u{00a0}", "# ")
+
+			// Some emojis can't be rendered in the font the website provides, therefore presanitization is needed
+			.replaceAll("1️⃣", "1")
+			.replaceAll("2️⃣", "2")
+			.replaceAll("3️⃣", "3")
+			.replaceAll("4️⃣", "4")
+			.replaceAll("5️⃣", "5")
+	)
+}


### PR DESCRIPTION
Macs often insert NBSP instead of normal spaces when typing quickly. This is fine in many markdown implementations, including Vs Code's built in MD renderer, but not on the website. This has caused a lot of broken markdown being released. 

```
##&nbsp;My Heading
```

This PR updates `@inlang/markdown` to rewrite NBSPs to regular spaces if they are part of a heading. 