### PR TITLE
Lorissigrist/parjs 126 support rune syntax in paraglide sveltekit

### DIFF
--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/vite/preprocessor/index.test.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/vite/preprocessor/index.test.ts
@@ -341,6 +341,18 @@ describe.concurrent(
 			const html = await renderComponent(code)
 			expect(html).toMatchInlineSnapshot('"<a href=\\"/rewritten\\">test</a>"')
 		})
+
+		it("handles rune with shorthand", async ({ expect }) => {
+			const code = `
+        <script>
+            const href = $state("/test")
+        </script>
+		<a {href}>test</a>
+		`
+
+			const html = await renderComponent(code)
+			expect(html).toMatchInlineSnapshot('"<a href=\\"/rewritten\\">test</a>"')
+		})
 	},
 	{ timeout: 60_000 }
 )

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/vite/preprocessor/index.test.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/vite/preprocessor/index.test.ts
@@ -318,7 +318,7 @@ describe.concurrent(
 			)
 		})
 
-		it("rewrites hrefs in svelte 5 components", async ({ expect }) => {
+		it("rewrites hrefs in components with snippets", async ({ expect }) => {
 			const code = `
 				{#snippet myLink(href)}
 				<a href={href}>content</a>
@@ -328,6 +328,18 @@ describe.concurrent(
 				`
 			const html = await renderComponent(code)
 			expect(html).toMatchInlineSnapshot('"<a href=\\"/rewritten\\">content</a>"')
+		})
+
+		it("handles rune syntax", async ({ expect }) => {
+			const code = `
+        <script>
+            const href = $state("/test")
+        </script>
+		<a href={href}>test</a>
+		`
+
+			const html = await renderComponent(code)
+			expect(html).toMatchInlineSnapshot('"<a href=\\"/rewritten\\">test</a>"')
 		})
 	},
 	{ timeout: 60_000 }


### PR DESCRIPTION
Adds tests to ensure that rune-syntax is supported in Paraglide-SvelteKit. Seems like it already was thanks to the Svelte 5 parser migration I did last week! 