### PR TITLE
Bump version of @inlang/settings-component to fix deps

### DIFF
--- a/.changeset/swift-squids-look.md
+++ b/.changeset/swift-squids-look.md
@@ -1,0 +1,5 @@
+---
+"@inlang/settings-component": patch
+---
+
+Bump version of @inlang/settings-component to fix deps

--- a/inlang/source-code/editor/package.json
+++ b/inlang/source-code/editor/package.json
@@ -16,7 +16,7 @@
 		"node": ">=18.0.0"
 	},
 	"dependencies": {
-		"@inlang/settings-component": "^1.0.7",
+		"@inlang/settings-component": "^1.0.6",
 		"@isomorphic-git/cors-proxy": "^2.7.1",
 		"@lix-js/client": "workspace:*",
 		"@lix-js/fs": "workspace:*",

--- a/inlang/source-code/ide-extension/package.json
+++ b/inlang/source-code/ide-extension/package.json
@@ -209,7 +209,7 @@
 		"@inlang/result": "workspace:*",
 		"@inlang/rpc": "workspace:*",
 		"@inlang/sdk": "workspace:*",
-		"@inlang/settings-component": "^1.0.7",
+		"@inlang/settings-component": "^1.0.6",
 		"@inlang/telemetry": "workspace:*",
 		"@lix-js/client": "workspace:*",
 		"@lix-js/fs": "workspace:*",


### PR DESCRIPTION
See https://discord.com/channels/897438559458430986/1130765707639001088/1235356269607518292

fixing broking pnpm install on main
```
 ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @inlang/settings-component@^1.0.7

This error happened while installing a direct dependency of /home/runner/work/monorepo/monorepo/inlang/source-code/editor

The latest release of @inlang/settings-component is "1.0.6".
```
