### PR TITLE
Update MARKETPLACE.md

### DIFF
--- a/inlang/source-code/ide-extension/MARKETPLACE.md
+++ b/inlang/source-code/ide-extension/MARKETPLACE.md
@@ -16,7 +16,7 @@ Sherlock is a powerful [open-source](https://github.com/opral/monorepo/tree/main
 View translations within your code, extract new strings with a simple click, and effortlessly edit translated strings using Inline Decorations & Hover Support. Get notified of missing translations and other issues in real-time directly in your IDE.
 
 <doc-features>
-  <doc-feature text-color="#000000" color="#F7FAFC" title="Inline Annotaions" image="https://cdn.jsdelivr.net/gh/opral/monorepo/inlang/source-code/ide-extension/assets/ide-inline-small.png"></doc-feature>
+  <doc-feature text-color="#000000" color="#F7FAFC" title="Inline Annotations" image="https://cdn.jsdelivr.net/gh/opral/monorepo/inlang/source-code/ide-extension/assets/ide-inline-small.png"></doc-feature>
   <doc-feature text-color="#000000" color="#F7FAFC" title="Lint messages" image="https://cdn.jsdelivr.net/gh/opral/monorepo/inlang/source-code/ide-extension/assets/ide-lint-small.png"></doc-feature>
   <doc-feature text-color="#000000" color="#F7FAFC" title="Extract Messages" image="https://cdn.jsdelivr.net/gh/opral/monorepo/inlang/source-code/ide-extension/assets/ide-extract-small.png"></doc-feature>
 </doc-features>


### PR DESCRIPTION
Typo fix: add missing second 't' to Annotations

<img width="306" alt="typo" src="https://github.com/opral/monorepo/assets/937917/6ac7a396-5856-4d77-b73e-b36ff84288f8">
