### PR TITLE
PARJS-80 Silent option for NextJS Adapter

### DIFF
--- a/.changeset/little-melons-grow.md
+++ b/.changeset/little-melons-grow.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js-adapter-next": minor
+---
+
+Add a `silent` option to the paragldie config field in `next.config.js` to silence the paraglide compiler logs.

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/README.md
@@ -340,7 +340,7 @@ export default function Document() {
 There are some known limitations with this adapter:
 
 - `output: static` isn't supported yet.
-- Evaluating messages in the module scope always renders the source language.
+- Evaluating messages in module scope always renders the source language.
 - Server actions that aren't inside a `.tsx` file will always read the default language unless `setLanguageTag(()=>headers().get("x-language-tag"))` is called at the top of the file.
 
 ## Roadmap to 1.0
@@ -351,9 +351,11 @@ There are some known limitations with this adapter:
 
 ## Examples
 
-You can find example projects on our Github, or try them on StackBlitz:
+You can find example projects in [our GitHub repository](https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide-js-adapter-next/examples), or try them on StackBlitz:
 
-- [App Router Example Repository](https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app)
-- [App Router Example on StackBlitz](https://stackblitz.com/~/LorisSigrist/paraglide-next-app-router-example)
-- [Pages Router Example](https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/pages)
-- [Pages Router Example on StackBlitz](https://stackblitz.com/~/LorisSigrist/paraglide-next-pages-router-example)
+<doc-links>
+    <doc-link title="App Router Example" icon="simple-icons:stackblitz" href="https://stackblitz.com/~/LorisSigrist/paraglide-next-app-router-example" description="Try out the App router example on StackBlitz"></doc-link>
+    <doc-link title="App Router Example Repository" icon="lucide:github" href="https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/app" description="View the source code for the App router Example"></doc-link>
+    <doc-link title="Pages Router Example" icon="simple-icons:stackblitz" href="https://stackblitz.com/~/LorisSigrist/paraglide-next-app-router-example" description="Try out the Pages router example on StackBlitz"></doc-link>
+	<doc-link title="App Router Example Repository" icon="lucide:github" href="https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-js-adapter-next/examples/pages" description="View the source code for the Pages router Example"></doc-link>
+</doc-links>

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/README.md
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/README.md
@@ -12,6 +12,7 @@ Get started instantly with the Paraglide-Next CLI.
 
 ```bash
 npx @inlang/paraglide-js-adapter-next init
+npm install
 ```
 
 The CLI will ask you which languages you want to support. This can be changed later. 

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/plugin/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/plugin/index.ts
@@ -4,13 +4,36 @@ import { once } from "./utils"
 import { useCompiler } from "./useCompiler"
 
 type ParaglideConfig = {
+	/**
+	 * Where the Inlang Project that defines the languages
+	 * and messages is located.
+	 *
+	 * This should be a relative path starting from the project root.
+	 *
+	 * @example "./project.inlang"
+	 */
 	project: string
+
+	/**
+	 * Where the paraglide output files should be placed. This is usually
+	 * inside a `src/paraglide` folder.
+	 *
+	 * This should be a relative path starting from the project root.
+	 *
+	 * @example "./src/paraglide"
+	 */
 	outdir: string
+
+	/**
+	 * If true, the paraglide compiler will only log errors to the console
+	 *
+	 * @default false
+	 */
+	silent?: boolean
 }
 
 type Config = NextConfig & {
 	paraglide: ParaglideConfig
-	paths?: Record<string, Record<string, string>>
 }
 
 /**
@@ -32,6 +55,7 @@ export function paraglide(config: Config): NextConfig {
 			project: config.paraglide.project,
 			outdir: config.paraglide.outdir,
 			watch: process.env.NODE_ENV === "development",
+			silent: config.paraglide.silent ?? false,
 		})
 	})
 

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/plugin/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/plugin/index.ts
@@ -44,8 +44,12 @@ type Config = NextConfig & {
  * @returns
  */
 export function paraglide(config: Config): NextConfig {
+	const aliasPath = config.paraglide.outdir.endsWith("/")
+		? config.paraglide.outdir + "runtime.js"
+		: config.paraglide.outdir + "/runtime.js"
+
 	addAlias(config, {
-		"$paraglide/runtime.js": config.paraglide.outdir + "/runtime.js",
+		"$paraglide/runtime.js": aliasPath,
 	})
 
 	// Next calls `next.config.js` TWICE. Once in a worker and once in the main process.

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/plugin/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/plugin/index.ts
@@ -39,9 +39,7 @@ type Config = NextConfig & {
 /**
  * Add this to your next.config.js to enable Paraglide.
  * It will register any aliases required by the Adapter,
- * aswell as register the build plugin if you're using webpack.
- *
- * @returns
+ * and register the build plugin if you're using webpack.
  */
 export function paraglide(config: Config): NextConfig {
 	const aliasPath = config.paraglide.outdir.endsWith("/")
@@ -63,7 +61,7 @@ export function paraglide(config: Config): NextConfig {
 		})
 	})
 
-	const nextConfig: NextConfig = { ...config }
+	const nextConfig: NextConfig = config
 	delete nextConfig.paraglide
 
 	return nextConfig

--- a/inlang/source-code/paraglide/paraglide-js-adapter-next/src/plugin/useCompiler.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js-adapter-next/src/plugin/useCompiler.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest"
+import { getCompileCommand, getWatchCommand } from "./useCompiler"
+describe("useCompiler", () => {
+	describe("getCompileCommand", () => {
+		it("is silent if watch is true", () => {
+			const command = getCompileCommand({
+				watch: true,
+				silent: false,
+				project: "./project.inlang",
+				outdir: "./outdir",
+			})
+			expect(command).toContain("--silent")
+		})
+
+		it("uses the correct outdir & project dir", () => {
+			const command = getCompileCommand({
+				watch: false,
+				silent: true,
+				project: "./somewhere/project.inlang",
+				outdir: "./paraglide",
+			})
+			expect(command).toContain("--outdir ./paraglide")
+			expect(command).toContain("--project ./somewhere/project.inlang")
+		})
+
+		const command = getCompileCommand({
+			watch: true,
+			silent: false,
+			project: "./project.inlang",
+			outdir: "./outdir",
+		})
+		expect(command).toContain("--silent")
+	})
+
+	describe("getWatchCommand", () => {
+		it("watches", () => {
+			const command = getWatchCommand({
+				watch: true,
+				silent: false,
+				project: "./somewhere/project.inlang",
+				outdir: "./paraglide",
+			})
+			expect(command).toContain("--watch")
+		})
+
+		it("is silent if silent is true", () => {
+			it("watches", () => {
+				const command = getWatchCommand({
+					watch: true,
+					silent: true,
+					project: "./somewhere/project.inlang",
+					outdir: "./paraglide",
+				})
+				expect(command).toContain("--silent")
+			})
+		})
+	})
+})


### PR DESCRIPTION
This PR adds a `silent` option to the paraglide config in `next.config.js` to turn off the compiler logs, as they can get quite annoying.