### PR TITLE
Add a `createMessageBundle` utility function

### DIFF
--- a/.changeset/dry-guests-wink.md
+++ b/.changeset/dry-guests-wink.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": minor
+---
+
+Add the `createMessageBundle` test utility function

--- a/inlang/source-code/sdk/package.json
+++ b/inlang/source-code/sdk/package.json
@@ -50,6 +50,7 @@
 		"debug": "^4.3.4",
 		"dedent": "1.5.1",
 		"deepmerge-ts": "^5.1.0",
+		"messageformat": "4.0.0-7",
 		"murmurhash3js": "^3.0.1",
 		"solid-js": "1.6.12",
 		"throttle-debounce": "^5.0.0"

--- a/inlang/source-code/sdk/src/test-utilities/__snapshots__/createMessageBundle.test.ts.snap
+++ b/inlang/source-code/sdk/src/test-utilities/__snapshots__/createMessageBundle.test.ts.snap
@@ -1,0 +1,108 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`createMessageBundle > creates a bundle with messages and an alias 1`] = `
+{
+  "alias": {
+    "default": "hello_world",
+  },
+  "id": "happy_elephant",
+  "messages": [
+    {
+      "declarations": [
+        {
+          "name": "name",
+          "type": "input",
+          "value": {
+            "annotation": undefined,
+            "arg": {
+              "name": "name",
+              "type": "variable",
+            },
+            "type": "expression",
+          },
+        },
+      ],
+      "locale": "en",
+      "selectors": [],
+      "variants": [
+        {
+          "match": [],
+          "pattern": [
+            {
+              "type": "text",
+              "value": "Hello ",
+            },
+            {
+              "annotation": undefined,
+              "arg": {
+                "name": "name",
+                "type": "variable",
+              },
+              "type": "expression",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      "declarations": [
+        {
+          "name": "name",
+          "type": "input",
+          "value": {
+            "annotation": undefined,
+            "arg": {
+              "name": "name",
+              "type": "variable",
+            },
+            "type": "expression",
+          },
+        },
+      ],
+      "locale": "de",
+      "selectors": [
+        {
+          "annotation": undefined,
+          "arg": {
+            "name": "name",
+            "type": "variable",
+          },
+          "type": "expression",
+        },
+      ],
+      "variants": [
+        {
+          "match": [
+            "World",
+          ],
+          "pattern": [
+            {
+              "type": "text",
+              "value": "Hallo Welt",
+            },
+          ],
+        },
+        {
+          "match": [
+            "*",
+          ],
+          "pattern": [
+            {
+              "type": "text",
+              "value": "Hallo ",
+            },
+            {
+              "annotation": undefined,
+              "arg": {
+                "name": "name",
+                "type": "variable",
+              },
+              "type": "expression",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+`;

--- a/inlang/source-code/sdk/src/test-utilities/createMessageBundle.test.ts
+++ b/inlang/source-code/sdk/src/test-utilities/createMessageBundle.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest"
+import { createMessageBundle } from "./createMessageBundle.js"
+import { MessageBundle } from "../v2/types.js"
+import { Value } from "@sinclair/typebox/value"
+
+describe("createMessageBundle", () => {
+	it("creates a bundle with no messages", () => {
+		const bundle: unknown = createMessageBundle({
+			id: "hello_world",
+			messages: {},
+		})
+
+		expect(Value.Check(MessageBundle, bundle)).toBe(true)
+
+		expect(bundle).toEqual({
+			id: "hello_world",
+			alias: {},
+			messages: [],
+		} satisfies MessageBundle)
+	})
+
+	it("creates a bundle with messages and an alias", () => {
+		const bundle: unknown = createMessageBundle({
+			id: "happy_elephant",
+			aliases: {
+				default: "hello_world",
+			},
+			messages: {
+				en: ".input {$name} {{Hello {$name}}}",
+				de: ".input {$name} .match {$name} World {{Hallo Welt}} * {{Hallo {$name}}}",
+			},
+		})
+
+		expect(Value.Check(MessageBundle, bundle)).toBe(true)
+		expect(bundle).toMatchSnapshot()
+	})
+})

