### PR TITLE
Lorissigrist/parjs 103 paraglide next isnt using the most specific pathname

### DIFF
--- a/.changeset/forty-sheep-wait.md
+++ b/.changeset/forty-sheep-wait.md
@@ -1,0 +1,6 @@
+---
+"@inlang/paraglide-next": patch
+"@inlang/paraglide-sveltekit": patch
+---
+
+Fix issue where the localised routing didn't always use the most specific pathname as outlined in https://kit.svelte.dev/docs/advanced-routing#sorting

--- a/.changeset/hungry-grapes-watch.md
+++ b/.changeset/hungry-grapes-watch.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Improve `bestMatch` reliability

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/index.ts
@@ -4,7 +4,6 @@ export {
 	bestMatch,
 	resolveRoute,
 	parseRouteDefinition,
-	exec,
 	type PathDefinitionTranslations,
 	type ParamMatcher,
 	type RouteParam,

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
@@ -228,18 +228,21 @@ describe("match", () => {
 		expect(match).toBeUndefined()
 	})
 
-	it("Uses params to disambiguate", () => {
-		const match = bestMatch("/foo/bar", ["/foo/[params=bar]", "/foo/[params=foo]"], {
-			foo: (param) => param === "foo",
-			bar: (param) => param === "bar",
-		})
-		expect(match).toEqual({
-			id: "/foo/[params=bar]",
-			params: {
-				params: "bar",
-			},
-		})
-	})
+	it.each(permute(["/foo/[params=bar]", "/foo/[params=foo]"]))(
+		"Uses params to disambiguate",
+		(...routeIds) => {
+			const match = bestMatch("/foo/bar", routeIds, {
+				foo: (param) => param === "foo",
+				bar: (param) => param === "bar",
+			})
+			expect(match).toEqual({
+				id: "/foo/[params=bar]",
+				params: {
+					params: "bar",
+				},
+			})
+		}
+	)
 })
 
 const permute = <T>(inputArr: T[]): T[][] => {

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
@@ -200,17 +200,16 @@ describe("match", () => {
 	})
 
 	// Test case from https://github.com/opral/inlang-paraglide-js/issues/100
-	it("prefers matches with non-catchall params", () => {
-		const match = bestMatch(
-			"/properties/custom",
-			["/properties/[...rest]", "/properties/custom"],
-			{}
-		)
-		expect(match).toEqual({
-			id: "/properties/custom",
-			params: {},
-		})
-	})
+	it.each(permute(["/properties/[...rest]", "/properties/custom", "/[...rest]"]))(
+		"prefers matches with non-catchall params",
+		(...routeIds) => {
+			const match = bestMatch("/properties/custom", routeIds, {})
+			expect(match).toEqual({
+				id: "/properties/custom",
+				params: {},
+			})
+		}
+	)
 
 	it("matches optional catchalls", () => {
 		const match = bestMatch("/foo/bar/baz", ["/foo/[[...rest]]"], {})
@@ -242,3 +241,23 @@ describe("match", () => {
 		})
 	})
 })
