### PR TITLE
Bump timeout for paraglide-sveltekit test from 30s to 90s

### DIFF
--- a/inlang/source-code/paraglide/paraglide-sveltekit/package.json
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/package.json
@@ -12,8 +12,8 @@
 		"url": "https://github.com/opral/inlang-paraglide-js"
 	},
 	"scripts": {
-		"test:with-base": "BASE_PATH=/base vitest run --test-timeout 30000 --dir src",
-		"test:without-base": "BASE_PATH=\"\" vitest run --test-timeout 30000 --dir src",
+		"test:with-base": "BASE_PATH=/base vitest run --test-timeout 90000 --dir src",
+		"test:without-base": "BASE_PATH=\"\" vitest run --test-timeout 90000 --dir src",
 		"test": "npm run test:with-base && npm run test:without-base",
 		"build": "tsc --noEmit && svelte-package -i src -o dist",
 		"dev": "svelte-package -w -i src -o dist",


### PR DESCRIPTION
to address failures on GH actions 
e.g. https://github.com/opral/monorepo/actions/runs/9036122243/job/24832339728#step:9:3034