### PR TITLE
PARJS-71 - Canonical message order

### DIFF
--- a/.changeset/wicked-doors-mix.md
+++ b/.changeset/wicked-doors-mix.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+In the `messages.js` file the languages are now prefixed with `_` so messages with the same name as a language won't cause a naming conflict

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -41,8 +41,8 @@ test("the files should include an eslint ignore comment", async () => {
 })
 
 test("imports in the messages.js index file should use underscores instead of hyphens to avoid invalid JS imports", async () => {
-	expect(output["messages.js"]).toContain("import * as en_US")
-	expect(output["messages.js"]).not.toContain("import * as en-US")
+	expect(output["messages.js"]).toContain("import * as _en_US")
+	expect(output["messages.js"]).not.toContain("import * as _en-US")
 })
 
 test("it should be possible to directly import a message function via a resource file", async () => {

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
@@ -90,7 +90,7 @@ export const compile = async (args: {
 /* eslint-disable */
 import { languageTag } from "./runtime.js"
 ${Object.keys(resources)
-	.map((languageTag) => `import * as ${i(languageTag)} from "./messages/${languageTag}.js"`)
+	.map((languageTag) => `import * as _${i(languageTag)} from "./messages/${languageTag}.js"`)
 	.join("\n")}
 
 ${compiledMessages.map((message) => message.index).join("\n\n")}
@@ -136,6 +136,13 @@ export const availableLanguageTags = /** @type {const} */ (${JSON.stringify(
  * @type {() => AvailableLanguageTag}
  */
 export let languageTag = () => sourceLanguageTag
+
+/**
+ * Get the index of the current language tag.
+ * @private
+ * @returns {number}
+ */
+export let _languageTagIdx = () => availableLanguageTags.indexOf(languageTag())
 
 /**
  * Set the language tag.

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
@@ -88,7 +88,7 @@ export const compile = async (args: {
 		// message index file
 		"messages.js": `
 /* eslint-disable */
-import { languageTag } from "./runtime.js"
+import * as _runtime from "./runtime.js"
 ${Object.keys(resources)
 	.map((languageTag) => `import * as _${i(languageTag)} from "./messages/${languageTag}.js"`)
 	.join("\n")}
@@ -139,10 +139,11 @@ export let languageTag = () => sourceLanguageTag
 
 /**
  * Get the index of the current language tag.
- * @private
+ * @param {AvailableLanguageTag} lang
  * @returns {number}
+ * @private Not for public use
  */
-export let _languageTagIdx = () => availableLanguageTags.indexOf(languageTag())
+export const _languageTagIdx = (lang) => availableLanguageTags.indexOf(lang)
 
 /**
  * Set the language tag.

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
@@ -1,7 +1,6 @@
 import { LanguageTag, type Message } from "@inlang/sdk"
 import { compilePattern } from "./compilePattern.js"
 import { paramsType, type Params } from "./paramsType.js"
-import { optionsType } from "./optionsType.js"
 import { isValidJSIdentifier } from "../services/valid-js-identifier/index.js"
 import { i } from "../services/codegen/identifier.js"
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js"
@@ -110,19 +109,15 @@ const messageIndexFunction = (args: {
  * - The params are NonNullable<unknown> because the inlang SDK does not provide information on the type of a param (yet).
  * 
  * ${paramsType(args.params, true)}
- * ${optionsType({ languageTags: args.availableLanguageTags })}
+ * @param {{ languageTag?: import("./runtime.js").AvailableLanguageTag }} options
  * @returns {string}
  */
 /* @__NO_SIDE_EFFECTS__ */
-export const ${args.message.id} = (params ${hasParams ? "" : "= {}"}, options = {}) => {
-	return {
-${args.availableLanguageTags
-	// sort language tags alphabetically to make the generated code more readable
-	.sort((a, b) => a.localeCompare(b))
-	.map((tag) => `\t\t${isValidJSIdentifier(tag) ? tag : `"${tag}"`}: _${i(tag)}.${args.message.id}`)
-	.join(",\n")}
-	}[options.languageTag ?? languageTag()](${hasParams ? "params" : ""})
-}
+export const ${args.message.id} = (params${hasParams ? "" : " = {}"}, options = {}) => [
+${args.availableLanguageTags.map((tag) => `\t\t_${i(tag)}.${args.message.id}`).join(",\n")}
+	][_runtime.availableLanguageTags.indexOf(options.languageTag ?? _runtime.languageTag())](${
+		hasParams ? "params" : ""
+	})
 ${reexportAliases(args.message)}
 `
 }

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compileMessage.ts
@@ -119,7 +119,7 @@ export const ${args.message.id} = (params ${hasParams ? "" : "= {}"}, options = 
 ${args.availableLanguageTags
 	// sort language tags alphabetically to make the generated code more readable
 	.sort((a, b) => a.localeCompare(b))
-	.map((tag) => `\t\t${isValidJSIdentifier(tag) ? tag : `"${tag}"`}: ${i(tag)}.${args.message.id}`)
+	.map((tag) => `\t\t${isValidJSIdentifier(tag) ? tag : `"${tag}"`}: _${i(tag)}.${args.message.id}`)
 	.join(",\n")}
 	}[options.languageTag ?? languageTag()](${hasParams ? "params" : ""})
 }

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/optionsType.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/optionsType.test.ts
@@ -1,9 +1,0 @@
-import { it, expect, describe } from "vitest"
-import { optionsType } from "./optionsType.js"
-
-describe("optionsType", () => {
-	it("should return valid jsdoc for options", () => {
-		const jsdoc = optionsType({ languageTags: ["en", "de"] })
-		expect(jsdoc).toBe('@param {{ languageTag?: "en" | "de" }} options')
-	})
-})

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/optionsType.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/optionsType.ts
@@ -1,5 +1,0 @@
-import { toStringUnion } from "../services/codegen/string-union.js"
-
-export const optionsType = (args: { languageTags: Iterable<string> }) => {
-	return `@param {{ languageTag?: ${toStringUnion(args.languageTags) ?? "undefined"} }} options`
-}


### PR DESCRIPTION
This PR updates the paraglide compiler to produce more minified output that's less likely to cause naming collisions. 