### PR TITLE
Handle failure to create new project id

### DIFF
--- a/.changeset/great-lobsters-brake.md
+++ b/.changeset/great-lobsters-brake.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": minor
+---
+
+Handle failure to create new project id

--- a/inlang/source-code/sdk/src/migrations/maybeCreateFirstProjectId.ts
+++ b/inlang/source-code/sdk/src/migrations/maybeCreateFirstProjectId.ts
@@ -41,7 +41,11 @@ export async function generateProjectId(args: { repo?: Repository; projectPath: 
 	const firstCommitHash = await args.repo.getFirstCommitHash()
 
 	if (firstCommitHash) {
-		return hash(`${firstCommitHash + args.projectPath}`)
+		try {
+			return await hash(`${firstCommitHash + args.projectPath}`)
+		} catch (error) {
+			console.error("Failed to generate project_id", error)
+		}
 	}
 	return undefined
 }


### PR DESCRIPTION
Fixes MESDK-37 (https://github.com/opral/inlang-message-sdk/issues/2)

Root cause of this bug was a missing await [here](https://github.com/opral/monorepo/blob/26a42043c3c67b393331d10833adcb152b7e9800/inlang/source-code/sdk/src/migrations/maybeCreateFirstProjectId.ts#L44) coupled with a failure to import crypto library ONLY IN non-debug vs-code extension host.

Filed separate issue for the latter.
https://linear.app/opral/issue/LIX-58/hash-throws-error-in-vs-code-extension-host-non-debug-only
(https://github.com/opral/lix-sdk/issues/17)