### PR TITLE
Paraglide-SvelteKit - Also update language cookie on client-side language changes

### DIFF
--- a/.changeset/new-turtles-doubt.md
+++ b/.changeset/new-turtles-doubt.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-sveltekit": patch
+---
+
+fix: Also update the `paraglide:lang` cookie on the client to allow for better language negotiation

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/constants.js
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/constants.js
@@ -3,3 +3,6 @@ export const NO_TRANSLATE_ATTRIBUTE = "data-no-translate"
 
 /** The key with which `invalidate` is called when the language changes */
 export const LANGUAGE_CHANGE_INVALIDATION_KEY = "paraglide:lang"
+
+/** The name of the cookie in which the language is stored */
+export const LANG_COOKIE_NAME = "paraglide:lang"

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/ParaglideJS.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/ParaglideJS.svelte
@@ -17,6 +17,7 @@
 	import { invalidate } from "$app/navigation"
 	import { setParaglideContext } from "./internal/index.js"
 	import AlternateLinks from "./AlternateLinks.svelte"
+	import { createLangCookie } from "./utils/cookie.js"
 
 	// The base path may be relative during SSR.
 	// To make sure it is absolute, we need to resolve it against the current page URL.
@@ -84,6 +85,7 @@
 	// We need to make sure that changing the key happens last.
 	// See https://github.com/sveltejs/svelte/issues/10597
 	$: langKey = lang
+	$: if(browser) document.cookie = createLangCookie(lang, absoluteBase)
 </script>
 
 <svelte:head>

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.ts
@@ -1,13 +1,12 @@
-import type { Handle } from "@sveltejs/kit"
-import type { I18nConfig } from "../adapter.js"
 import { parseRoute } from "../utils/route.js"
 import { negotiateLanguagePreferences } from "@inlang/paraglide-js/internal/adapter-utils"
 import { base } from "$app/paths"
 import { dev } from "$app/environment"
+import { LANG_COOKIE_NAME } from "../../constants.js"
+import type { Handle } from "@sveltejs/kit"
+import type { I18nConfig } from "../adapter.js"
 import type { RoutingStrategy } from "../strategy.js"
 import type { ParaglideLocals } from "../locals.js"
-
-const LANG_COOKIE_NAME = "paraglide:lang"
 
 /**
  * The default lang attribute string that's in SvelteKit's `src/app.html` file.
@@ -133,4 +132,3 @@ export const createHandle = <T extends string>(
 		})
 	}
 }
-

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/utils/cookie.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/utils/cookie.ts
@@ -1,0 +1,12 @@
+import { LANG_COOKIE_NAME } from "../../constants.js"
+import type { NormalizedBase } from "./normaliseBase.js"
+
+/**
+ * Returns a language cookie string that can be assigned to `document.cookie`.
+ *
+ * Use this to update the language cookie in the browser.
+ *
+ * The cookie lasts for 1 year.
+ */
+export const createLangCookie = (lang: string, path: NormalizedBase) =>
+	`${LANG_COOKIE_NAME}=${lang};Path=${path};SameSite=lax;Max-Age=31557600`


### PR DESCRIPTION
This PR updates the behavior of `Paraglide-SvelteKit` to also update the `paraglide:lang` cookie when a language is changed client side. Until now only the next server-interaction would have updated the cookie, now it happens immediately.