### PR TITLE
MESDK-72 Cleanup comments and debug-logging

### DIFF
--- a/.changeset/big-yaks-give.md
+++ b/.changeset/big-yaks-give.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Minor debug logging improvements

--- a/inlang/source-code/sdk/src/api.ts
+++ b/inlang/source-code/sdk/src/api.ts
@@ -65,7 +65,7 @@ export type InlangProject = {
 
 /**
  * WIP template for async V2 crud interfaces
- * E.g. `project.messageBundles.get({ id: "..." })`
+ * E.g. `await project.messageBundles.get({ id: "..." })`
  **/
 interface Query<T> {
 	get: (args: unknown) => Promise<T>

--- a/inlang/source-code/sdk/src/createMessageLintReportsQuery.ts
+++ b/inlang/source-code/sdk/src/createMessageLintReportsQuery.ts
@@ -10,12 +10,19 @@ import type { resolveModules } from "./resolve-modules/index.js"
 import type { MessageLintReport, Message } from "./versionedInterfaces.js"
 import { lintSingleMessage } from "./lint/index.js"
 
+import _debug from "debug"
+const debug = _debug("sdk:lintReports")
+
 function sleep(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 /**
- * Creates a ~~reactive~~ query API for lint reports.
+ * Creates a non-reactive async query API for lint reports.
+ * e.g. used in editor/.../Listheader.tsx
+ *
+ * TODO MESDK-50: reactivity should be restored in future
+ * See https://github.com/opral/monorepo/pull/2378 for why this design.
  */
 export function createMessageLintReportsQuery(
 	messagesQuery: MessageQueryApi,
@@ -51,7 +58,7 @@ export function createMessageLintReportsQuery(
 			message: message,
 		}).then((report) => {
 			if (report.errors.length === 0 && index.get(message.id) !== report.data) {
-				// console.log("lintSingleMessage", messageId, report.data.length)
+				debug("lintSingleMessage", message.id, report.data.length)
 				index.set(message.id, report.data)
 			}
 		})
@@ -90,12 +97,13 @@ export function createMessageLintReportsQuery(
 	return {
 		getAll: async () => {
 			await sleep(0) // evaluate on next tick to allow for out-of-order effects
-			return structuredClone(
-				[...index.values()].flat().length === 0 ? [] : [...index.values()].flat()
-			)
+			const flatValues = [...index.values()].flat()
+			debug("getAll", flatValues.length)
+			return structuredClone(flatValues.length === 0 ? [] : flatValues)
 		},
 		get: async (args: Parameters<MessageLintReportsQueryApi["get"]>[0]) => {
 			await sleep(0) // evaluate on next tick to allow for out-of-order effects
+			debug("get", args.where.messageId)
 			return structuredClone(index.get(args.where.messageId) ?? [])
 		},
 	}

--- a/inlang/source-code/sdk/src/createMessagesQuery.ts
+++ b/inlang/source-code/sdk/src/createMessagesQuery.ts
@@ -15,7 +15,7 @@ import type { ProjectSettings } from "@inlang/project-settings"
 import { releaseLock } from "./persistence/filelock/releaseLock.js"
 import { PluginLoadMessagesError, PluginSaveMessagesError } from "./errors.js"
 import { humanIdHash } from "./storage/human-id/human-readable-id.js"
-const debug = _debug("sdk:createMessagesQuery")
+const debug = _debug("sdk:messages")
 
 function sleep(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms))

--- a/inlang/source-code/sdk/src/createNewProject.ts
+++ b/inlang/source-code/sdk/src/createNewProject.ts
@@ -6,11 +6,6 @@ import { defaultProjectSettings } from "./defaultProjectSettings.js"
 /**
  * Creates a new project in the given directory.
  * The directory must be an absolute path, must not exist, and must end with {name}.inlang
- * Uses defaultProjectSettings unless projectSettings are provided.
- *
- * @param projectPath - Absolute path to the [name].inlang directory
- * @param repo - An instance of a lix repo as returned by `openRepository`
- * @param projectSettings - Optional project settings to use for the new project.
  */
 export async function createNewProject(args: {
 	projectPath: string

--- a/inlang/source-code/sdk/src/persistence/filelock/acquireFileLock.ts
+++ b/inlang/source-code/sdk/src/persistence/filelock/acquireFileLock.ts
@@ -1,7 +1,7 @@
 import { type NodeishFilesystem } from "@lix-js/fs"
 import type { NodeishStats } from "@lix-js/fs"
 import _debug from "debug"
-const debug = _debug("sdk:acquireFileLock")
+const debug = _debug("sdk:fileLock")
 
 const maxRetries = 10
 const nProbes = 50
@@ -13,7 +13,9 @@ export async function acquireFileLock(
 	tryCount: number = 0
 ): Promise<number> {
 	if (tryCount > maxRetries) {
-		throw new Error(lockOrigin + " exceeded maximum Retries (5) to acquire lockfile " + tryCount)
+		throw new Error(
+			`${lockOrigin} exceeded maximum retries (${maxRetries}) to acquire lockfile ${tryCount}`
+		)
 	}
 
 	try {

--- a/inlang/source-code/sdk/src/persistence/filelock/releaseLock.ts
+++ b/inlang/source-code/sdk/src/persistence/filelock/releaseLock.ts
@@ -1,6 +1,6 @@
 import { type NodeishFilesystem } from "@lix-js/fs"
 import _debug from "debug"
-const debug = _debug("sdk:releaseLock")
+const debug = _debug("sdk:fileLock")
 
 export async function releaseLock(
 	fs: NodeishFilesystem,


### PR DESCRIPTION
export `DEBUG=sdk:*` or one or more of the following (comma separated)

```
sdk:lintReports
sdk:messages
sdk:loadProject
sdk:persistence
sdk:fileLock
sdk:resolvePlugins
```
 