### PR TITLE
INCLI-2 inlang machine translate calls rpc only if message has missing translations

### DIFF
--- a/.changeset/two-clocks-stare.md
+++ b/.changeset/two-clocks-stare.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cli": patch
+---
+
+Filter inlang machine translate to call rpc only if hasMissingTranslations

--- a/inlang/source-code/cli/src/commands/machine/translate.test.ts
+++ b/inlang/source-code/cli/src/commands/machine/translate.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest"
-import { translateCommandAction } from "./translate.js"
+import { translateCommandAction, hasMissingTranslations } from "./translate.js"
 import { Message, ProjectSettings, loadProject, Plugin, type InlangModule } from "@inlang/sdk"
 import { createMessage } from "@inlang/sdk/test-utilities"
 import { mockRepo } from "@lix-js/client"
@@ -162,3 +162,12 @@ test.runIf(process.env.GOOGLE_TRANSLATE_API_KEY)(
 	},
 	{ timeout: 10000 }
 )
+
+// Only test with valid sourceLanguageTag and targetLanguageTags
+test("hasMissingTranslations", () => {
+	expect(hasMissingTranslations(createMessage("a", { en: "test" }), "en", ["en"])).toBe(false)
+	expect(hasMissingTranslations(createMessage("a", { en: "test" }), "en", ["en", "de"])).toBe(true)
+	expect(
+		hasMissingTranslations(createMessage("a", { en: "test", de: "Test" }), "en", ["en", "de"])
+	).toBe(false)
+})


### PR DESCRIPTION
Resolves INCLI-2 (https://github.com/opral/inlang-cli/issues/2)

- [x] Introduces a filter on the CLI client side to call the rpc server only when actually needed for missting translations.
(Before it would send all messages over the wire regardless)
- [x] Small fixes to sdk/load-test - can be ignored for PR review