### PR TITLE
PARJS-139: Paraglide next init cli does not reliably detect pages/app router

### DIFF
--- a/.changeset/empty-humans-flow.md
+++ b/.changeset/empty-humans-flow.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-next": patch
+---
+
+`init` command now prompts which router is being used if it cannot automatically determined from the File-System

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/flows/scan-next-project/index.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/flows/scan-next-project/index.ts
@@ -43,13 +43,9 @@ export const scanNextJSProject: CliStep<
 		process.exit(1)
 	}
 
-	// try to read tsconfig or JSConfig
-	const tsConfigPath = path.join(process.cwd(), "tsconfig.json")
-	const jsConfigPath = path.join(process.cwd(), "jsconfig.json")
-
 	const [tsConfigExists, jsConfigExists] = await Promise.all([
-		fileExists(ctx.repo.nodeishFs, tsConfigPath),
-		fileExists(ctx.repo.nodeishFs, jsConfigPath),
+		fileExists(ctx.repo.nodeishFs, path.join(process.cwd(), "tsconfig.json")),
+		fileExists(ctx.repo.nodeishFs, path.join(process.cwd(), "jsconfig.json")),
 	])
 
 	const typescript = tsConfigExists && !jsConfigExists

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/utils.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/utils.ts
@@ -72,3 +72,12 @@ export async function folderExists(fs: NodeishFilesystem, path: string): Promise
 		return false
 	}
 }
+
+export async function fileExists(fs: NodeishFilesystem, path: string): Promise<boolean> {
+	try {
+		const stat = await fs.stat(path)
+		return stat.isFile()
+	} catch {
+		return false
+	}
+}

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/utils.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/utils.ts
@@ -1,3 +1,4 @@
+import { NodeishFilesystem } from "@lix-js/fs"
 import path from "node:path"
 
 /**
@@ -61,4 +62,13 @@ const isWindows = typeof process !== "undefined" && process.platform === "win32"
 
 export function normalizePath(id: string) {
 	return path.posix.normalize(isWindows ? slash(id) : id)
+}
+
+export async function folderExists(fs: NodeishFilesystem, path: string): Promise<boolean> {
+	try {
+		const stat = await fs.stat(path)
+		return stat.isDirectory()
+	} catch {
+		return false
+	}
 }


### PR DESCRIPTION
This PR changes how the `paraglide-next init` command determines which router is being used. If it's unsure it will now ask explicitly