### PR TITLE
Paraglide next init windows paths

### DIFF
--- a/.changeset/hot-tigers-pump.md
+++ b/.changeset/hot-tigers-pump.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-next": patch
+---
+
+The `init` command now always produces posix paths for the outdir and project path, even on windows

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/flows/addPluginToNextConfig.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/flows/addPluginToNextConfig.ts
@@ -1,8 +1,8 @@
+import path from "node:path"
 import { Logger } from "@inlang/paraglide-js/internal"
-import { CliStep } from "../utils"
+import { CliStep, normalizePath } from "../utils"
 import { Repository } from "@lix-js/client"
 import { NextJSProject } from "./scan-next-project"
-import path from "node:path"
 import { Outdir } from "./getOutDir"
 
 export const addParaglideNextPluginToNextConfig: CliStep<
@@ -63,8 +63,10 @@ https://inlang.com/m/osslbuzt/paraglide-next-i18n
 		const configIdentifier = match.groups?.configIdentifier as string
 		const identifierStartIndex = endIndex - configIdentifier.length
 
-		const relativeOutdir = "./" + path.relative(process.cwd(), ctx.outdir.path)
-		const relativeProjectPath = "./" + path.relative(process.cwd(), ctx.projectPath)
+		const posixCWD = normalizePath(process.cwd())
+
+		const relativeOutdir = "./" + path.posix.relative(posixCWD, normalizePath(ctx.outdir.path))
+		const relativeProjectPath = "./" + path.posix.relative(posixCWD, normalizePath(ctx.projectPath))
 
 		const wrappedIdentifier = `paraglide({
 	paraglide: {

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/flows/getOutDir.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/flows/getOutDir.ts
@@ -1,10 +1,12 @@
 import path from "node:path"
 import { NextJSProject } from "./scan-next-project"
-import { CliStep } from "../utils"
+import { CliStep, normalizePath } from "../utils"
 
 export type Outdir = {
 	/**
 	 * The absolute path to the outdir
+	 * Will use forward slashes, even on Windows
+	 *
 	 * @example
 	 *   "/Users/---/dev/next-project/src/paraglide"
 	 */
@@ -25,7 +27,7 @@ export const getOutDir: CliStep<{ nextProject: NextJSProject }, { outdir: Outdir
 	ctx
 ) => {
 	const outdir: Outdir = {
-		path: path.resolve(ctx.nextProject.srcRoot, "paraglide"),
+		path: normalizePath(path.resolve(ctx.nextProject.srcRoot, "paraglide")),
 		importAlias: "@/paraglide",
 	}
 	return { ...ctx, outdir }

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/flows/getOutDir.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/flows/getOutDir.ts
@@ -1,11 +1,10 @@
 import path from "node:path"
 import { NextJSProject } from "./scan-next-project"
-import { CliStep, normalizePath } from "../utils"
+import { CliStep } from "../utils"
 
 export type Outdir = {
 	/**
 	 * The absolute path to the outdir
-	 * Will use forward slashes, even on Windows
 	 *
 	 * @example
 	 *   "/Users/---/dev/next-project/src/paraglide"
@@ -27,7 +26,7 @@ export const getOutDir: CliStep<{ nextProject: NextJSProject }, { outdir: Outdir
 	ctx
 ) => {
 	const outdir: Outdir = {
-		path: normalizePath(path.resolve(ctx.nextProject.srcRoot, "paraglide")),
+		path: path.resolve(ctx.nextProject.srcRoot, "paraglide"),
 		importAlias: "@/paraglide",
 	}
 	return { ...ctx, outdir }

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/utils.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/utils.ts
@@ -1,3 +1,5 @@
+import path from "path"
+
 /**
  * One step in a CLI chain.
  * Defines which types the context needs to extend and how it extends the context
@@ -48,4 +50,15 @@ export async function succeedOrElse<T extends Promise<unknown>, U>(
 	} catch (err) {
 		return orElse
 	}
+}
+
+const WINDOWS_SLASH_REGEX = /\\/g
+function slash(p: string): string {
+	return p.replace(WINDOWS_SLASH_REGEX, "/")
+}
+
+const isWindows = typeof process !== "undefined" && process.platform === "win32"
+
+export function normalizePath(id: string) {
+	return path.posix.normalize(isWindows ? slash(id) : id)
 }

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/utils.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/utils.ts
@@ -1,4 +1,4 @@
-import path from "path"
+import path from "node:path"
 
 /**
  * One step in a CLI chain.


### PR DESCRIPTION
This PR fixes the issue described in https://discord.com/channels/897438559458430986/1083724234142011392/1233171690381508698 where the `outdir` and `project` paths generated by the `paraglide-next init` command may have been using backslashes accidentally. Now only posix paths should be used