### PR TITLE
MESDK-90 Simplify and improve load test instructions

### DIFF
--- a/.changeset/large-crews-reply.md
+++ b/.changeset/large-crews-reply.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+improve load-test for experimental persistence

--- a/inlang/source-code/sdk/load-test/README.md
+++ b/inlang/source-code/sdk/load-test/README.md
@@ -1,14 +1,13 @@
 # inlang sdk load-test
-
-This repo can be used for volume testing, with more messages than existing unit tests.
+package for volume testing
 
 - The test starts by opening an inlang project with just one english message.
-- It generates additional engish messages, overwriting ./locales/en/common.json.
+- It generates additional engish messages, overwriting either ./locales/en/common.json
+  or ./project.inlang/messages.json (depending on experimental.persistence)
 - It can "mock-translate" those into 37 preconfigured languages using the inlang cli.
 - Lint-rule plugins are configured in the project settings but lint reports are not subscribed, unless requested.
-- The test uses the i18next message storage plugin.
-
-To allow additional testing on the generated project e.g. with the ide-extension, the test calls `pnpm clean` when it starts, but not after it runs.
+- The test uses the i18next message storage plugin (undless experimental.persistence is set)
+- To allow additional testing on the generated project e.g. with the ide-extension, the test calls `pnpm clean` when it starts, but not after it runs.
 
 ```
 USAGE:
@@ -20,37 +19,23 @@ e.g.
 Defaults: translate: 1, subscribeToMessages: 1, subscribeToLintReports: 0, watchMode: 0
 ```
 
-### mock rpc server
-This test expects the rpc server from PR [#2108](https://github.com/opral/monorepo/pull/2108) running on localhost:3000 with MOCK_TRANSLATE=true.
+### to configure additional debug logging
+`export DEBUG=sdk:acquireFileLock,sdk:releaseLock,sdk:lintReports,sdk:loadProject`
 
-```sh
-# in your opral/monorepo
-git checkout 1844-sdk-persistence-of-messages-in-project-direcory
-pnpm install
-pnpm build
-MOCK_TRANSLATE=true pnpm --filter @inlang/server dev
+### to translate from separate process
+1. Run pnpm test with translate:0, watchMode:1 E.g. `pnpm test 100 0 1 1 1`
+2. In another terminal, run `pnpm translate`
+
+### to toggle experimental persistence
+Modify project.inlang/settings.json to add/remove (The whole persistence key must be removed, you cannot set it to false.)
+
+```json
+	"experimental": {
+		"persistence": true
+	}
 ```
 
-### install
-```sh
-git clone https://github.com/opral/load-test.git
-cd load-test
-pnpm install
-```
-This test is also available under /inlang/source-code/sdk/load-test in the monorepo, using workspace:* dependencies.
-
-### run
-```sh
-pnpm test messageCount [translate] [subscribeToMessages] [subscribeToLintReports] [watchMode]
-```
-
-### clean
-Called before each test run, does `rm -rf ./locales`.
-```sh
-pnpm clean
-```
-
-### debug in chrome dev tools with node inspector
+### to debug in chrome dev tools with node inspector
 Passes --inpect-brk to node.
 ```sh
 pnpm inspect messageCount [translate] [subscribeToMessages] [subscribeToLintReports] [watchMode]

--- a/inlang/source-code/sdk/load-test/package.json
+++ b/inlang/source-code/sdk/load-test/package.json
@@ -19,15 +19,15 @@
 	},
 	"scripts": {
 		"clean": "rm -rf ./locales ./project.inlang/messages.json",
-		"translate": "PUBLIC_SERVER_BASE_URL=http://localhost:3000 pnpm inlang machine translate -n -f --project ./project.inlang",
+		"translate": "MOCK_TRANSLATE_LOCAL=1 PUBLIC_SERVER_BASE_URL=http://localhost:3000 pnpm inlang machine translate -n -f --project ./project.inlang",
 		"test-lint": "pnpm inlang lint --project ./project.inlang",
-		"test": "pnpm clean && DEBUG=$DEBUG,load-test tsx ./main.ts",
-		"inspect": "pnpm clean && DEBUG=$DEBUG,load-test tsx --inspect-brk ./main.ts"
+		"test": "pnpm clean && MOCK_TRANSLATE_LOCAL=1 DEBUG=$DEBUG,load-test tsx ./main.ts",
+		"inspect": "pnpm clean && MOCK_TRANSLATE_LOCAL=1 DEBUG=$DEBUG,load-test tsx --inspect-brk ./main.ts"
 	},
 	"prettier": {
 		"semi": false,
 		"useTabs": true,
 		"printWidth": 100
 	},
-	"version": null
+	"version": ""
 }


### PR DESCRIPTION
resolves https://github.com/opral/inlang-message-sdk/issues/52

This removes the need to run a mock translation server. The scripts in package.json automatically set MOCK_TRANSLATE_LOCAL.

###  inlang sdk load-test
package for volume testing

- The test starts by opening an inlang project with just one english message.
- It generates additional engish messages, overwriting either ./locales/en/common.json
  or ./project.inlang/messages.json (depending on experimental.persistence)
- It can "mock-translate" those into 37 preconfigured languages using the inlang cli.
- Lint-rule plugins are configured in the project settings but lint reports are not subscribed, unless requested.
- The test uses the i18next message storage plugin (undless experimental.persistence is set)
- To allow additional testing on the generated project e.g. with the ide-extension, the test calls `pnpm clean` when it starts, but not after it runs.

```
USAGE:
  pnpm test messageCount [translate] [subscribeToMessages] [subscribeToLintReports] [watchMode]
e.g.
  pnpm test 300
  pnpm test 100 1 1 0

Defaults: translate: 1, subscribeToMessages: 1, subscribeToLintReports: 0, watchMode: 0
```

### to configure additional debug logging
`export DEBUG=sdk:acquireFileLock,sdk:releaseLock,sdk:lintReports,sdk:loadProject`

### to translate from separate process
1. Run pnpm test with translate:0, watchMode:1 E.g. `pnpm test 100 0 1 1 1`
2. In another terminal, run `pnpm translate`

### to toggle experimental persistence
Modify project.inlang/settings.json to add/remove (The whole persistence key must be removed, you cannot set it to false.)

```json
	"experimental": {
		"persistence": true
	}
```

### to debug in chrome dev tools with node inspector
Passes --inpect-brk to node.
```sh
pnpm inspect messageCount [translate] [subscribeToMessages] [subscribeToLintReports] [watchMode]
```
