### PR TITLE
docs: fix `paraglide-next` examples repo link

### DIFF
--- a/inlang/source-code/paraglide/paraglide-next/README.md
+++ b/inlang/source-code/paraglide/paraglide-next/README.md
@@ -333,7 +333,7 @@ There are some known limitations with Paraglide-Next.
 
 # Examples
 
-You can find example projects in [our GitHub repository](https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide-next/examples), or try them on StackBlitz:
+You can find example projects in [our GitHub repository](https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-next/examples), or try them on StackBlitz:
 
 <doc-links>
     <doc-link title="App Router Example" icon="simple-icons:stackblitz" href="https://stackblitz.com/~/LorisSigrist/paraglide-next-app-router-example" description="Try out the App router example on StackBlitz"></doc-link>


### PR DESCRIPTION
Just discovered paraglide this morning, everything looks awesome so far! This just fixes a broken link on https://inlang.com/m/osslbuzt/paraglide-next-i18n#examples. 

Thanks for all the hard work!