### PR TITLE
MESDK-82 Improve error handling for module URLs in project settings

### DIFF
--- a/.changeset/witty-icons-kick.md
+++ b/.changeset/witty-icons-kick.md
@@ -1,0 +1,6 @@
+---
+"@inlang/project-settings": patch
+"@inlang/sdk": patch
+---
+
+Improve error handling for module URLs in project settings

--- a/inlang/source-code/sdk/src/errors.ts
+++ b/inlang/source-code/sdk/src/errors.ts
@@ -1,3 +1,4 @@
+import type { SchemaOptions } from "@sinclair/typebox"
 import type { ValueError } from "@sinclair/typebox/errors"
 
 export class LoadProjectInvalidArgument extends Error {
@@ -11,13 +12,24 @@ export class ProjectSettingsInvalidError extends Error {
 	constructor(options: { errors: ValueError[] }) {
 		// TODO: beatufiy ValueErrors
 		super(
-			`The project settings are invalid:\n\n${options.errors
-				.filter((error) => error.path)
-				.map((error) => `"${error.path}":\n\n${error.message}`)
-				.join("\n")}`
+			`The project settings are invalid:
+${options.errors
+	.filter((error) => error.path)
+	.map(FormatProjectSettingsError)
+	.join("\n")}`
 		)
 		this.name = "ProjectSettingsInvalidError"
 	}
+}
+
+function FormatProjectSettingsError(error: ValueError) {
+	let msg = `${error.message} at ${error.path}`
+	if (error.path.startsWith("/modules/")) {
+		msg += `
+value = "${error.value}"
+- ${error.schema.allOf.map((o: SchemaOptions) => `${o.description ?? ""}`).join("\n- ")}`
+	}
+	return msg
 }
 
 export class ProjectSettingsFileJSONSyntaxError extends Error {

--- a/inlang/source-code/versioned-interfaces/project-settings/src/interface.ts
+++ b/inlang/source-code/versioned-interfaces/project-settings/src/interface.ts
@@ -65,8 +65,7 @@ const InternalProjectSettings = Type.Object({
 			}),
 			Type.String({
 				pattern: "^(?!.*@\\d\\.)[^]*$",
-				description:
-					"The module can only contain a major version number (ComVer, not SemVer). See https://inlang.com/documentation/comver",
+				description: "The module can only contain a major version number.",
 			}),
 		]),
 		{


### PR DESCRIPTION
Resolves https://github.com/opral/inlang-message-sdk/issues/44

####  Old error for incorrectly typed module URL
```
ProjectSettingsInvalidError: The project settings are invalid:

"/modules/0":

Expected all values to match
    at parseSettings (file:///Users/jldec/opral/monorepo/inlang/source-code/cli/dist/main.js:88702:13)
    at loadSettings (file:///Users/jldec/opral/monorepo/inlang/source-code/cli/dist/main.js:88695:10)
```

#### New error
```
ProjectSettingsInvalidError: The project settings are invalid:
Expected all values to match at /modules/2
value = "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.ts"
- The module must be a valid URI according to RFC 3986.
- The module must end with `.js`.
- The module can only contain a major version number.
    at parseSettings (file:///Users/jldec/opral/monorepo/inlang/source-code/cli/dist/main.js:88708:13)
    at loadSettings (file:///Users/jldec/opral/monorepo/inlang/source-code/cli/dist/main.js:88701:10)
```

Error for missing source language in target languages is more or less the same as before
```
ProjectSettingsInvalidError: The project settings are invalid:
The sourceLanguageTag "en" is not included in the languageTags "eng", "de". Please add it to the languageTags. at sourceLanguageTag
    at parseSettings (file:///Users/jldec/opral/monorepo/inlang/source-code/cli/dist/main.js:88715:11)
    at loadSettings (file:///Users/jldec/opral/monorepo/inlang/source-code/cli/dist/main.js:88701:10)
```

