### PR TITLE
Sort & Normalize Messages before hashing

### DIFF
--- a/.changeset/tall-pumas-talk.md
+++ b/.changeset/tall-pumas-talk.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-unplugin": patch
+---
+
+Better hashing to avoid unnecessary recompilations

--- a/inlang/source-code/paraglide/paraglide-unplugin/src/index.test.ts
+++ b/inlang/source-code/paraglide/paraglide-unplugin/src/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest"
+import { hashMessages } from "./index.js"
+import type { Message, ProjectSettings } from "@inlang/sdk"
+
+describe("hashMessages", () => {
+	it("should return the same hash for the same set of messages", () => {
+		const messages1: Message[] = [
+			{ id: "foo", alias: {}, variants: [], selectors: [] },
+			{ id: "bar", alias: {}, variants: [], selectors: [] },
+		]
+
+		const messages2: Message[] = [
+			{ id: "bar", alias: {}, variants: [], selectors: [] },
+			{ id: "foo", alias: {}, variants: [], selectors: [] },
+		]
+
+		const settings: ProjectSettings = { modules: [], languageTags: [], sourceLanguageTag: "en" }
+
+		expect(hashMessages(messages1, settings)).toBe(hashMessages(messages2, settings))
+	})
+
+	it("should return the same hash even if variants aren't in the same order", () => {
+		const messages1: Message[] = [
+			{
+				id: "foo",
+				alias: {},
+				variants: [
+					{
+						languageTag: "en",
+						match: [],
+						pattern: [],
+					},
+					{
+						languageTag: "de",
+						match: [],
+						pattern: [],
+					},
+				],
+				selectors: [],
+			},
+		]
+
+		const messages2: Message[] = [
+			{
+				id: "foo",
+				alias: {},
+				variants: [
+					{
+						languageTag: "de",
+						match: [],
+						pattern: [],
+					},
+					{
+						languageTag: "en",
+						match: [],
+						pattern: [],
+					},
+				],
+				selectors: [],
+			},
+		]
+
+		const settings: ProjectSettings = { modules: [], languageTags: [], sourceLanguageTag: "en" }
+
+		expect(hashMessages(messages1, settings)).toBe(hashMessages(messages2, settings))
+	})
+})

--- a/inlang/source-code/paraglide/paraglide-unplugin/src/index.ts
+++ b/inlang/source-code/paraglide/paraglide-unplugin/src/index.ts
@@ -1,5 +1,11 @@
 import { createUnplugin } from "unplugin"
-import { Message, ProjectSettings, loadProject, type InlangProject } from "@inlang/sdk"
+import {
+	Message,
+	ProjectSettings,
+	loadProject,
+	type InlangProject,
+	normalizeMessage,
+} from "@inlang/sdk"
 import { openRepository, findRepoRoot } from "@lix-js/client"
 import path from "node:path"
 import fs from "node:fs/promises"
@@ -155,11 +161,15 @@ export const paraglide = createUnplugin((config: UserConfig) => {
 	]
 })
 
-function hashMessages(messages: readonly Message[], settings: ProjectSettings): string {
+export function hashMessages(messages: readonly Message[], settings: ProjectSettings): string {
+	const normalizedMessages = messages
+		.map(normalizeMessage)
+		.sort((a, b) => a.id.localeCompare(b.id, "en"))
+
 	try {
 		const hash = crypto.createHash("sha256")
-		hash.update(JSON.stringify(messages) || "")
-		hash.update(JSON.stringify(settings) || "")
+		hash.update(JSON.stringify(normalizedMessages))
+		hash.update(JSON.stringify(settings))
 		return hash.digest("hex")
 	} catch (e) {
 		return crypto.randomUUID()


### PR DESCRIPTION
This PR updates the hashing behavior in Paraglide-Unplugin to first normalize & sort messages. This should eliminate most false negatives & help avoid unnecessary recompilations