### PR TITLE
fix: make PushException in Fink consistent

### DIFF
--- a/inlang/source-code/editor/src/pages/@host/@owner/@repository/State.tsx
+++ b/inlang/source-code/editor/src/pages/@host/@owner/@repository/State.tsx
@@ -373,7 +373,7 @@ export function EditorStateProvider(props: { children: JSXElement }) {
 		try {
 			const push = await loadedRepo.push().catch((error) => ({ error }))
 			if (push?.error) {
-				return { error: new PushException("Failed to push", { cause: push.error }) }
+				return { error: new PushException("Failed to push.", { cause: push.error }) }
 			}
 			await loadedRepo.pull({
 				author: {
@@ -389,7 +389,7 @@ export function EditorStateProvider(props: { children: JSXElement }) {
 			args.setLastPullTime(time)
 			return { data: true }
 		} catch (error) {
-			return { error: (error as PushException) ?? "Unknown error" }
+			return { error: new PushException("Failed to push.", { cause: error }) }
 		}
 	}
 

--- a/inlang/source-code/editor/src/pages/@host/@owner/@repository/components/Gitfloat.tsx
+++ b/inlang/source-code/editor/src/pages/@host/@owner/@repository/components/Gitfloat.tsx
@@ -194,7 +194,7 @@ export const Gitfloat = () => {
 		})
 
 		// @ts-expect-error – unknown type error for cause
-		if (pushResult.error?.cause?.data.statusCode === 403) {
+		if (pushResult.error?.cause?.data?.statusCode === 403) {
 			pushPermissionDialog.show()
 			return
 		}


### PR DESCRIPTION
@janfjohannes Just to double-check, does this correct the issues we had with the error handling, or did I miss something?

Related: https://linear.app/opral/issue/FINK-48/make-pushexception-in-fink-consistent