### PR TITLE
improve getInlangProject test, cleanup multi-project-test

### DIFF
--- a/inlang/source-code/sdk/multi-project-test/package.json
+++ b/inlang/source-code/sdk/multi-project-test/package.json
@@ -20,7 +20,7 @@
 		"lint2": "pnpm inlang lint --project ./project2-dir/project.inlang",
 		"lint3": "pnpm inlang lint --project ./project3-dir/project.inlang",
 		"lint4": "pnpm inlang lint --project ./project4-dir/project.inlang",
-		"test": "pnpm clean && vitest --reporter=tap-flat run"
+		"test": "pnpm clean && vitest --reporter=tap-flat run && pnpm clean"
 	},
 	"prettier": {
 		"semi": false,


### PR DESCRIPTION
small followup to #2684 - no review required.

- [x] don't fetch plugin over the wire in getInlangProject.test and cleanup temp dir
- [x] cleanup after sdk multi-project-test 