### PR TITLE
Paraglide-SvelteKit Gracefully handle Parse errors

### DIFF
--- a/.changeset/nine-hairs-run.md
+++ b/.changeset/nine-hairs-run.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-sveltekit": patch
+---
+
+The link preprocessor no longer crashes when encountering a file with a syntax error. Insetad it will log a warning & noop. Reporting the error is delegated to the main svelte parser.

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/vite/preprocessor/index.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/vite/preprocessor/index.ts
@@ -2,7 +2,6 @@ import { parse, type PreprocessorGroup, type LegacyRoot } from "svelte/compiler"
 import MagicString from "magic-string"
 import { shouldApply } from "./precheck.js"
 import { rewrite } from "./rewrite.js"
-import dedent from "dedent"
 
 export type PreprocessorConfig = Record<string, never>
 
@@ -63,13 +62,12 @@ export function preprocessor(_config: PreprocessorConfig): PreprocessorGroup {
 			try {
 				root = parse(content)
 			} catch (error) {
-				throw new Error(
-					dedent`
-						[@inlang/paraglide-sveltekit] Failed to parse ${filename}. 
-						This may be because you are using a signifficantly newer version of the "svelte" package. 
-						Try forcing "@inlang/paraglide-sveltekit" to use your version of "svelte" using pnpm overrides`,
-					{ cause: error }
+				console.error(
+					`[@inlang/paraglide-sveltekit] Failed to parse ${filename}. Link translations were NOT applied.`,
+					error
 				)
+
+				return NOOP
 			}
 
 			const code = new MagicString(content)


### PR DESCRIPTION
This PR changes how Paraglide-SvelteKit deals with parse errors. 
Previously it would crash. Now it instead logs a warning & noops. Handling the Syntax error is deferred to the svelte-compiler, which is where devs expect the errors to come from. 