### PR TITLE
MESDK-101 modify load-test to generate messages before loadProject

### DIFF
--- a/inlang/source-code/sdk/load-test/README.md
+++ b/inlang/source-code/sdk/load-test/README.md
@@ -1,12 +1,11 @@
 # inlang sdk load-test
 package for volume testing
 
-- The test starts by opening an inlang project with just one english message.
-- It generates additional engish messages, overwriting either ./locales/en/common.json
+- The test starts by generating engish messages in ./locales/en/common.json
   or ./project.inlang/messages.json (depending on experimental.persistence)
-- It can "mock-translate" those into 37 preconfigured languages using the inlang cli.
-- Lint-rule plugins are configured in the project settings but lint reports are not subscribed, unless requested.
-- The test uses the i18next message storage plugin (undless experimental.persistence is set)
+- It then calls loadProject() and subscribes to events.
+- It mock-translates into 36 languages using the inlang cli.
+- It uses the i18next message storage plugin (unless experimental.persistence is set)
 - To allow additional testing on the generated project e.g. with the ide-extension, the test calls `pnpm clean` when it starts, but not after it runs.
 
 ```

--- a/inlang/source-code/sdk/load-test/load-test.ts
+++ b/inlang/source-code/sdk/load-test/load-test.ts
@@ -52,7 +52,9 @@ export async function runLoadTest(
 		process.exit(0)
 	})
 
-	await generateMessageFile(1)
+	debug(`generating ${messageCount} messages`)
+	// this is called before loadProject() to avoid reading partially written JSON
+	await generateMessageFile(messageCount)
 
 	debug("opening repo and loading project")
 	const repoRoot = await findRepoRoot({ nodeishFs: fs, path: __dirname })
@@ -104,9 +106,6 @@ export async function runLoadTest(
 		})
 	}
 
-	debug(`generating ${messageCount} messages`)
-	await generateMessageFile(messageCount)
-
 	if (translate) {
 		debug("translating messages with inlang cli")
 		await run(translateCommand)
@@ -121,10 +120,6 @@ export async function runLoadTest(
 	}
 }
 
-// experimental persistence message format
-// async function generateMessageFile(messageCount: number) {
-
-// inlang message format
 async function generateMessageFile(messageCount: number) {
 	if (isExperimentalPersistence) {
 		const messageFile = join(__dirname, "project.inlang", "messages.json")


### PR DESCRIPTION
Resolves https://github.com/opral/inlang-message-sdk/issues/62
Alternative to https://github.com/opral/monorepo/pull/2758
