### PR TITLE
introduces sollid batching for loadMessagesViaPlugin

### DIFF
--- a/.changeset/smart-terms-destroy.md
+++ b/.changeset/smart-terms-destroy.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+introduces solid batching for loadViaPlugin

--- a/inlang/source-code/sdk/src/adapter/solidAdapter.test.ts
+++ b/inlang/source-code/sdk/src/adapter/solidAdapter.test.ts
@@ -222,7 +222,7 @@ describe("messages", () => {
 		// TODO: how can we await `setConfig` correctly
 		await new Promise((resolve) => setTimeout(resolve, 510))
 
-		expect(effectOnMessagesCounter).toBe(3) // 3 = setSetting, loadMessage (2x - one per message)
+		expect(effectOnMessagesCounter).toBe(2) // 2 = setSetting (clearing the message index), subsequencial loadMessage call
 		expect(Object.values(project.query.messages.getAll()).length).toBe(2)
 	})
 


### PR DESCRIPTION
Previously we executed message updates in batches (500 updates per batch) and waited for the next tick to mitigate the mass production of cached triggeres in ReactiveMap.

We mitigate the problem of trigger production by batching all changes to the reactive map and reduce signal production to one per loadMessagesViaPlugin call instead. 

This means getAll() and get() signals are produced once per message load instead of per message changed when messages loaded from a plugin. 

Example results of load-test executed with `pnpm run load-test 10000 1 1 1`
```
ℹ Machine translated message "message_key_9993"                                             12:22:46 PM
ℹ Machine translated message "message_key_9994"                                             12:22:46 PM
ℹ Machine translated message "message_key_9995"                                             12:22:46 PM
ℹ Machine translated message "message_key_9996"                                             12:22:46 PM
ℹ Machine translated message "message_key_9997"                                             12:22:46 PM
ℹ Machine translated message "message_key_9998"                                             12:22:46 PM
ℹ Machine translated message "message_key_9999"                                             12:22:46 PM
ℹ Machine translated message "message_key_10000"                                            12:22:46 PM
✔ Machine translate complete.                                                               12:22:46 PM
  load-test messages getAll event: 2, length: 10000 +12s
  load-test lint reports changed event: 2, length: 0 +95ms
  load-test load-test done - exiting +8s
```

closes https://github.com/opral/inlang-message-sdk/issues/72