### PR TITLE
Expose Error types that are part of the external api

### DIFF
--- a/.changeset/pink-windows-divide.md
+++ b/.changeset/pink-windows-divide.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Expose `ModuleError`s, enabling more fine-grained error-handling in Apps.

--- a/inlang/source-code/sdk/src/index.ts
+++ b/inlang/source-code/sdk/src/index.ts
@@ -25,7 +25,13 @@ export {
 	PluginLoadMessagesError,
 	PluginSaveMessagesError,
 } from "./errors.js"
-export * from "./resolve-modules/errors.js"
+export {
+	ModuleError,
+	ModuleHasNoExportsError,
+	ModuleImportError,
+	ModuleExportIsInvalidError,
+	ModuleSettingsAreInvalidError,
+} from "./resolve-modules/errors.js"
 
 export { randomHumanId } from "./storage/human-id/human-readable-id.js"
 export { normalizeMessage } from "./storage/helper.js"

--- a/inlang/source-code/sdk/src/index.ts
+++ b/inlang/source-code/sdk/src/index.ts
@@ -25,6 +25,7 @@ export {
 	PluginLoadMessagesError,
 	PluginSaveMessagesError,
 } from "./errors.js"
+export * from "./resolve-modules/errors.js"
 
 export { randomHumanId } from "./storage/human-id/human-readable-id.js"
 export { normalizeMessage } from "./storage/helper.js"


### PR DESCRIPTION
See: https://linear.app/opral/issue/MESDK-140/expose-error-types-that-are-part-of-the-external-api

Reviewers: If this change is ok for you you can merge this