### PR TITLE
Update Inlang Message Format Documentation

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/README.md
+++ b/inlang/source-code/paraglide/paraglide-js/README.md
@@ -85,7 +85,31 @@ m.hello() // Hello world!
 m.loginHeader({ name: "Samuel" }) // Hello Samuel, please login to continue.
 ```
 
-To choose between messages at runtime create a map of messages and index into it.
+## Working with the Inlang Message Format
+
+Paraglide is part of the highly modular Inlang Ecosystem. This allows you to switch between different message formats as you see fit.
+
+By default, the [Inlang Message Format](https://inlang.com/m/reootnfj/plugin-inlang-messageFormat) is used. It expects messages to be in `messages/{lang}.json`.
+
+```json
+//messages/en.json
+{
+	//the $schema key is automatically ignored 
+	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"hello_world: "Hello World!",
+	"greeting": "Hello {name}!"
+}
+```
+
+The `messages/{lang}.json` file contains key-value pairs of message-IDs and their translations. You can use curly braces to insert `{parameters}`.
+
+The Message Format is still quite young and will become more powerful in the future. Features like plurals, param-formatting, and markup interpolation are currently not supported but are all on our roadmap.
+
+**Nesting purposely isn't supported and likely won't be**. Nested messages are way harder to interact with from complementary tools like the [Sherlock IDE Extension](https://inlang.com/m/r7kp499g/app-inlang-ideExtension), the [Parrot Figma Plugin](https://inlang.com/m/gkrpgoir/app-parrot-figmaPlugin), or the [Fink Localization editor](https://inlang.com/m/tdozzpar/app-inlang-finkLocalizationEditor). Intellisense also becomes less helpful since it only shows the messages at the current level. Additionally enforcing an organization-style side-steps organization discussions with other contributors. 
+
+If you need complex formatting like, plurals, dates, currency or markup interpolation you can achieve them like so:s
+
+For a message with multiple cases, aka a _select message_, you can define a message for each case & then use a Map in JS to index into it.
 
 ```ts
 import * as m from "./paraglide/messages.js"
