### PR TITLE
Lorissigrist/parjs 153 SvelteKit adapter regression with exclude path option

### DIFF
--- a/.changeset/red-crews-yell.md
+++ b/.changeset/red-crews-yell.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-sveltekit": patch
+---
+
+fix regression with `exclude` option

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/lib/i18n.js
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/lib/i18n.js
@@ -2,6 +2,7 @@ import { createI18n } from "@inlang/paraglide-sveltekit"
 import { match as int } from "../params/int"
 import * as runtime from "$lib/paraglide/runtime.js"
 import * as m from "$lib/paraglide/messages.js"
+import { base } from "$app/paths"
 
 export const i18n = createI18n(runtime, {
 	pathnames: {
@@ -17,7 +18,7 @@ export const i18n = createI18n(runtime, {
 	},
 	matchers: { int },
 	prefixDefaultLanguage: "always",
-	exclude: ["/base/not-translated"],
+	exclude: [base + "/not-translated", base + "/excluded"],
 	textDirection: {
 		en: "ltr",
 		de: "ltr",

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/excluded/+page.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/excluded/+page.svelte
@@ -1,0 +1,1 @@
+<h1>This page should not be translated</h1>

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.server.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.server.ts
@@ -93,7 +93,7 @@ export const createHandle = <T extends string>(
 			})
 		}
 
-		if (lang !== cookieLang) {
+		if (lang !== cookieLang && !i18n.exclude(event.url.pathname)) {
 			event.cookies.set(LANG_COOKIE_NAME, lang, {
 				maxAge: 31557600, //Math.round(60 * 60 * 24 * 365.25) = 1 year,
 				sameSite: "lax",


### PR DESCRIPTION
Fixes a regression with `exclude` that was introduced with language negotiation