--- a/inlang/source-code/sdk/src/test-utilities/createMessageBundle.ts
+++ b/inlang/source-code/sdk/src/test-utilities/createMessageBundle.ts
@@ -1,0 +1,117 @@
+import * as MF from "messageformat"
+import type * as AST from "../v2/types.js"
+
+/**
+ * Utility function to generate message bundles for tests
+ *
+ * @throws if the given source-strings aren't valid or not representable
+ */
+export function createMessageBundle(bundleOptions: {
+	id: string
+	aliases?: Record<string, string>
+	/**
+	 * A map of languages to ICU MessageFormat 2 message strings
+	 */
+	messages: Record<string, string>
+}): AST.MessageBundle {
+	const bundle: AST.MessageBundle = {
+		id: bundleOptions.id,
+		alias: bundleOptions.aliases || {},
+
+		messages: Object.entries(bundleOptions.messages).map(([locale, source]) =>
+			parseICUMessage(locale, source)
+		),
+	}
+
+	return bundle
+}
+
+function parseICUMessage(locale: string, source: string): AST.Message {
+	const ast = MF.parseMessage(source)
+	const declarations = ast.declarations.map(toDeclaration)
+
+	switch (ast.type) {
+		case "message": {
+			return {
+				locale,
+				declarations,
+				selectors: [],
+				variants: [
+					{
+						match: [],
+						pattern: toPattern(ast.pattern),
+					},
+				],
+			}
+		}
+		case "select": {
+			return {
+				locale,
+				declarations,
+				selectors: ast.selectors.map(toExpression),
+				variants: ast.variants.map(toVariant),
+			}
+		}
+	}
+}
+
+function toVariant(mfVariant: MF.Variant): AST.Variant {
+	return {
+		match: mfVariant.keys.map((key) => (key.type === "literal" ? key.value : "*")),
+		pattern: toPattern(mfVariant.value),
+	}
+}
+
+function toDeclaration(mfDeclaration: MF.Declaration): AST.Declaration {
+	switch (mfDeclaration.type) {
+		case "input": {
+			return {
+				type: mfDeclaration.type,
+				name: mfDeclaration.name,
+				value: toExpression(mfDeclaration.value),
+			}
+		}
+		default: {
+			throw new Error("Unsupported declaration type: " + mfDeclaration.type)
+		}
+	}
+}
+
+function toPattern(mfPattern: MF.Pattern): AST.Pattern {
+	return mfPattern.map((element) => {
+		if (typeof element == "string")
+			return {
+				type: "text",
+				value: element,
+			}
+
+		if (element.type === "expression") return toExpression(element)
+		throw new Error("Unknown pattern element type: " + element.type)
+	})
+}
+
+function toExpression(mfExpression: MF.Expression): AST.Expression {
+	const annotation = mfExpression.annotation
+	const arg = mfExpression.arg
+	if (!arg) throw new Error()
+	return {
+		type: "expression",
+		arg,
+		annotation: annotation ? toAnnotation(annotation) : undefined,
+	}
+}
+
+function toAnnotation(
+	mfAnnotation: MF.FunctionAnnotation | MF.UnsupportedAnnotation
+): AST.FunctionAnnotation {
+	if (mfAnnotation.type !== "function") throw new Error("Junk annotation")
+	return {
+		type: "function",
+		name: mfAnnotation.name,
+		options:
+			mfAnnotation.options?.map((mfOption) => ({
+				name: mfOption.name,
+				value: mfOption.value,
+			})) || [],
+	}
+}

--- a/inlang/source-code/sdk/src/test-utilities/index.ts
+++ b/inlang/source-code/sdk/src/test-utilities/index.ts
@@ -1,2 +1,3 @@
 export { createMessage } from "./createMessage.js"
 export { createNodeishMemoryFs } from "@lix-js/fs"
+export { createMessageBundle } from "./createMessageBundle.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2259,6 +2259,9 @@ importers:
       deepmerge-ts:
         specifier: ^5.1.0
         version: 5.1.0
+      messageformat:
+        specifier: 4.0.0-7
+        version: 4.0.0-7
       murmurhash3js:
         specifier: ^3.0.1
         version: 3.0.1
@@ -11779,6 +11782,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  messageformat@4.0.0-7:
+    resolution: {integrity: sha512-e7Ev5SNMHQ02dZPlc2blZWum1kB2B3jGQAskO97cZd9H/Eo8BF1GMhigswTNbh/2itpbDqa0jtBz9+VcRgfiQA==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -27437,6 +27443,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  messageformat@4.0.0-7: {}
 
   methods@1.1.2: {}
 


### PR DESCRIPTION
This PR adds a `createMessageBundle` utility function to the SDK.

Example usage
```ts

const bundle = createMessageBundle({
  id: "happy_elephant",

  //optionally define aliases
  alias: {
    "default": "hello_world"
  },
  
  // define a map of messages for all the languages you want. 
  // ICU MF 2 strings are used
  // Throws error if the ICU string cannot be represented using our AST
  messages: {
    en: ".input {$name} {{Hello {$name}}}",
    de: ".input {$name} .match {$name} World {{Hallo Welt}} * {{Hallo {$name}}}",
  },
})
```

Exported from `@inlang/sdk/test-utilities`