### PR TITLE
PARJS-70 - Use `listProjects` to find existing projects

### DIFF
--- a/.changeset/short-crews-lie.md
+++ b/.changeset/short-crews-lie.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+`paraglide-js init` now finds more existing projects

--- a/inlang/source-code/end-to-end-tests/paraglide-js/package.json
+++ b/inlang/source-code/end-to-end-tests/paraglide-js/package.json
@@ -11,7 +11,8 @@
 		"clean": "rm -rf ./.tmp ./node_modules"
 	},
 	"dependencies": {
-		"@inlang/paraglide-js": "workspace:*"
+		"@inlang/paraglide-js": "workspace:*",
+		"@inlang/sdk": "workspace:*"
 	},
 	"devDependencies": {
 		"@gmrchk/cli-testing-library": "^0.1.2",

--- a/inlang/source-code/end-to-end-tests/paraglide-js/src/e2e.test.ts
+++ b/inlang/source-code/end-to-end-tests/paraglide-js/src/e2e.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import { prepareEnvironment } from "@gmrchk/cli-testing-library"
 import path from "node:path"
 import child_process from "node:child_process"
+import type { ProjectSettings } from "@inlang/sdk"
 
 const ParaglideLocation = child_process.execSync("which paraglide-js").toString().trim()
 
@@ -19,6 +20,80 @@ describe("paraglide-js", () => {
 				const { spawn, writeFile, readFile, cleanup, path: workingDir } = await prepareEnvironment()
 				await writeFile(path.resolve(workingDir, "package.json"), "{}")
 				process.env.TERM_PROGRAM = "not-vscode"
+				const { wait, waitForText, writeText, debug, pressKey } = await spawn(
+					ParaglideLocation,
+					"init"
+				)
+
+				debug()
+
+				await waitForText("Which languages do you want to support?")
+				await wait(200)
+				await writeText("en, de")
+				await wait(200)
+				await pressKey("enter")
+
+				await waitForText("Where should the compiled files be placed?")
+				await wait(200)
+				await pressKey("enter") // use default value of ./src/paraglide
+
+				await waitForText("Are you using Visual Studio Code?")
+				await wait(200)
+				await writeText("y")
+				await wait(200)
+				await pressKey("enter")
+
+				await waitForText("Which tech stack are you using?")
+				await wait(200)
+				await pressKey("enter")
+				await wait(1000)
+
+				//check that the settings.json file exists
+				const fileContent = await readFile(path.resolve(workingDir, "project.inlang/settings.json"))
+				const settings = JSON.parse(fileContent)
+				expect(settings.languageTags).toEqual(["en", "de"])
+				expect(settings.sourceLanguageTag).toEqual("en")
+
+				//Check that the messages/en.json and messages/de.json files exist
+				expect(await readFile(path.resolve(workingDir, "messages/en.json"))).toBeTruthy()
+				expect(await readFile(path.resolve(workingDir, "messages/de.json"))).toBeTruthy()
+
+				//Check that the compiler ran and generated the files
+				expect(await readFile(path.resolve(workingDir, "src/paraglide/runtime.js"))).toBeTruthy()
+				expect(await readFile(path.resolve(workingDir, "src/paraglide/messages.js"))).toBeTruthy()
+				expect(await readFile(path.resolve(workingDir, "src/paraglide/messages/en.js"))).includes(
+					"export {}"
+				)
+				expect(await readFile(path.resolve(workingDir, "src/paraglide/messages/de.js"))).includes(
+					"export {}"
+				)
+
+				const packageJson = JSON.parse(await readFile(path.resolve(workingDir, "package.json")))
+
+				const expectedVersion = child_process.execSync(ParaglideLocation + " --version").toString()
+				expect(packageJson.devDependencies["@inlang/paraglide-js"].trim()).toEqual(
+					expectedVersion.trim()
+				)
+				await cleanup()
+			},
+			{ timeout: 30_000 }
+		)
+
+		it(
+			"initializes paraglide if another project is present",
+			async () => {
+				const { spawn, writeFile, readFile, cleanup, path: workingDir } = await prepareEnvironment()
+				await writeFile(path.resolve(workingDir, "package.json"), "{}")
+				process.env.TERM_PROGRAM = "not-vscode"
+
+				const existingProject: ProjectSettings = {
+					modules: [],
+					sourceLanguageTag: "en",
+					languageTags: ["en"],
+				}
+
+				writeFile(path.resolve(workingDir, "project.inlang/settings.json"), "{}")
+
 				const { wait, waitForText, writeText, debug, pressKey } = await spawn(
 					ParaglideLocation,
 					"init"

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.test.ts
@@ -152,6 +152,7 @@ describe("addCompileStepToPackageJSON()", () => {
 	})
 
 	test("if an existing build step exists, it should be preceeded by the paraglide-js compile command", async () => {
+		process.cwd = () => "/"
 		const fs = mockFiles({
 			"/package.json": JSON.stringify({
 				scripts: {
@@ -229,6 +230,7 @@ describe("addCompileStepToPackageJSON()", () => {
 	})
 
 	test("if there is a postinstall script present, add the paraglide-js compile command to it", async () => {
+		process.cwd = () => "/"
 		const fs = mockFiles({
 			"/package.json": JSON.stringify({
 				scripts: {
@@ -286,6 +288,7 @@ describe("addCompileStepToPackageJSON()", () => {
 	})
 
 	test("if there is no postinstall script present add the paragldie compile command", async () => {
+		process.cwd = () => "/"
 		const fs = mockFiles({
 			"/package.json": JSON.stringify({}),
 		})

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.test.ts
@@ -681,7 +681,6 @@ describe("checkIfPackageJsonExists()", () => {
 	})
 })
 
-
 describe("maybeChangeTsConfigModuleResolution()", () => {
 	test("it should return if no tsconfig.json exists", async () => {
 		const fs = mockFiles({})

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.ts
@@ -13,7 +13,7 @@ import { Logger } from "~/services/logger/index.js"
 import { findRepoRoot, openRepository, type Repository } from "@lix-js/client"
 import { pathExists } from "~/services/file-handling/exists.js"
 import { findPackageJson } from "~/services/environment/package.js"
-import { execAsync } from "./utils.js"
+import { execAsync, getCommonPrefix } from "./utils.js"
 import { getNewProjectTemplate, DEFAULT_PROJECT_PATH, DEFAULT_OUTDIR } from "./defaults.js"
 import { compile } from "~/compiler/compile.js"
 import { writeOutput } from "~/services/file-handling/write-output.js"
@@ -257,6 +257,8 @@ export const existingProjectFlow = async (ctx: {
 }): Promise<{ project: InlangProject; projectPath: string }> => {
 	const NEW_PROJECT_VALUE = "newProject"
 
+	const commonPrefix = getCommonPrefix(ctx.existingProjectPaths)
+
 	const selection = (await prompt(
 		`Do you want to use an existing Inlang Project or create a new one?`,
 		{
@@ -265,7 +267,7 @@ export const existingProjectFlow = async (ctx: {
 				{ label: "Create a new project", value: NEW_PROJECT_VALUE },
 				...ctx.existingProjectPaths.map((path) => {
 					return {
-						label: "Use '" + path + "'",
+						label: "Use '" + path.replace(commonPrefix, "") + "'",
 						value: path,
 					}
 				}),
@@ -354,7 +356,11 @@ async function promptForLanguageTags(
 export const createNewProjectFlow = async (ctx: {
 	repo: Repository
 	logger: Logger
-}): Promise<{ project: InlangProject; projectPath: string }> => {
+}): Promise<{
+	project: InlangProject
+	/** An absolute path to the created project */
+	projectPath: string
+}> => {
 	const languageTags = await promptForLanguageTags()
 	const settings = getNewProjectTemplate()
 

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.ts
@@ -461,7 +461,6 @@ export const addCompileStepToPackageJSON: CliStep<
 	{ repo: Repository; logger: Logger; projectPath: string; outdir: string },
 	unknown
 > = async (ctx) => {
-
 	const relativePathToProject = nodePath.relative(process.cwd(), ctx.projectPath)
 	const projectPath = `./${relativePathToProject}`
 

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.ts
@@ -461,6 +461,10 @@ export const addCompileStepToPackageJSON: CliStep<
 	{ repo: Repository; logger: Logger; projectPath: string; outdir: string },
 	unknown
 > = async (ctx) => {
+
+	const relativePathToProject = nodePath.relative(process.cwd(), ctx.projectPath)
+	const projectPath = `./${relativePathToProject}`
+
 	const file = await ctx.repo.nodeishFs.readFile("./package.json", { encoding: "utf-8" })
 	const stringify = detectJsonFormatting(file)
 	const pkg = JSON.parse(file)
@@ -472,16 +476,16 @@ export const addCompileStepToPackageJSON: CliStep<
 	// add the compile command to the postinstall script
 	// this isn't super important, so we won't interrupt the user if it fails
 	if (!pkg.scripts.postinstall) {
-		pkg.scripts.postinstall = `paraglide-js compile --project ${ctx.projectPath} --outdir ${ctx.outdir}`
+		pkg.scripts.postinstall = `paraglide-js compile --project ${projectPath} --outdir ${ctx.outdir}`
 	} else if (pkg.scripts.postinstall.includes("paraglide-js compile") === false) {
-		pkg.scripts.postinstall = `paraglide-js compile --project ${ctx.projectPath} --outdir ${ctx.outdir} && ${pkg.scripts.postinstall}`
+		pkg.scripts.postinstall = `paraglide-js compile --project ${projectPath} --outdir ${ctx.outdir} && ${pkg.scripts.postinstall}`
 	}
 
 	//Add the compile command to the build script
 	if (pkg?.scripts?.build === undefined) {
-		pkg.scripts.build = `paraglide-js compile --project ${ctx.projectPath} --outdir ${ctx.outdir}`
+		pkg.scripts.build = `paraglide-js compile --project ${projectPath} --outdir ${ctx.outdir}`
 	} else if (pkg?.scripts?.build.includes("paraglide-js compile") === false) {
-		pkg.scripts.build = `paraglide-js compile --project ${ctx.projectPath} --outdir ${ctx.outdir} && ${pkg.scripts.build}`
+		pkg.scripts.build = `paraglide-js compile --project ${projectPath} --outdir ${ctx.outdir} && ${pkg.scripts.build}`
 	} else {
 		ctx.logger
 			.warn(`The "build" script in the \`package.json\` already contains a "paraglide-js compile" command.

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/utils.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/utils.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest"
+import { getCommonPrefix } from "./utils.js"
+
+describe("getCommonPrefix()", () => {
+	it("returns the common prefix of two strings", () => {
+		expect(getCommonPrefix(["foo", "foobar"])).toBe("foo")
+		expect(getCommonPrefix(["foobar", "foo"])).toBe("foo")
+	})
+})

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/utils.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/utils.ts
@@ -18,3 +18,25 @@ export function execAsync(command: string) {
 		})
 	})
 }
+
+export function longestCommonPrefix(strA: string, strB: string): string {
+	let commonPrefix = ""
+	for (let i = 0; i < Math.min(strA.length, strB.length); i++) {
+		if (strA[i] === strB[i]) {
+			commonPrefix += strA[i]
+		} else {
+			break
+		}
+	}
+	return commonPrefix
+}
+
+export function getCommonPrefix(strings: string[]): string {
+	const strs = strings.filter(Boolean)
+	const firstString = strs[0]
+	if (firstString === undefined) {
+		return ""
+	}
+
+	return strs.reduce((commonPrefix, str) => longestCommonPrefix(commonPrefix, str), firstString)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,9 @@ importers:
       '@inlang/paraglide-js':
         specifier: workspace:*
         version: link:../../paraglide/paraglide-js
+      '@inlang/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
     devDependencies:
       '@gmrchk/cli-testing-library':
         specifier: ^0.1.2
@@ -28613,7 +28616,7 @@ packages:
 
   file:..:
     resolution: {directory: .., type: directory}
-    name: monorepo
+    name: dev
     dev: true
 
   file:inlang/source-code/cli:


### PR DESCRIPTION
This PR updates the `paraglide-js init` command to use `listProjects` internally to find projects.

This also required updating the prompt as it was previously only possible to find a single existing project, while now there may be many. 
If there are many existing projects the prompt may get overwhelming, so we strip the common prefix of all existing-project-paths so as little text as possible is displayed.