### PR TITLE
Trailing slash hotfix

### DIFF
--- a/.changeset/tall-bears-change.md
+++ b/.changeset/tall-bears-change.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-sveltekit": patch
+---
+
+Fix crashe when navigating to `/{lang}/` with `trailingSlash="always"`

--- a/inlang/source-code/markdown/src/convert.ts
+++ b/inlang/source-code/markdown/src/convert.ts
@@ -190,4 +190,3 @@ export async function convert(markdown: string): Promise<string> {
 	return String(`<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark-dimmed.min.css">
 	${content}`)
 }
-

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/lib/i18n.js
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/example/src/lib/i18n.js
@@ -1,7 +1,7 @@
 import { createI18n } from "@inlang/paraglide-js-adapter-sveltekit"
+import { match as int } from "../params/int"
 import * as runtime from "$paraglide/runtime.js"
 import * as m from "$paraglide/messages.js"
-import { match as int } from "../params/int"
 
 export const i18n = createI18n(runtime, {
 	pathnames: {
@@ -13,14 +13,6 @@ export const i18n = createI18n(runtime, {
 		"/users/[id=int]/[...rest]": {
 			en: "/users/[id=int]/[...rest]",
 			de: "/benutzer/[id=int]/[...rest]",
-		},
-		"/some-subpage": {
-			en: "/some-subpage",
-			de: "/irgendeine-unterseite",
-		},
-		"/matchall/[...rest]": {
-			en: "/matchall/[...rest]",
-			de: "/joker/[...rest]",
 		},
 	},
 	matchers: { int },

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/package.json
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/package.json
@@ -12,7 +12,9 @@
 		"url": "https://github.com/opral/inlang-paraglide-js"
 	},
 	"scripts": {
-		"test": "vitest run --passWithNoTests --test-timeout 30000 --dir src",
+		"test:with-base": "BASE_PATH=/base vitest run --test-timeout 30000 --dir src",
+		"test:without-base": "BASE_PATH=\"\" vitest run --test-timeout 30000 --dir src",
+		"test": "npm run test:with-base && npm run test:without-base",
 		"build": "svelte-package -i src -o dist",
 		"dev": "svelte-package -w -i src -o dist",
 		"lint": "eslint ./src --fix",
@@ -39,7 +41,7 @@
 		"rollup-plugin-svelte": "^7.1.6",
 		"typescript": "^5.3.2",
 		"vite": "^5.0.4",
-		"vitest": "^0.34.6"
+		"vitest": "^1.0.0"
 	},
 	"files": [
 		"dist"

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/reroute.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/hooks/reroute.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest"
+import { base } from "$app/paths"
 import { createReroute } from "./reroute"
 
 //@ts-ignore
@@ -20,28 +21,34 @@ const reroute = createReroute<"en" | "de">({
 	},
 })
 
-describe("createReroute", () => {
+describe("reroute", () => {
 	it("keeps the trailing slash if present", () => {
-		const url = new URL("https://example.com/base/some-page/")
+		const url = new URL("https://example.com" + base + "/some-page/")
 		const pathname = reroute({ url })
-		expect(pathname).toBe("/base/some-page/")
+		expect(pathname).toBe(base + "/some-page/")
 	})
 
 	it("doesn't add a trailing slash", () => {
-		const url = new URL("https://example.com/base/some-page")
+		const url = new URL("https://example.com" + base + "/some-page")
 		const pathname = reroute({ url })
-		expect(pathname).toBe("/base/some-page")
+		expect(pathname).toBe(base + "/some-page")
 	})
 
 	it("keeps the trailing slash on the language", () => {
-		const url = new URL("https://example.com/base/de/")
+		const url = new URL("https://example.com" + base + "/de/")
 		const pathname = reroute({ url })
-		expect(pathname).toBe("/base/")
+		expect(pathname).toBe(base ? base + "/" : "/")
 	})
 
 	it("doesn't add a trailing slash to the language", () => {
-		const url = new URL("https://example.com/base/de")
+		const url = new URL("https://example.com" + base + "/de")
 		const pathname = reroute({ url })
-		expect(pathname).toBe("/base")
+		expect(pathname).toBe(base ? base : "/")
+	})
+
+	it("removes the languagePrefix", () => {
+		const url = new URL("https://example.com" + base + "/de")
+		const pathname = reroute({ url })
+		expect(pathname).toBe(base ? base : "/")
 	})
 })

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/path-translations/translatePath.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/path-translations/translatePath.test.ts
@@ -1,72 +1,73 @@
 import { describe, it, expect } from "vitest"
 import { translatePath } from "./translatePath"
+import { base } from "$app/paths"
 
 describe("translatePath", () => {
-	it("translates from the default language (no base path)", () => {
+	it("translates from the default language", () => {
 		const translatedPath = translatePath(
-			"/foo/bar",
+			base + "/foo/bar",
 			"de",
 			{},
 			{},
 			{
-				base: "/",
+				base,
 				availableLanguageTags: ["de", "en"],
 				defaultLanguageTag: "en",
 				prefixDefaultLanguage: "never",
 			}
 		)
 
-		expect(translatedPath).toBe("/de/foo/bar")
+		expect(translatedPath).toBe(base + "/de/foo/bar")
 	})
 
-	it("translates a path from the default language (with base)", () => {
+	it("keeps the trailing slash if present", () => {
 		const translatedPath = translatePath(
-			"/base/foo/bar",
+			base + "/foo/bar/",
 			"de",
 			{},
 			{},
 			{
-				base: "/base",
+				base,
 				availableLanguageTags: ["de", "en"],
 				defaultLanguageTag: "en",
 				prefixDefaultLanguage: "never",
 			}
 		)
 
-		expect(translatedPath).toBe("/base/de/foo/bar")
+		expect(translatedPath).toBe(base + "/de/foo/bar/")
 	})
 
-	it("keeps the trailing slash if present (with base)", () => {
+	it("doesn't add a trailing slash if not present", () => {
 		const translatedPath = translatePath(
-			"/base/foo/bar/",
+			base + "/foo/bar",
 			"de",
 			{},
 			{},
 			{
-				base: "/base",
+				base,
 				availableLanguageTags: ["de", "en"],
 				defaultLanguageTag: "en",
 				prefixDefaultLanguage: "never",
 			}
 		)
 
-		expect(translatedPath).toBe("/base/de/foo/bar/")
+		expect(translatedPath).toBe(base + "/de/foo/bar")
 	})
 
-	it("doesn't add a trailing slash if not present (with base)", () => {
+	it("removes the language prefix with trailing slash", () => {
 		const translatedPath = translatePath(
-			"/base/foo/bar",
-			"de",
+			"/de/",
+			"en",
 			{},
 			{},
 			{
-				base: "/base",
+				base,
 				availableLanguageTags: ["de", "en"],
 				defaultLanguageTag: "en",
 				prefixDefaultLanguage: "never",
 			}
 		)
 
-		expect(translatedPath).toBe("/base/de/foo/bar")
+		expect(translatedPath).toBe(base ? base + "/" : "/")
 	})
 })

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/external.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/external.test.ts
@@ -5,7 +5,7 @@ describe("isExternal", () => {
 	it("returns true if the origin is different", () => {
 		const url = new URL("https://example.com")
 		const currentUrl = new URL("https://example.org")
-		const base = "/"
+		const base = ""
 
 		expect(isExternal(url, currentUrl, base)).toBe(true)
 	})

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/external.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/external.ts
@@ -1,5 +1,5 @@
 export function isExternal(url: URL, currentUrl: URL, base: string) {
-	const absoluteBase = new URL(base, currentUrl).pathname
+	const absoluteBase = new URL(base ?? "/", currentUrl).pathname
 
 	if (url.origin !== currentUrl.origin) {
 		return true

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/get-path-info.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/get-path-info.test.ts
@@ -27,7 +27,7 @@ describe("parsePath", () => {
 			path: canonicalPath,
 			trailingSlash,
 		} = getPathInfo("/de/foo/bar", {
-			base: "/",
+			base: "",
 			availableLanguageTags: ["en", "de"],
 			defaultLanguageTag: "en",
 		})

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/serialize-path.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/serialize-path.test.ts
@@ -106,4 +106,16 @@ describe("serializePath", () => {
 
 		expect(path).toBe("/base/foo/bar/")
 	})
+
+	it("correctly serializes / with a trailing slash", () => {
+		const path = serializeRoute({
+			path: "/",
+			base: "",
+			dataSuffix: undefined,
+			includeLanguage: false,
+			trailingSlash: true,
+		})
+
+		expect(path).toBe("/")
+	})
 })

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/serialize-path.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/utils/serialize-path.ts
@@ -19,7 +19,14 @@ export function serializeRoute(opts: SerializePathOptions): string {
 	parts.push(opts.path)
 
 	if (opts.dataSuffix) parts.push(DATA_SUFFIX)
-	return Path.resolve(...parts) + (opts.trailingSlash && !opts.dataSuffix ? "/" : "")
+
+	const resolvedPath = Path.resolve(...parts)
+	if (opts.trailingSlash && !opts.dataSuffix && resolvedPath !== "/") {
+		return resolvedPath + "/"
+	} else {
+		return resolvedPath
+	}
+
 }
 
 type SerializePathOptions = {

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/vitest.config.js
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/vitest.config.js
@@ -1,23 +1,28 @@
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
 
 const __filename = resolve(fileURLToPath(import.meta.url))
 const __dirname = dirname(__filename)
 
-export default {
-	plugins: [
-		virtualModules({
-			"$app/paths": getPathsModule({ base: "/base" }),
-			"$app/environment": getEnvironmentModule({ dev: false, browser: false }),
-			"$app/stores": getStoresModule({}),
-		}),
-	],
-	test: {
-		alias: {
-			"$paraglide/runtime.js": resolve(__dirname, "./mocks/runtime.js"),
+const BASE_PATH = process.env.BASE_PATH ?? ""
+
+export default defineConfig((env) => {
+	return {
+		plugins: [
+			virtualModules({
+				"$app/paths": getPathsModule({ base: BASE_PATH }),
+				"$app/environment": getEnvironmentModule({ dev: false, browser: false }),
+				"$app/stores": getStoresModule({}),
+			}),
+		],
+		test: {
+			alias: {
+				"$paraglide/runtime.js": resolve(__dirname, "./mocks/runtime.js"),
+			},
 		},
-	},
-}
+	}
+})
 
 /**
  * @param {Record<string, string>} map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28681,7 +28681,7 @@ packages:
 
   file:..:
     resolution: {directory: .., type: directory}
-    name: monorepo
+    name: dev
     dev: true
 
   file:inlang/source-code/cli:


### PR DESCRIPTION
This PR fixes the trailing slash behavior when navigating to `/{lang}/`

Previously it would try to rewrite to the path `//` which would crash. This happened because it rewrote the `/{lang}` part to `/` and then tried to preserve the trailing slash. There now is special-case handling for this.