### PR TITLE
PARJS-68 SvelteKit Trailing Slash Behavior

### DIFF
--- a/.changeset/shaggy-zebras-kiss.md
+++ b/.changeset/shaggy-zebras-kiss.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-sveltekit": patch
+---
+
+Trailing Slashes are now preserverd more reliably if present

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/routes/+layout.server.js
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/routes/+layout.server.js
@@ -1,7 +1,6 @@
 export const prerender = true
 export const trailingSlash = "always"
 
-
 /**
  * @type { import("./$types").LayoutServerLoad}
  */

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/routes/users/[id]/+page.svelte
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/routes/users/[id]/+page.svelte
@@ -17,5 +17,7 @@
 <br />
 <a data-sveltekit-keepfocus href="{base}/users/{next}">{m.next_user()}</a>
 
+<br />
+<br />
 
-<a href={resolveRoute("/users/[id]/edit", { id: num_users.toString() })}>{m.edit_user({ userId: num_users })}</a>
+<a href={resolveRoute("/users/[id]/edit/", { id: num_users.toString() })}>{m.edit_user({ userId: num_users })}</a>

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/routes/users/[id]/edit/+page.svelte
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/routes/users/[id]/edit/+page.svelte
@@ -1,7 +1,9 @@
 <script>
 	import { page } from "$app/stores"
+    import * as m from "$paraglide/messages.js"
 
-    $: User = Number.parseFloat($page.params.id);
+    $: userId = Number.parseFloat($page.params.id);
 </script>
 
-<h1>Edit User {User}</h1>
+<h1>{m.edit_user({ userId })}</h1>
+<a href="/users/{userId}">{m.users()}</a>

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.test.ts
@@ -43,6 +43,15 @@ describe("createI18n", () => {
 			expect(i18n.resolveRoute(base + "/about", "en")).toBe(base + "/about")
 			expect(i18n.resolveRoute(base + "/about", "de")).toBe(base + "/about")
 		})
