### PR TITLE
take 600 as a standard calculation anchor for primitive shades

### DIFF
--- a/inlang/source-code/settings-component/src/helper/overridePrimitiveColors.ts
+++ b/inlang/source-code/settings-component/src/helper/overridePrimitiveColors.ts
@@ -41,7 +41,7 @@ const getColor = (unformattedColor: string) => chroma(unformattedColor)
 
 const getPalette = (unformattedColor: string) => {
 	const color = getColor(unformattedColor)
-	const colors = chroma.scale(["white", color, "black"]).mode("lrgb")
+	const colors = chroma.scale(["white", color, "black"]).domain([0, 0.6, 1]).mode("lrgb")
 	const palette: Record<number, string> = {}
 
 	// Create 50


### PR DESCRIPTION
see: https://github.com/opral/inlang-message-ui-components/issues/21