@@ -99,6 +123,41 @@ const season = {
 
 const msg = season["spring"]() // Hello spring!
 ```
+
+For date & currency formatting use the `.toLocaleString` method on the `Date` or `Number`.
+
+```ts
+import * as m from "./paraglide/messages.js"
+import { languageTag } from "./paraglide/runtime.js"
+
+const todaysDate = new Date();
+m.today_is_the({ 
+	date: todaysDate.toLocaleString(languageTag()) 
+})
+
+const price = 100;
+m.the_price_is({
+	price: price.toLocaleString(languageTag(), {
+		style: "currency",
+		currency: "EUR",
+	})
+})
+```
+
+You can put HTML into the messages. This is useful for links and images. 
+```
+// messages/en.json
+{
+	"you_must_agree_to_the_tos": "You must agree to the <a href='/en/tos'>Terms of Service</a>."
+}
+
+// messages/de.json
+{
+	you_must_agree_to_the_tos": "Sie müssen den <a href='/de/agb'>Nutzungsbedingungen</a> zustimmen."
+}
+```
+
+There is currently no way to put full-blown components into the messages. If you require components mid-message you will need to create a one-off component that includes both the text and the components. We're working on this.
 
 ## Setting the language
 
@@ -338,6 +397,8 @@ Of course, we're not done yet! We plan on adding the following features to Parag
 - [ ] Pluralization ([Join the Discussion](https://github.com/opral/monorepo/discussions/2025))
 - [ ] Formatting of numbers and dates ([Join the Discussion](https://github.com/opral/monorepo/discussions/992))
 - [ ] Markup Placeholders ([Join the Discussion](https://github.com/opral/monorepo/discussions/913))
+- [ ] Component Interpolation
+- [ ] Per-Language Splitting without Lazy-Loading 
 - [ ] Even Smaller Output
 
 # Talks
@@ -347,7 +408,7 @@ Of course, we're not done yet! We plan on adding the following features to Parag
 - Web Zurich December 2023
 - [Svelte London January 2024](https://www.youtube.com/watch?v=eswNQiq4T2w&t=646s)
 
-# Tooling
+# Complementary Tooling
 
 Paraglide JS is part of the Inlang ecosystem and integrates nicely with all the other Inlang-compatible tools.
 

--- a/inlang/source-code/paraglide/paraglide-js/README.md
+++ b/inlang/source-code/paraglide/paraglide-js/README.md
@@ -87,9 +87,9 @@ m.loginHeader({ name: "Samuel" }) // Hello Samuel, please login to continue.
 
 ## Working with the Inlang Message Format
 
-Paraglide is part of the highly modular Inlang Ecosystem. This allows you to switch between different message formats as you see fit.
+Paraglide is part of the highly modular Inlang Ecosystem which supports many different Message Formats. By default, the [Inlang Message Format](https://inlang.com/m/reootnfj/plugin-inlang-messageFormat) is used. 
 
-By default, the [Inlang Message Format](https://inlang.com/m/reootnfj/plugin-inlang-messageFormat) is used. It expects messages to be in `messages/{lang}.json`.
+It expects messages to be in `messages/{lang}.json` relative to your repo root.
 
 ```json
 //messages/en.json
@@ -101,13 +101,15 @@ By default, the [Inlang Message Format](https://inlang.com/m/reootnfj/plugin-inl
 }
 ```
 
-The `messages/{lang}.json` file contains key-value pairs of message-IDs and their translations. You can use curly braces to insert `{parameters}`.
+The `messages/{lang}.json` file contains a flat map of message IDs and their translations. You can use curly braces to insert `{parameters}` into translations
 
-The Message Format is still quite young and will become more powerful in the future. Features like plurals, param-formatting, and markup interpolation are currently not supported but are all on our roadmap.
+**Nesting purposely isn't supported and likely won't be**. Nested messages are way harder to interact with from complementary tools like the [Sherlock IDE Extension](https://inlang.com/m/r7kp499g/app-inlang-ideExtension), the [Parrot Figma Plugin](https://inlang.com/m/gkrpgoir/app-parrot-figmaPlugin), or the [Fink Localization editor](https://inlang.com/m/tdozzpar/app-inlang-finkLocalizationEditor). Intellisense also becomes less helpful since it only shows the messages at the current level, not all messages. Additionally enforcing an organization-style side-steps organization discussions with other contributors. 
 
-**Nesting purposely isn't supported and likely won't be**. Nested messages are way harder to interact with from complementary tools like the [Sherlock IDE Extension](https://inlang.com/m/r7kp499g/app-inlang-ideExtension), the [Parrot Figma Plugin](https://inlang.com/m/gkrpgoir/app-parrot-figmaPlugin), or the [Fink Localization editor](https://inlang.com/m/tdozzpar/app-inlang-finkLocalizationEditor). Intellisense also becomes less helpful since it only shows the messages at the current level. Additionally enforcing an organization-style side-steps organization discussions with other contributors. 
+### Complex Formatting
 
-If you need complex formatting like, plurals, dates, currency or markup interpolation you can achieve them like so:s
+The Message Format is still quite young, so advanced formats like plurals, param-formatting, and markup interpolation are currently not supported but are all on our roadmap.
+
+If you need complex formatting, like plurals, dates, currency, or markup interpolation you can achieve them like so:
 
 For a message with multiple cases, aka a _select message_, you can define a message for each case & then use a Map in JS to index into it.
 
@@ -145,19 +147,21 @@ m.the_price_is({
 ```
 
 You can put HTML into the messages. This is useful for links and images. 
-```
+
+```json
 // messages/en.json
 {
 	"you_must_agree_to_the_tos": "You must agree to the <a href='/en/tos'>Terms of Service</a>."
 }
-
+```
+```json
 // messages/de.json
 {
 	you_must_agree_to_the_tos": "Sie müssen den <a href='/de/agb'>Nutzungsbedingungen</a> zustimmen."
 }
 ```
 
-There is currently no way to put full-blown components into the messages. If you require components mid-message you will need to create a one-off component that includes both the text and the components. We're working on this.
+There is currently no way to interpolate full-blown components into the messages. If you require components mid-message you will need to create a one-off component for that bit of text.
 
 ## Setting the language
 

--- a/inlang/source-code/plugins/inlang-message-format/README.md
+++ b/inlang/source-code/plugins/inlang-message-format/README.md
@@ -1,49 +1,67 @@
 # The easiest "storage" plugin for inlang
 
-- [x] official inlang message format
-- [x] simple to manually edit 
-- [x] typesafe via JSON schema
+The Inlang Message Format is a simple storage plugin for the Inlang ecosystem. It allows you to store simple
+messages in a JSON file per language.
 
-`messages/en.json`
+You will have a JSON file for each of your languages. By default, they are in `./messages/{languageTag}.json`, although this can be moved (read [Configuration](#configuration)).
+
+The message files contain key-value pairs of the message ID and the translation. You can add variables in your message by using curly braces.
 
 ```json
+//messages/en.json
 {
-  "hello": "Hello {name}!"
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "hello_world": "Hello World!",
+  "greeting": "Good morning {name}!"
+}
+
+//messages/de.json
+{	
+  //the $schema key is automatically ignored
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "hello_world": "Hallo Welt!",
+  "greeting": "Guten Tag {name}!"
 }
 ```
 
-`messages/de.json`
+Advanced formatting such as Plurals, Formatting functions, and Markup Interpolation are currently not supported, but they are planned.
 
-```json
+Nesting is not supported and likely won't be.
+
+## Installation
+
+If you used an init CLI to create your Inlang project, most likely, this plugin is already installed.
+
+Otherwise, you can install it in your Inlang Project by adding it to your `"modules"` in `project.inlang/settings.json`. You will also need to provide a `pathPattern` for the plugin.
+
+```diff
+// project.inlang/settings.json
 {
-  "hello": "Guten Tag {name}!"
+  "modules" : [
++    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"
+  ],
++ "plugin.inlang.messageFormat": {
++   "pathPattern": "./messages/{languageTag}.json" 
++ }
 }
 ```
 
-## Settings
+## Configuration
 
-### `pathPattern`
+Configuration happens in `project.inlang/settings.json` under the `"plugin.inlang.messageFormat"` key.
 
-The path pattern is used to find the files that contain the messages. 
+### Moving the Message Files using `pathPattern`
 
+The path pattern defines _where_ the plugin will be looking for your message files. The default is `./messages/{languageTag}.json`. It's a relative path that's resolved from your package root.
 
-```json
-{
-  "pathPattern": "./messages/{languageTag}.json"
-}
-```
-
-
-## Syntax
-
-### Variable References
+The `{languageTag}` placeholder will be replaced with the language tag for each of your languages. 
 
 ```json
+// project.inlang/settings.json
 {
-  "hello": "Hello {name}!"
+  "modules": [ ... ],
+  "plugin.inlang.messageFormat": {
+		"pathPattern": "./messages/{languageTag}.json"
+	}
 }
 ```
-
-## Pricing 
-
-<doc-pricing></doc-pricing>


### PR DESCRIPTION
We got some [Feedback](https://discord.com/channels/897438559458430986/1070750156644962434/1227951584516902922) that the Documentation for the Inlang Message Format was insufficient. This PR updates the docs on Paraglide _and_ the Inlang-Message-Format-Plugin page. 

One factor that likely played into this confusion is how limited the format is. People assume that the docs are incomplete. 