### PR TITLE
PARJS-26  Paraglide-SvelteKit Local types

### DIFF
--- a/.changeset/odd-papayas-talk.md
+++ b/.changeset/odd-papayas-talk.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-sveltekit": minor
+---
+
+Add the `ParaglideLocals` interface for properly typing paraglide's locals. It should be added in `app.d.ts` under `Locals.paraglide`. The `init` CLI will do this automatically

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/app.d.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/app.d.ts
@@ -1,9 +1,14 @@
+import type { AvailableLanguageTag } from "$lib/paraglide/runtime"
+import type { ParaglideLocals } from "@inlang/paraglide-sveltekit"
+
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			paraglide: ParaglideLocals<AvailableLanguageTag>
+		}
 		// interface PageData {}
 		// interface Platform {}
 	}

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/lib/i18n.js
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/lib/i18n.js
@@ -1,7 +1,7 @@
 import { createI18n } from "@inlang/paraglide-sveltekit"
 import { match as int } from "../params/int"
-import * as runtime from "$paraglide/runtime.js"
-import * as m from "$paraglide/messages.js"
+import * as runtime from "$lib/paraglide/runtime.js"
+import * as m from "$lib/paraglide/messages.js"
 
 export const i18n = createI18n(runtime, {
 	pathnames: {

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/lib/ui/Header.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/lib/ui/Header.svelte
@@ -1,7 +1,7 @@
 <script>
 	import LanguageSwitcher from "./LanguageSwitcher.svelte"
     import { page } from "$app/stores";
-    import * as m from "$paraglide/messages.js"
+    import * as m from "$lib/paraglide/messages.js"
 </script>
 <header>
     <nav>

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/lib/ui/LanguageSwitcher.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/lib/ui/LanguageSwitcher.svelte
@@ -1,12 +1,12 @@
 <script>
-    import { availableLanguageTags, languageTag } from "$paraglide/runtime";
+    import { availableLanguageTags, languageTag } from "$lib/paraglide/runtime";
     import { i18n } from "$lib/i18n";
 	import { goto } from "$app/navigation"
     import { page } from "$app/stores";
 	import { get } from "svelte/store"
 
     /**
-     * @param { import("$paraglide/runtime").AvailableLanguageTag } newLanguage
+     * @param { import("$lib/paraglide/runtime").AvailableLanguageTag } newLanguage
      */
     function switchToLanguage(newLanguage) {
         const canonicalPath = i18n.route(get(page).url.pathname)
@@ -15,7 +15,7 @@
     }
 
     /**
-     * @type {Record<import("$paraglide/runtime").AvailableLanguageTag, string>}
+     * @type {Record<import("$lib/paraglide/runtime").AvailableLanguageTag, string>}
      */
     const labels = {
         en: "🇬🇧 English",

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/+page.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import * as m from "$paraglide/messages.js"
+	import * as m from "$lib/paraglide/messages.js"
 </script>
 
 

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/about/+page.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/about/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-    import * as m from "$paraglide/messages.js"
+    import * as m from "$lib/paraglide/messages.js"
 </script>
 
 <h1>{m.about()}</h1>

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/users/[id]/+page.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/users/[id]/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { page } from "$app/stores"
     import { base, resolveRoute } from "$app/paths"
-    import * as m from "$paraglide/messages.js"
+    import * as m from "$lib/paraglide/messages.js"
 
     const totalUsers = 10;
 

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/users/[id]/edit/+page.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/users/[id]/edit/+page.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { page } from "$app/stores"
-    import * as m from "$paraglide/messages.js"
+    import * as m from "$lib/paraglide/messages.js"
 
     $: userId = Number.parseFloat($page.params.id);
 </script>

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/svelte.config.js
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/svelte.config.js
@@ -6,11 +6,6 @@ const config = {
 	preprocess: [vitePreprocess()],
 	kit: {
 		adapter: adapter(),
-
-		alias: {
-			$paraglide: "./src/paraglide/",
-			$lib: "./src/lib/",
-		},
 		prerender: {
 			//Needed for correctly prerendering <link rel="alternate" hreflang="x" href="y">
 			origin: "https://example.com",

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/vite.config.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 	plugins: [
 		paraglide({
 			project: "./project.inlang",
-			outdir: "./src/paraglide",
+			outdir: "./src/lib/paraglide",
 		}),
 		sveltekit(),
 		visualizer({

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/commands/inits.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/commands/inits.ts
@@ -11,6 +11,7 @@ import { editAppHtmlFile } from "../steps/editAppHtmlFile.js"
 import { addRerouteHook } from "../steps/addRerouteFile.js"
 import { addHandleHook } from "../steps/addHandleHook.js"
 import { PARAGLIDE_SVELTEKIT_VERSION, PARAGLIDE_SVELTEKIT_MARKETPLACE_ID } from "../../meta.js"
+import { addTypesForLocals } from "../steps/updateAppTypes.js"
 
 export const initCommand = new Command()
 	.name("init")
@@ -54,11 +55,12 @@ export const initCommand = new Command()
 		const ctx8 = await editAppHtmlFile(ctx7)
 		const ctx9 = await addRerouteHook(ctx8)
 		const ctx10 = await addHandleHook(ctx9)
-		const ctx11 = await Steps.maybeAddSherlock(ctx10)
-		const crx12 = await Steps.maybeAddNinja(ctx11)
+		const ctx11 = await addTypesForLocals(ctx10)
+		const crx12 = await Steps.maybeAddSherlock(ctx11)
+		const crx13 = await Steps.maybeAddNinja(crx12)
 
 		try {
-			await Steps.runCompiler({ ...crx12, outdir: "./src/lib/paraglide" })
+			await Steps.runCompiler({ ...crx13, outdir: "./src/lib/paraglide" })
 		} catch (e) {
 			//silently ignore
 		}

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/steps/updateAppTypes.test.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/steps/updateAppTypes.test.ts
@@ -20,16 +20,14 @@ export {}`
 		expect(result.ok).toBe(true)
 		expect(result.updated).toMatchInlineSnapshot(`
 			"import type { AvailableLanguageTag } from \\"$lib/paraglide/runtime\\"
+			import type { ParaglideLocals } from \\"@inlang/paraglide-sveltekit\\"
 			// See https://kit.svelte.dev/docs/types#app
 			// for information about these interfaces
 			declare global {
 				namespace App {
 					// interface Error {}
 					 interface Locals {
-			    paraglide: {
-			        lang: AvailableLanguageTag,
-			        textDirection: 'ltr' | 'rtl'
-			    },
+			    paraglide: ParaglideLocals<AvailableLanguageTag>,
 			}
 					// interface PageData {}
 					// interface Platform {}

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/steps/updateAppTypes.test.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/steps/updateAppTypes.test.ts
@@ -1,0 +1,42 @@
+import { updateAppDTsFile } from "./updateAppTypes"
+import { describe, it, expect } from "vitest"
+
+describe("updateAppDTsFile", () => {
+	it("updates the default dts file", () => {
+		const file = `// See https://kit.svelte.dev/docs/types#app
+// for information about these interfaces
+declare global {
+	namespace App {
+		// interface Error {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface Platform {}
+	}
+}
+
+export {}`
+
+		const result = updateAppDTsFile(file)
+		expect(result.ok).toBe(true)
+		expect(result.updated).toMatchInlineSnapshot(`
+			"import type { AvailableLanguageTag } from \\"$lib/paraglide/runtime\\"
+			// See https://kit.svelte.dev/docs/types#app
+			// for information about these interfaces
+			declare global {
+				namespace App {
+					// interface Error {}
+					 interface Locals {
+			    paraglide: {
+			        lang: AvailableLanguageTag,
+			        textDirection: 'ltr' | 'rtl'
+			    },
+			}
+					// interface PageData {}
+					// interface Platform {}
+				}
+			}
+
+			export {}"
+		`)
+	})
+})

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/steps/updateAppTypes.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/steps/updateAppTypes.ts
@@ -29,11 +29,15 @@ type UpdateResult =
  */
 export function updateAppDTsFile(code: string): UpdateResult {
 	// add the type import
-	if (code.includes("AvailableLanguageTag")) {
+	if (code.includes("AvailableLanguageTag") || code.includes("ParaglideLocals")) {
 		return { ok: false, reason: "Paraglide types already present" }
 	}
 
-	code = 'import type { AvailableLanguageTag } from "$lib/paraglide/runtime"\n' + code
+	code = [
+		'import type { AvailableLanguageTag } from "$lib/paraglide/runtime"',
+		'import type { ParaglideLocals } from "@inlang/paraglide-sveltekit"',
+		code,
+	].join("\n")
 
 	const LocalsInterfaceRegex = /interface\s+Locals\s*\{/g
 	const match = LocalsInterfaceRegex.exec(code)
@@ -50,9 +54,7 @@ export function updateAppDTsFile(code: string): UpdateResult {
 	beforeLines[beforeLines.length - 1] = beforeLines.at(-1)?.replace("//", "") || ""
 
 	code =
-		beforeLines.join("\n") +
-		"\n    paraglide: {\n        lang: AvailableLanguageTag,\n        textDirection: 'ltr' | 'rtl'\n    },\n" +
-		after
+		beforeLines.join("\n") + "\n    paraglide: ParaglideLocals<AvailableLanguageTag>,\n" + after
 
 	return {
 		ok: true,

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/steps/updateAppTypes.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/cli/steps/updateAppTypes.ts
@@ -1,0 +1,61 @@
+import type { Repository } from "@lix-js/client"
+import type { Logger } from "@inlang/paraglide-js/internal"
+import type { CliStep } from "../utils.js"
+
+export const updateAppTypes: CliStep<
+	{
+		repo: Repository
+		logger: Logger
+	},
+	unknown
+> = async (ctx) => {
+	return ctx
+}
+
+type UpdateResult =
+	| {
+			ok: true
+			updated: string
+			reason?: undefined
+	  }
+	| {
+			ok: false
+			reason: string
+			updated?: undefined
+	  }
+
+/**
+ * @private
+ */
+export function updateAppDTsFile(code: string): UpdateResult {
+	// add the type import
+	if (code.includes("AvailableLanguageTag")) {
+		return { ok: false, reason: "Paraglide types already present" }
+	}
+
+	code = 'import type { AvailableLanguageTag } from "$lib/paraglide/runtime"\n' + code
+
+	const LocalsInterfaceRegex = /interface\s+Locals\s*\{/g
+	const match = LocalsInterfaceRegex.exec(code)
+	if (!match) {
+		return { ok: false, reason: "Could not find the Locals interface" }
+	}
+
+	// add the type to the Locals interface
+	const endIndex = match.index + match[0].length
+	const before = code.slice(0, endIndex)
+	const after = code.slice(endIndex)
+
+	const beforeLines = before.split("\n")
+	beforeLines[beforeLines.length - 1] = beforeLines.at(-1)?.replace("//", "") || ""
+
+	code =
+		beforeLines.join("\n") +
+		"\n    paraglide: {\n        lang: AvailableLanguageTag,\n        textDirection: 'ltr' | 'rtl'\n    },\n" +
+		after
+
+	return {
+		ok: true,
+		updated: code,
+	}
+}

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.ts
@@ -5,6 +5,7 @@ import { negotiateLanguagePreferences } from "@inlang/paraglide-js/internal/adap
 import { base } from "$app/paths"
 import { dev } from "$app/environment"
 import type { RoutingStrategy } from "../strategy.js"
+import type { ParaglideLocals } from "../locals.js"
 
 const LANG_COOKIE_NAME = "paraglide:lang"
 
@@ -95,10 +96,14 @@ export const createHandle = <T extends string>(
 
 		const textDirection = i18n.textDirection[lang as T] ?? "ltr"
 
-		event.locals.paraglide = {
+		const paraglideLocals: ParaglideLocals<T> = {
 			lang,
 			textDirection,
 		}
+
+		// @ts-expect-error
+		// The user needs to have the ParaglideLocals type in their app.d.ts file
+		event.locals.paraglide = paraglideLocals
 
 		return resolve(event, {
 			transformPageChunk({ html, done }) {
@@ -129,14 +134,3 @@ export const createHandle = <T extends string>(
 	}
 }
 
-declare global {
-	// eslint-disable-next-line @typescript-eslint/no-namespace
-	namespace App {
-		interface Locals {
-			paraglide: {
-				lang: string
-				textDirection: "ltr" | "rtl"
-			}
-		}
-	}
-}

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/index.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/index.ts
@@ -1,2 +1,3 @@
 export { default as ParaglideJS } from "./ParaglideJS.svelte"
 export { createI18n } from "./adapter.js"
+export type { ParaglideLocals } from "./locals.js"

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/locals.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/locals.ts
@@ -1,0 +1,22 @@
+/**
+ * The interface for Paraglide's Locals, available under `event.locals.paraglide`
+ *
+ * @example
+ * ```ts
+ * // src/app.d.ts
+ * import type { AvailableLanguageTag } from "$lib/paraglide/runtime"
+ * import type { ParaglideLocals } from "@inlang/paraglide-sveltekit"
+ *
+ * declare global {
+ *   namespace App {
+ *     interface Locals {
+ *       paraglide: ParaglideLocals<AvailableLanguageTag>
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export type ParaglideLocals<T extends string> = {
+	lang: T
+	textDirection: "ltr" | "rtl"
+}


### PR DESCRIPTION
This PR changes how Paraglide-SvelteKit adds `locals`. It is now done by adding the `ParaglideLocals` in `app.d.ts`. This makes it more transparent where the locals come from and gives devs the opportunity to edit / override them.

The `init` cli adds the types automatically. 