### PR TITLE
Use the `createNewProject` API from the SDK

### DIFF
--- a/.changeset/slimy-ghosts-tease.md
+++ b/.changeset/slimy-ghosts-tease.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+`paraglide-js init` now uses the `createNewProject` API from `@inlang/sdk` for creating new projects. This resulits in higher reliability.

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/defaults.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/defaults.ts
@@ -1,26 +1,4 @@
-import type { ProjectSettings } from "@inlang/sdk"
-
-const newProjectTemplate = {
-	$schema: "https://inlang.com/schema/project-settings",
-	sourceLanguageTag: "en",
-	languageTags: ["en"],
-	modules: [
-		// for instant gratification, we're adding common rules
-		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-empty-pattern@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-valid-js-identifier@latest/dist/index.js",
-
-		// default to the message format plugin because it supports all features
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js",
-
-		// the m function matcher should be installed by default in case Sherlock (VS Code extension) is adopted
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js",
-	],
-	"plugin.inlang.messageFormat": {
-		pathPattern: "./messages/{languageTag}.json",
-	},
-} satisfies ProjectSettings
+import { defaultProjectSettings } from "@inlang/sdk"
 
 /**
  * @returns A new copy of the default project template that is safe to mutate.
@@ -28,14 +6,14 @@ const newProjectTemplate = {
 export function getNewProjectTemplate() {
 	if (!("structuredClone" in globalThis)) {
 		try {
-			return JSON.parse(JSON.stringify(newProjectTemplate)) as typeof newProjectTemplate
+			return JSON.parse(JSON.stringify(defaultProjectSettings)) as typeof defaultProjectSettings
 		} catch {
 			throw new Error(
 				"structuredClone is not supported in your Node Version. Please use version 17 or higher"
 			)
 		}
 	}
-	return structuredClone(newProjectTemplate)
+	return structuredClone(defaultProjectSettings)
 }
 
 export const DEFAULT_PROJECT_PATH = "./project.inlang"

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/steps/initialize-inlang-project.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/steps/initialize-inlang-project.ts
@@ -1,6 +1,7 @@
 import {
 	LanguageTag,
 	isValidLanguageTag,
+	createNewProject,
 	listProjects,
 	loadProject,
 	type InlangProject,
@@ -194,12 +195,13 @@ export const createNewProjectFlow = async (ctx: {
 	)
 
 	ctx.logger.info(`Creating a new inlang project in the current working directory.`)
-	await ctx.repo.nodeishFs.mkdir(DEFAULT_PROJECT_PATH, { recursive: true })
-
-	const settingsFilePath = nodePath.resolve(process.cwd(), DEFAULT_PROJECT_PATH, "settings.json")
-	await ctx.repo.nodeishFs.writeFile(settingsFilePath, JSON.stringify(settings, undefined, 2))
 
 	const projectPath = nodePath.resolve(process.cwd(), DEFAULT_PROJECT_PATH)
+	await createNewProject({
+		projectPath,
+		repo: ctx.repo,
+		projectSettings: settings,
+	})
 	const project = await loadProject({
 		projectPath,
 		repo: ctx.repo,


### PR DESCRIPTION
This PR updates the `paraglide-js init` command so that it uses the `createNewProject` API form the SDK instead of paraglide's special sauce.

It keeps the paraglide specific behavior of creating the `messages` folder.