### PR TITLE
t function matcher extract message should offer no brackets version | Sherlock 🕵️‍♂️

### DIFF
--- a/.changeset/wet-donkeys-rescue.md
+++ b/.changeset/wet-donkeys-rescue.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-t-function-matcher": patch
+---
+
+fix t-function matcher extract message should offer no-brace version

--- a/inlang/source-code/plugins/t-function-matcher/src/ideExtension/config.ts
+++ b/inlang/source-code/plugins/t-function-matcher/src/ideExtension/config.ts
@@ -15,6 +15,18 @@ export const ideExtensionConfig = (): ReturnType<Exclude<Plugin["addCustomApi"],
 					messageReplacement: `{t("${args.messageId}")}`,
 				}),
 			},
+			{
+				callback: (args: { messageId: string }) => ({
+					messageId: args.messageId,
+					messageReplacement: `t("${args.messageId}")`,
+				}),
+			},
+			{
+				callback: (args: { messageId: string }) => ({
+					messageId: args.messageId,
+					messageReplacement: args.messageId,
+				}),
+			},
 		],
 		documentSelectors: [
 			{


### PR DESCRIPTION
- fix SHERL-64
cc @KraXen72 