### PR TITLE
PARJS-81 Use index accesses instead of `.at` function to better support legacy browsers

### DIFF
--- a/.changeset/early-rice-change.md
+++ b/.changeset/early-rice-change.md
@@ -1,0 +1,7 @@
+---
+"@inlang/paraglide-js-adapter-sveltekit": patch
+"@inlang/paraglide-js-adapter-next": patch
+"@inlang/paraglide-js": patch
+---
+
+Use index accesses instead of `.at` function for better compatability with legacy browsers

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/middleware/resolveLanguage.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/app/middleware/resolveLanguage.ts
@@ -28,5 +28,5 @@ export function resolveLanguage<T extends string>(
 
 	const acceptLanguage = request.headers.get(ACCEPT_LANGUAGE_HEADER_NAME)
 	const preferences = negotiateLanguagePreferences(acceptLanguage, config.availableLanguageTags)
-	return preferences.at(0) ?? config.defaultLanguage
+	return preferences[0] ?? config.defaultLanguage
 }

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/runtime/adapter.ts
@@ -232,7 +232,7 @@ export function createI18n<T extends string>(runtime: Paraglide<T>, options?: I1
 		 */
 		getLanguageFromUrl(url: URL): T {
 			const pathWithLanguage = url.pathname.slice(normaliseBase(base).length)
-			const lang = pathWithLanguage.split("/").filter(Boolean).at(0)
+			const lang = pathWithLanguage.split("/").find(Boolean)
 
 			if (runtime.isAvailableLanguageTag(lang)) return lang
 			return defaultLanguageTag

--- a/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/utils/escape.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-sveltekit/src/vite/preprocessor/utils/escape.ts
@@ -7,6 +7,6 @@ export const toJSIdentifier = (str: string) => {
 	//replace all non-alphanumeric characters with underscores
 	str = str.replace(/[^a-zA-Z0-9]/g, "_")
 	//If the first character is a number, prefix it with an underscore
-	if ((str.at(0) ?? "").match(/[0-9]/)) str = "_" + str
+	if ((str[0] ?? "").match(/[0-9]/)) str = "_" + str
 	return str
 }

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/detectLanguage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/detectLanguage.ts
@@ -35,7 +35,7 @@ export function detectLanguageFromPath<T extends string>({
 
 	const pathWithoutBase = path.replace(base, "")
 
-	const maybeLang = pathWithoutBase.split("/").at(1)
+	const maybeLang = pathWithoutBase.split("/")[1]
 	if (!maybeLang) return undefined
 
 	for (const lang of availableLanguageTags) {

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/init/command.ts
@@ -365,7 +365,7 @@ export const createNewProjectFlow = async (ctx: {
 	const settings = getNewProjectTemplate()
 
 	//Should always be defined. This is to shut TS up
-	const sourceLanguageTag = languageTags.at(0)
+	const sourceLanguageTag = languageTags[0]
 	if (!sourceLanguageTag) throw new Error("sourceLanguageTag is not defined")
 
 	settings.languageTags = languageTags


### PR DESCRIPTION
This PR changes the implementation of several paraglide packages to use direct index accesses instead of the `.at` array function. While `.at` is more idiomatic, it's only been widely supported for the last two years. 

People reported that this was causing issues for some of their users.