### PR TITLE
Change load-test to write to temp file and then rename

### DIFF
--- a/inlang/source-code/sdk/load-test/.gitignore
+++ b/inlang/source-code/sdk/load-test/.gitignore
@@ -2,3 +2,4 @@ node_modules
 locales
 project.inlang/messages
 project.inlang/messages.json
+project.inlang/temp.json

--- a/inlang/source-code/sdk/load-test/load-test.ts
+++ b/inlang/source-code/sdk/load-test/load-test.ts
@@ -127,6 +127,7 @@ export async function runLoadTest(
 // inlang message format
 async function generateMessageFile(messageCount: number) {
 	if (isExperimentalPersistence) {
+		const tempFile = join(__dirname, "project.inlang", "temp.json")
 		const messageFile = join(__dirname, "project.inlang", "messages.json")
 
 		const messages: Message[] = []
@@ -134,10 +135,13 @@ async function generateMessageFile(messageCount: number) {
 			messages.push(createMessage(`message_key_${i}`, { en: `Generated message (${i})` }))
 		}
 		await fs.writeFile(
-			messageFile,
+			tempFile,
 			JSON.stringify(messages.map(normalizeMessage), undefined, 2),
 			"utf-8"
 		)
+		// overwrites existing messageFile
+		// https://nodejs.org/docs/v20.12.1/api/fs.html#fsrenameoldpath-newpath-callback
+		await fs.rename(tempFile, messageFile)
 	} else {
 		const messageDir = join(__dirname, "locales", "en")
 		const messageFile = join(__dirname, "locales", "en", "common.json")

--- a/inlang/source-code/sdk/load-test/package.json
+++ b/inlang/source-code/sdk/load-test/package.json
@@ -18,7 +18,7 @@
 		"tsx": "^4.7.1"
 	},
 	"scripts": {
-		"clean": "rm -rf ./locales ./project.inlang/messages.json",
+		"clean": "rm -rf ./locales ./project.inlang/messages.json ./project.inlang/temp.json",
 		"translate": "MOCK_TRANSLATE_LOCAL=1 PUBLIC_SERVER_BASE_URL=http://localhost:3000 pnpm inlang machine translate -n -f --project ./project.inlang",
 		"test-lint": "pnpm inlang lint --project ./project.inlang",
 		"test": "pnpm clean && MOCK_TRANSLATE_LOCAL=1 DEBUG=$DEBUG,load-test tsx ./main.ts",


### PR DESCRIPTION
See https://github.com/opral/inlang-message-sdk/issues/53 (MESDK-91)

To repro, build the sdk, then go to the load test directory and run `pnpm test 10 0 1 0 1`. This generates 10 messages, no translation, subscribed to messages.getAll() events, no lint reports, and with watch mode on to prevent the project from exiting. 

```
cd /inlang/source-code/sdk/load-test
pnpm test 10 0 1 0 1
```

Normally using an editor to manually overwrite the messages file in `project.inlang/messages.json` will trigger additional message events (marked with pink below) in the load-test console output on each change. 

With the changes in this PR, those events are not being triggered.

![Screenshot 2024-05-13 at 08 45 06](https://github.com/opral/monorepo/assets/849592/7a4c5ba2-6f0b-4299-a561-1244e88d5894)

 
 