+
+const permute = <T>(inputArr: T[]): T[][] => {
+	let result: T[][] = []
+
+	const permute = (arr: T[], m: T[] = []) => {
+		if (arr.length === 0) {
+			result.push(m)
+		} else {
+			for (let i = 0; i < arr.length; i++) {
+				let curr = arr.slice()
+				let next = curr.splice(i, 1)
+				permute(curr.slice(), m.concat(next))
+			}
+		}
+	}
+
+	permute(inputArr)
+
+	return result
+}

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
@@ -190,7 +190,7 @@ describe("match", () => {
 	})
 
 	it("prefers matches with fewer params", () => {
-		const match = bestMatch("/foo/bar/baz", ["/foo/[id]/baz", "/foo/[id]/[slug]"], {})
+		const match = bestMatch("/foo/bar/baz", ["/foo/[id]/[slug]", "/foo/[id]/baz"], {})
 		expect(match).toEqual({
 			id: "/foo/[id]/baz",
 			params: {

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
@@ -252,16 +252,16 @@ describe("bestMatch", () => {
 })
 
 const permute = <T>(inputArr: T[]): T[][] => {
-	let result: T[][] = []
+	const result: T[][] = []
 
 	const permute = (arr: T[], m: T[] = []) => {
 		if (arr.length === 0) {
 			result.push(m)
 		} else {
 			for (let i = 0; i < arr.length; i++) {
-				let curr = arr.slice()
-				let next = curr.splice(i, 1)
-				permute(curr.slice(), m.concat(next))
+				const curr = [...arr]
+				const next = curr.splice(i, 1)
+				permute(curr, [...m, ...next])
 			}
 		}
 	}

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.test.ts
@@ -199,6 +199,19 @@ describe("match", () => {
 		})
 	})
 
+	// Test case from https://github.com/opral/inlang-paraglide-js/issues/100
+	it("prefers matches with non-catchall params", () => {
+		const match = bestMatch(
+			"/properties/custom",
+			["/properties/[...rest]", "/properties/custom"],
+			{}
+		)
+		expect(match).toEqual({
+			id: "/properties/custom",
+			params: {},
+		})
+	})
+
 	it("matches optional catchalls", () => {
 		const match = bestMatch("/foo/bar/baz", ["/foo/[[...rest]]"], {})
 		expect(match).toEqual({

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
@@ -1,7 +1,14 @@
 //vendored in from sveltekit and adapted
 
+import { sort_routes } from "./sortRoutes.js"
+
 export type PathDefinitionTranslations<T extends string = string> = {
 	[canonicalPath: `/${string}`]: Record<T, `/${string}`>
+}
+
+type Route = {
+	params: RouteParam[]
+	pattern: RegExp
 }
 
 export type RouteParam = {
@@ -21,10 +28,7 @@ const param_pattern = /^(\[)?(\.\.\.)?(\w+)(?:=(\w+))?(\])?$/
 /**
  * Creates the regex pattern, extracts parameter names, and generates types for a route
  */
-export function parseRouteDefinition(id: string): {
-	params: RouteParam[]
-	pattern: RegExp
-} {
+export function parseRouteDefinition(id: string): Route {
 	const params: RouteParam[] = []
 
 	const pattern =
@@ -261,59 +265,22 @@ export function bestMatch(
 	pathDefinitions: string[],
 	matchers: Record<string, ParamMatcher>
 ): { params: Record<string, string>; id: string } | undefined {
-	let bestMatch:
-		| {
-				id: string
-				params: Record<string, string>
-				route: ReturnType<typeof parseRouteDefinition>
-		  }
-		| undefined = undefined
+	const sorted = sort_routes(pathDefinitions)
 
-	for (const pathDefinition of pathDefinitions) {
+	//find the first match
+	for (const pathDefinition of sorted) {
 		const route = parseRouteDefinition(pathDefinition)
 		const match = route.pattern.exec(removeTrailingSlash(canonicalPath))
-
-		//if the path doesn't match the pattern it's not a match
 		if (!match) continue
 
-		//the params are undefined IFF the matchers don't match
 		const params = exec(match, route.params, matchers)
+		//the params are undefined IFF the matchers don't match
 		if (!params) continue
 
-		if (!bestMatch) {
-			bestMatch = { params, route, id: pathDefinition }
-			continue
-		}
-
-		const bestMatchNumParams = Object.keys(bestMatch.route.params).length
-		const currentMatchNumParams = Object.keys(route.params).length
-
-		// the best match requires fewer parameters
-		if (bestMatchNumParams < currentMatchNumParams) {
-			continue
-		}
-
-		//if the current match has fewer parameters, it's a better match
-		if (bestMatchNumParams > currentMatchNumParams) {
-			bestMatch = { params, route, id: pathDefinition }
-			continue
-		}
-
-		// if they're tied, pick the shorter one
-		if (
-			bestMatchNumParams === currentMatchNumParams &&
-			route.pattern.source.length < bestMatch.route.pattern.source.length
-		) {
-			bestMatch = { params, route, id: pathDefinition }
-		}
+		return { params, id: pathDefinition }
 	}
 
-	return bestMatch
-		? {
-				id: bestMatch.id,
-				params: bestMatch.params,
-		  }
-		: undefined
+	return undefined
 }
 
 function removeTrailingSlash(path: string): string {
@@ -327,6 +294,4 @@ function removeTrailingSlash(path: string): string {
  * @param {string} route
  * @returns string[]
  */
-function get_route_segments(route: string) {
-	return route.slice(1).split("/")
-}
+export const get_route_segments = (route: string) => route.slice(1).split("/")

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
@@ -6,7 +6,6 @@ export type PathDefinitionTranslations<T extends string = string> = {
 }
 
 type Route = {
-	id: string
 	params: RouteParam[]
 	pattern: RegExp
 }
@@ -119,7 +118,7 @@ export function parseRouteDefinition(id: string): Route {
 						.join("")}/?$`
 			  )
 
-	return { pattern, params, id }
+	return { pattern, params }
 }
 
 export function exec(

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
@@ -10,6 +10,7 @@ export type RouteParam = {
 	optional: boolean
 	rest: boolean
 	chained: boolean
+	//priority: number
 }
 export type ParamMatcher = (segment: string) => boolean
 

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
@@ -1,5 +1,4 @@
 //vendored in from sveltekit and adapted
-
 import { sort_routes } from "./sortRoutes.js"
 
 export type PathDefinitionTranslations<T extends string = string> = {
@@ -7,6 +6,7 @@ export type PathDefinitionTranslations<T extends string = string> = {
 }
 
 type Route = {
+	id: string
 	params: RouteParam[]
 	pattern: RegExp
 }
@@ -17,8 +17,8 @@ export type RouteParam = {
 	optional: boolean
 	rest: boolean
 	chained: boolean
-	//priority: number
 }
+
 export type ParamMatcher = (segment: string) => boolean
 
 //vendored in from @sveltejs/kit utils/routing.js
@@ -119,7 +119,7 @@ export function parseRouteDefinition(id: string): Route {
 						.join("")}/?$`
 			  )
 
-	return { pattern, params }
+	return { pattern, params, id }
 }
 
 export function exec(

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
@@ -89,9 +89,7 @@ export function parseRouteDefinition(id: string): Route {
 										// param/matcher name with non-alphanumeric character.
 										const match = /** @type {RegExpExecArray} */ param_pattern.exec(content)
 										if (!match) {
-											throw new Error(
-												`Invalid param: ${content}. Params and matcher names can only have underscores and alphanumeric characters.`
-											)
+											throw new Error(`Invalid param: ${content}`)
 										}
 
 										const [, is_optional, is_rest, name, matcher] = match

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/routeDefinitions.ts
@@ -126,7 +126,7 @@ export function exec(
 	const result: Record<string, string> = {}
 
 	const values = match.slice(1)
-	const values_needing_match = values.filter((value) => value !== undefined)
+	const values_needing_match = values.filter((v) => v !== undefined)
 
 	let buffered = 0
 
@@ -225,25 +225,21 @@ const basic_param_pattern = /\[(\[)?(\.\.\.)?(\w+?)(?:=(\w+))?\]\]?/g
  * ```
  */
 export function resolveRoute(id: string, params: Record<string, string | undefined>): string {
-	const segments = get_route_segments(id)
 	return (
 		"/" +
-		segments
+		get_route_segments(id)
 			.map((segment) =>
 				segment.replace(basic_param_pattern, (_, optional, rest, name) => {
 					const param_value = params[name]
 
 					// This is nested so TS correctly narrows the type
 					if (!param_value) {
-						if (optional) return ""
-						if (rest && param_value !== undefined) return ""
-						throw new Error(`Missing parameter '${name}' in route ${id}`)
+						if (optional || (rest && param_value !== undefined)) return ""
+						else throw new Error(`Missing parameter '${name}' in route ${id}`)
 					}
 
-					if (param_value.startsWith("/") || param_value.endsWith("/"))
-						throw new Error(
-							`Parameter '${name}' in route ${id} cannot start or end with a slash -- this would cause an invalid route like foo//bar`
-						)
+					if (param_value[0] == "/" || param_value.endsWith("/"))
+						throw new Error(`Parameter '${name}' in route ${id} cannot start or end with a slash`)
 					return param_value
 				})
 			)

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/sortRoutes.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/sortRoutes.ts
@@ -112,7 +112,7 @@ export function sort_routes(routes: string[]): string[] {
 					if (a === EMPTY) return -1
 					if (b === EMPTY) return +1
 
-					return sort_static(a!.content, b!.content)
+					return sort_static((a as Part).content, (b as Part).content)
 				}
 			}
 		}
@@ -135,7 +135,8 @@ function split_route_id(id: string) {
 function sort_static(a: string, b: string): -1 | 0 | 1 {
 	if (a === b) return 0
 
-	for (let i = 0; true; i += 1) {
+	let i = 0
+	while (a[i] || b[i]) {
 		const char_a = a[i]
 		const char_b = b[i]
 
@@ -144,5 +145,7 @@ function sort_static(a: string, b: string): -1 | 0 | 1 {
 			if (char_b === undefined) return -1
 			return char_a < char_b ? -1 : +1
 		}
+		i++
 	}
+	return 0
 }

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/sortRoutes.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/sortRoutes.ts
@@ -132,7 +132,7 @@ function split_route_id(id: string) {
 /**
  * Sort two strings lexicographically, except `foobar` outranks `foo`
  */
-function sort_static(a: string, b: string) {
+function sort_static(a: string, b: string): -1 | 0 | 1 {
 	if (a === b) return 0
 
 	for (let i = 0; true; i += 1) {

--- a/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/sortRoutes.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/adapter-utils/routing/sortRoutes.ts
@@ -1,0 +1,148 @@
+import { get_route_segments } from "./routeDefinitions.js"
+
+type Part = {
+	type: "static" | "required" | "optional" | "rest"
+	content: string
+	matched: boolean
+}
+
+const EMPTY = { type: "static", content: "", matched: false } satisfies Part
+
+export function sort_routes(routes: string[]): string[] {
+	const segment_cache = new Map<string, Part[]>()
+
+	function split(id: string) {
+		const parts: Part[] = []
+
+		let i = 0
+		while (i <= id.length) {
+			const start = id.indexOf("[", i)
+			if (start === -1) {
+				parts.push({ type: "static", content: id.slice(i), matched: false })
+				break
+			}
+
+			parts.push({ type: "static", content: id.slice(i, start), matched: false })
+
+			const type = id[start + 1] === "[" ? "optional" : id[start + 1] === "." ? "rest" : "required"
+			const delimiter = type === "optional" ? "]]" : "]"
+			const end = id.indexOf(delimiter, start)
+
+			if (end === -1) {
+				throw new Error(`Invalid route ID ${id}`)
+			}
+
+			const content = id.slice(start, (i = end + delimiter.length))
+
+			parts.push({
+				type,
+				content,
+				matched: content.includes("="),
+			})
+		}
+
+		return parts
+	}
+
+	function get_parts(segment: string) {
+		if (!segment_cache.has(segment)) {
+			segment_cache.set(segment, split(segment))
+		}
+
+		return segment_cache.get(segment)
+	}
+
+	return routes.sort((route_a, route_b) => {
+		const segments_a = split_route_id(route_a).map(get_parts)
+		const segments_b = split_route_id(route_b).map(get_parts)
+
+		for (let i = 0; i < Math.max(segments_a.length, segments_b.length); i += 1) {
+			const segment_a = segments_a[i] ?? [EMPTY]
+			const segment_b = segments_b[i] ?? [EMPTY]
+
+			for (let j = 0; j < Math.max(segment_a.length, segment_b.length); j += 1) {
+				const a = segment_a[j]
+				const b = segment_b[j]
+
+				// first part of each segment is always static
+				// (though it may be the empty string), then
+				// it alternates between dynamic and static
+				// (i.e. [foo][bar] is disallowed)
+
+				const dynamic = !!(j % 2) //is odd
+
+				if (dynamic) {
+					if (!a) return -1
+					if (!b) return +1
+
+					// get the next static chunk, so we can handle [...rest] edge cases
+					const next_a = (segment_a[j + 1]?.content || segments_a[i + 1]?.[0]?.content) as string
+					const next_b = (segment_b[j + 1]?.content || segments_b[i + 1]?.[0]?.content) as string
+
+					// `[...rest]/x` outranks `[...rest]`
+					if (a.type === "rest" && b.type === "rest") {
+						if (next_a && next_b) continue
+						if (next_a) return -1
+						if (next_b) return +1
+					}
+
+					// `[...rest]/x` outranks `[required]` or `[required]/[required]`
+					// but not `[required]/x`
+					if (a.type === "rest") {
+						return next_a && !next_b ? -1 : +1
+					}
+
+					if (b.type === "rest") {
+						return next_b && !next_a ? +1 : -1
+					}
+
+					// part with matcher outranks one without
+					if (a.matched !== b.matched) {
+						return a.matched ? -1 : +1
+					}
+
+					if (a.type !== b.type) {
+						// `[...rest]` has already been accounted for, so here
+						// we're comparing between `[required]` and `[[optional]]`
+						if (a.type === "required") return -1
+						if (b.type === "required") return +1
+					}
+				} else if (a?.content !== b?.content) {
+					// shallower path outranks deeper path
+					if (a === EMPTY) return -1
+					if (b === EMPTY) return +1
+
+					return sort_static(a!.content, b!.content)
+				}
+			}
+		}
+
+		return route_a < route_b ? +1 : -1
+	})
+}
+
+function split_route_id(id: string) {
+	return get_route_segments(
+		id
+			// remove all [[optional]] parts unless they're at the very end
+			.replace(/\[\[[^\]]+\]\](?!$)/g, "")
+	).filter(Boolean)
+}
+
+/**
+ * Sort two strings lexicographically, except `foobar` outranks `foo`
+ */
+function sort_static(a: string, b: string) {
+	if (a === b) return 0
+
+	for (let i = 0; true; i += 1) {
+		const char_a = a[i]
+		const char_b = b[i]
+
+		if (char_a !== char_b) {
+			if (char_a === undefined) return +1
+			if (char_b === undefined) return -1
+			return char_a < char_b ? -1 : +1
+		}
+	}
+}

--- a/inlang/source-code/paraglide/paraglide-next/examples/app/src/app/actions.ts
+++ b/inlang/source-code/paraglide/paraglide-next/examples/app/src/app/actions.ts
@@ -12,6 +12,6 @@ export async function greet(formData: FormData) {
 
 export async function fetchData() {
 	const data = "this is the data"
-	console.log("server response:", data)
+	console.info("server response:", data)
 	return data
 }


### PR DESCRIPTION
This PR fixes an issue in Paraglide-Next and Paraglide-SvelteKit that caused it to not always pick the most specific route available, as outlined in https://kit.svelte.dev/docs/advanced-routing#sorting. This caused unexpected Routing Behavior 