### PR TITLE
No longer run `CI` on macos

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         version: [18]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This PR changes the `CI` workflow to no longer run on MacOS. 
MacOS actions are 5x slower & don't really provide much value to us, given how similar the environment is to linux. Most of the team develops on Macs & will catch any mac-issues during development. 