### PR TITLE
Use messages in NextJS App Example Metadata

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/src/app/about/page.tsx
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/src/app/about/page.tsx
@@ -1,5 +1,19 @@
 import { redirect } from "@/lib/i18n"
 import * as m from "@/paraglide/messages.js"
+import { languageTag } from "@/paraglide/runtime"
+import { Metadata } from "next"
+
+export function generateMetadata(): Metadata {
+	const locale = languageTag()
+	return {
+		title: m.paraglide_and_next_app_router(),
+		description: m.this_app_was_localised_with_paraglide(),
+		icons: "/favicon.png",
+		openGraph: {
+			locale,
+		},
+	}
+}
 
 export default function About() {
 	async function redirectHome() {

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/src/app/layout.tsx
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app/src/app/layout.tsx
@@ -2,16 +2,21 @@ import "@/lib/ui/styles.css"
 import { LanguageProvider } from "@inlang/paraglide-js-adapter-next"
 import { AvailableLanguageTag, languageTag } from "@/paraglide/runtime"
 import { Header } from "@/lib/ui/Header"
+import * as m from "@/paraglide/messages.js"
 import type { Metadata } from "next"
 
 export function generateMetadata(): Metadata {
+	const locale = languageTag()
 	return {
-		title: "Paraglide App Router Example",
-		description:
-			"This is a NextJS App using the App router. It was localised using Paraglide and the ParaglideJS Adapter for NextJS.",
+		title: m.paraglide_and_next_app_router(),
+		description: m.this_app_was_localised_with_paraglide(),
 		icons: "/favicon.png",
+		openGraph: {
+			locale,
+		},
 	}
 }
+
 
 const direction: Record<AvailableLanguageTag, "ltr" | "rtl"> = {
 	en: "ltr",


### PR DESCRIPTION
This PR updates the Nextjs App router example to use messages in the metadata.

Someone reported that this wasn't working properly, so I tested it, and it _does_ appear to work. However, to be safe & to be confident that it stays working let's add it into CI. 