+
+		it("keeps the trailing slash if present", () => {
+			const i18n = createI18n(runtime)
+
+			//don't prefix the default language
+			expect(i18n.resolveRoute(base + "/about/", "en")).toBe(base + "/about/")
+			expect(i18n.resolveRoute(base + "/about/", "de")).toBe(base + "/de/about/")
+		})
+
 	})
 
 	describe("route", () => {

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.test.ts
@@ -47,11 +47,16 @@ describe("createI18n", () => {
 		it("keeps the trailing slash if present", () => {
 			const i18n = createI18n(runtime)
 
-			//don't prefix the default language
 			expect(i18n.resolveRoute(base + "/about/", "en")).toBe(base + "/about/")
 			expect(i18n.resolveRoute(base + "/about/", "de")).toBe(base + "/de/about/")
 		})
 
+		it("doesn't add the trailing slash if not present", () => {
+			const i18n = createI18n(runtime)
+
+			expect(i18n.resolveRoute(base + "/about", "en")).toBe(base + "/about")
+			expect(i18n.resolveRoute(base + "/about", "de")).toBe(base + "/de/about")
+		})
 	})
 
 	describe("route", () => {
@@ -76,11 +81,18 @@ describe("createI18n", () => {
 			expect(i18n.route(base + "/de/ueber-uns")).toBe(base + "/about")
 		})
 
-		it("handles trailing slashes", () => {
+		it("keeps the trailing slash if present", () => {
 			const i18n = createI18n(runtime)
 
-			expect(i18n.route(base + "/about/")).toBe(base + "/about")
-			expect(i18n.route(base + "/de/about/")).toBe(base + "/about")
+			expect(i18n.route(base + "/about/")).toBe(base + "/about/")
+			expect(i18n.route(base + "/de/about/")).toBe(base + "/about/")
+		})
+
+		it("doesn't add the trailing shalsh if not present", () => {
+			const i18n = createI18n(runtime)
+
+			expect(i18n.route(base + "/about")).toBe(base + "/about")
+			expect(i18n.route(base + "/de/about")).toBe(base + "/about")
 		})
 	})
 })

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
@@ -9,7 +9,6 @@ import { serializeRoute } from "./utils/serialize-path.js"
 import { getCanonicalPath } from "./path-translations/getCanonicalPath.js"
 import { getPathInfo } from "./utils/get-path-info.js"
 import { normaliseBase as canonicalNormaliseBase } from "./utils/normaliseBase.js"
-import { resolve } from "./utils/path.js"
 import { createExclude, type ExcludeConfig } from "./exclude.js"
 import { guessTextDirMap } from "./utils/text-dir.js"
 import { resolvePathTranslations } from "./config/resolvePathTranslations.js"
@@ -305,14 +304,24 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 		 * ```
 		 */
 		route(translatedPath: string) {
-			const { path, lang, trailingSlash } = getPathInfo(translatedPath, {
-				base: normaliseBase(base),
+
+			const normalizedBase = normaliseBase(base)
+
+			const { path, lang, trailingSlash, dataSuffix } = getPathInfo(translatedPath, {
+				base: normalizedBase,
 				availableLanguageTags: config.runtime.availableLanguageTags,
 				defaultLanguageTag: config.defaultLanguageTag,
 			})
 
 			const canonicalPath = getCanonicalPath(path, lang, config.translations, config.matchers)
-			return resolve(normaliseBase(base), canonicalPath) + (trailingSlash ? "/" : "")
+
+			return serializeRoute({
+				path: canonicalPath,
+				base: normalizedBase,
+				trailingSlash,
+				dataSuffix,
+				includeLanguage: false,
+			})
 		},
 	}
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
@@ -305,14 +305,14 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 		 * ```
 		 */
 		route(translatedPath: string) {
-			const { path, lang } = getPathInfo(translatedPath, {
+			const { path, lang, trailingSlash } = getPathInfo(translatedPath, {
 				base: normaliseBase(base),
 				availableLanguageTags: config.runtime.availableLanguageTags,
 				defaultLanguageTag: config.defaultLanguageTag,
 			})
 
 			const canonicalPath = getCanonicalPath(path, lang, config.translations, config.matchers)
-			return resolve(normaliseBase(base), canonicalPath)
+			return resolve(normaliseBase(base), canonicalPath) + (trailingSlash ? "/" : "")
 		},
 	}
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
@@ -256,6 +256,12 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 
 			const normalisedBase = normaliseBase(base)
 
+			const { trailingSlash, dataSuffix } = getPathInfo(path, {
+				base: normalisedBase,
+				availableLanguageTags: runtime.availableLanguageTags,
+				defaultLanguageTag: runtime.sourceLanguageTag,
+			})
+
 			lang = lang ?? runtime.languageTag()
 
 			if (!path.startsWith(normalisedBase)) return path
@@ -272,11 +278,11 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 				path: translatedPath,
 				lang,
 				base: normalisedBase,
-				dataSuffix: undefined,
+				dataSuffix,
 				includeLanguage: true,
 				defaultLanguageTag,
 				prefixDefaultLanguage: config.prefixDefaultLanguage,
-				trailingSlash: false,
+				trailingSlash,
 			})
 		},
 

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/reroute.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/reroute.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest"
+import { createReroute } from "./reroute"
+
+//@ts-ignore
+import * as runtime from "$paraglide/runtime.js"
+
+const reroute = createReroute<"en" | "de">({
+	defaultLanguageTag: "en",
+	prefixDefaultLanguage: "never",
+	exclude: () => false,
+	seo: {
+		noAlternateLinks: false,
+	},
+	translations: {},
+	matchers: {},
+	runtime,
+	textDirection: {
+		de: "ltr",
+		en: "ltr",
+	},
+})
+
+describe("createReroute", () => {
+	it("keeps the trailing slash if present", () => {
+		const url = new URL("https://example.com/base/some-page/")
+		const pathname = reroute({ url })
+		expect(pathname).toBe("/base/some-page/")
+	})
+
+	it("doesn't add a trailing slash", () => {
+		const url = new URL("https://example.com/base/some-page")
+		const pathname = reroute({ url })
+		expect(pathname).toBe("/base/some-page")
+	})
+
+	it("keeps the trailing slash on the language", () => {
+		const url = new URL("https://example.com/base/de/")
+		const pathname = reroute({ url })
+		expect(pathname).toBe("/base/")
+	})
+
+	it("doesn't add a trailing slash to the language", () => {
+		const url = new URL("https://example.com/base/de")
+		const pathname = reroute({ url })
+		expect(pathname).toBe("/base")
+	})
+})

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/path-translations/translatePath.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/path-translations/translatePath.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest"
+import { translatePath } from "./translatePath"
+
+describe("translatePath", () => {
+	it("translates from the default language (no base path)", () => {
+		const translatedPath = translatePath(
+			"/foo/bar",
+			"de",
+			{},
+			{},
+			{
+				base: "/",
+				availableLanguageTags: ["de", "en"],
+				defaultLanguageTag: "en",
+				prefixDefaultLanguage: "never",
+			}
+		)
+
+		expect(translatedPath).toBe("/de/foo/bar")
+	})
+
+	it("translates a path from the default language (with base)", () => {
+		const translatedPath = translatePath(
+			"/base/foo/bar",
+			"de",
+			{},
+			{},
+			{
+				base: "/base",
+				availableLanguageTags: ["de", "en"],
+				defaultLanguageTag: "en",
+				prefixDefaultLanguage: "never",
+			}
+		)
+
+		expect(translatedPath).toBe("/base/de/foo/bar")
+	})
+
+	it("keeps the trailing slash if present (with base)", () => {
+		const translatedPath = translatePath(
+			"/base/foo/bar/",
+			"de",
+			{},
+			{},
+			{
+				base: "/base",
+				availableLanguageTags: ["de", "en"],
+				defaultLanguageTag: "en",
+				prefixDefaultLanguage: "never",
+			}
+		)
+
+		expect(translatedPath).toBe("/base/de/foo/bar/")
+	})
+
+	it("doesn't add a trailing slash if not present (with base)", () => {
+		const translatedPath = translatePath(
+			"/base/foo/bar",
+			"de",
+			{},
+			{},
+			{
+				base: "/base",
+				availableLanguageTags: ["de", "en"],
+				defaultLanguageTag: "en",
+				prefixDefaultLanguage: "never",
+			}
+		)
+
+		expect(translatedPath).toBe("/base/de/foo/bar")
+	})
+})

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/path-translations/translatePath.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/path-translations/translatePath.ts
@@ -24,6 +24,7 @@ export function translatePath(
 		path: targetedPathSource,
 		lang,
 		dataSuffix,
+		trailingSlash,
 	} = getPathInfo(path, {
 		base: opts.base,
 		availableLanguageTags: opts.availableLanguageTags,
@@ -46,6 +47,6 @@ export function translatePath(
 		lang: targetLanguage,
 		defaultLanguageTag: opts.defaultLanguageTag,
 		prefixDefaultLanguage: opts.prefixDefaultLanguage,
-		trailingSlash: false,
+		trailingSlash,
 	})
 }


### PR DESCRIPTION
This PR updates the SvelteKit link-rewrites to always keep the trailing slash if it's present. 