### PR TITLE
Add `generateAlternateLinks` API for better SEO

### DIFF
--- a/.changeset/sharp-waves-brush.md
+++ b/.changeset/sharp-waves-brush.md
@@ -2,4 +2,27 @@
 "@inlang/paraglide-next": patch
 ---
 
-Add `generateAlternateLinks` API for easily adding `<link rel="alternate"` tags to your page `<head>`.
+Added a `generateAlternateLinks` API for easily adding `<link rel="alternate"` tags to your page `<head>`. This is _in addition_ to the `Link` HTTP-Headers that are already present. 
+
+Use it like this in your `layout.tsx` file:
+
+```tsx
+// src/app/layout.tsx
+import { generateAlternateLinks } from "@inlang/paraglide-next"
+import { strategy } from "@/lib/i18n"
+import type { Metadata, ResolvingMetadata } from "next"
+
+export const generateMetadata = (params: any, parent: ResolvingMetadata): Metadata => {
+	return {
+		alternates: {
+			languages: generateAlternateLinks({
+				origin: "https://example.com", // the origin of your site
+				strategy: strategy,
+				resolvingMetadata: parent,
+			}),
+		},
+	}
+}
+```
+
+> You do not need to do this on every page, just the root layout

--- a/.changeset/sharp-waves-brush.md
+++ b/.changeset/sharp-waves-brush.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-next": patch
+---
+
+Add `generateAlternateLinks` API for easily adding `<link rel="alternate"` tags to your page `<head>`.

--- a/inlang/source-code/paraglide/paraglide-next/docs/advanced/seo.md
+++ b/inlang/source-code/paraglide/paraglide-next/docs/advanced/seo.md
@@ -1,8 +1,8 @@
-# SEO 
+# SEO
 
 ## Translated Metadata
 
-You'll likely want to have metadata in different languages. 
+You'll likely want to have metadata in different languages.
 
 You can use messages in metadata just like everywhere else, as long as you're using `generateMetadata` instead of exporting `metadata`
 
@@ -15,13 +15,32 @@ export async function generateMetadata() {
 }
 ```
 
-
 > If you were to use `export const metadata` your metadata would always end up in the source language.
-
 
 ## Alternate Links / Sitemap
 
 Search engines like Google expect you to tell them about translated versions of your pages. Paraglide-Next does this by default by adding the `Link` Header to requests.
+
+If you also want to instead have the alternate links in your page's `<head>` you can use the `generateAlternateLinks` function to generate the links. In your root layout, add the following:
+
+```tsx
+// src/app/layout.tsx
+import { generateAlternateLinks } from "@inlang/paraglide-next"
+import { strategy } from "@/lib/i18n"
+import type { Metadata, ResolvingMetadata } from "next"
+
+export const generateMetadata = (params: any, parent: ResolvingMetadata): Metadata => {
+	return {
+		alternates: {
+			languages: generateAlternateLinks({
+				origin: "https://example.com", // the origin of your site
+				strategy: strategy,
+				resolvingMetadata: parent,
+			}),
+		},
+	}
+}
+```
 
 You **don't** need to add the translated versions of your site to your sitemap, although it doesn't hurt if you do. Adding one language is sufficient.
 

--- a/inlang/source-code/paraglide/paraglide-next/examples/app/src/app/layout.tsx
+++ b/inlang/source-code/paraglide/paraglide-next/examples/app/src/app/layout.tsx
@@ -6,7 +6,7 @@ import * as m from "@/paraglide/messages.js"
 import type { Metadata, ResolvingMetadata } from "next"
 import { strategy } from "@/lib/i18n"
 
-export function generateMetadata(_, parent: ResolvingMetadata): Metadata {
+export function generateMetadata(_: unknown, parent: ResolvingMetadata): Metadata {
 	const locale = languageTag()
 	return {
 		title: m.paraglide_and_next_app_router(),

--- a/inlang/source-code/paraglide/paraglide-next/examples/app/src/app/layout.tsx
+++ b/inlang/source-code/paraglide/paraglide-next/examples/app/src/app/layout.tsx
@@ -1,11 +1,12 @@
 import "@/lib/ui/styles.css"
-import { LanguageProvider } from "@inlang/paraglide-next"
+import { LanguageProvider, generateAlternateLinks } from "@inlang/paraglide-next"
 import { AvailableLanguageTag, languageTag } from "@/paraglide/runtime"
 import { Header } from "@/lib/ui/Header"
 import * as m from "@/paraglide/messages.js"
-import type { Metadata } from "next"
+import type { Metadata, ResolvingMetadata } from "next"
+import { strategy } from "@/lib/i18n"
 
-export function generateMetadata(): Metadata {
+export function generateMetadata(_, parent: ResolvingMetadata): Metadata {
 	const locale = languageTag()
 	return {
 		title: m.paraglide_and_next_app_router(),
@@ -14,9 +15,15 @@ export function generateMetadata(): Metadata {
 		openGraph: {
 			locale,
 		},
+		alternates: {
+			languages: generateAlternateLinks({
+				origin: "https://example.com",
+				strategy: strategy,
+				resolvingMetadata: parent,
+			}),
+		},
 	}
 }
-
 
 const direction: Record<AvailableLanguageTag, "ltr" | "rtl"> = {
 	en: "ltr",

--- a/inlang/source-code/paraglide/paraglide-next/src/app/alternateLinks.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/alternateLinks.ts
@@ -1,0 +1,84 @@
+import { availableLanguageTags, languageTag } from "$paraglide/runtime.js"
+import { ResolvingMetadata } from "next"
+import { RoutingStrategy } from "./index.client"
+import { format } from "./utils/format"
+import { addBasePath } from "./utils/basePath"
+
+/**
+ * Generates the metadata NextJS needs to generate the `<link rel="alternate"` headers.
+ * Call this in your root-layout's `generateMetadata` function
+ *
+ * @example
+ * ```ts
+ * import { strategy } from "@/lib/i18n"
+ * import { generateAlternateLinks } from "@inlang/paraglide-next"
+ *
+ * export function generateMetadata(props, parent) {
+ *   return {
+ *     alternates: {
+ *       languages: generateAlternateLinks({
+ *         origin: "https://example.com",
+ *         strategy: strategy,
+ *         resolvingMetadata: parent
+ *       }),
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export function generateAlternateLinks<T extends string>({
+	origin,
+	strategy,
+	resolvingMetadata: parent,
+}: {
+	/**
+	 * The origin url at which the NextJS app is running
+	 */
+	origin: `http${string}`
+	/**
+	 * The routing strategy
+	 */
+	strategy: RoutingStrategy<T>
+	/**
+	 * The ResolvingMetadata. Get this from the second argument of `generateMetadata`
+	 */
+	resolvingMetadata: ResolvingMetadata
+}): Record<string, string> {
+	const pathname = illegallyGetPathname(parent)
+	if (!pathname) return {}
+	const locale = languageTag() as T
+
+	//current pathname, rendered per page
+	const localisedPathname = new URL(pathname, "http://n.com").pathname as `/${string}`
+	const canonicalPathname = strategy.getCanonicalPath(localisedPathname, locale)
+
+	const alternateLinks = Object.fromEntries(
+		(availableLanguageTags as readonly T[]).map((lang) => {
+			const localisedUrl = strategy.getLocalisedUrl(canonicalPathname, lang, true)
+			const formatted = format(localisedUrl)
+			const withBase = formatted.startsWith("/") ? addBasePath(formatted, true) : formatted
+			const href = new URL(withBase, origin).href
+			return [lang, href]
+		})
+	)
+
+	const hrefsAreUnique =
+		new Set(Object.values(alternateLinks)).size === Object.values(alternateLinks).length
+
+	return hrefsAreUnique ? alternateLinks : {}
+}
+
+function illegallyGetPathname(parent: ResolvingMetadata): string | undefined {
+	type NextInternalRouteData = {
+		urlPathname: string
+	}
+
+	const routeData = Object.getOwnPropertySymbols(parent)
+		.map((symbol) => (parent as any)[symbol])
+		.filter((thing) => typeof thing === "object")
+		.filter((thing): thing is NextInternalRouteData => "urlPathname" in thing)
+		.at(0)
+
+	if (!routeData) return undefined
+	else return routeData.urlPathname
+}

--- a/inlang/source-code/paraglide/paraglide-next/src/app/index.client.tsx
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/index.client.tsx
@@ -2,6 +2,7 @@
 export { Middleware } from "./middleware"
 export { Navigation } from "./navigation/navigation.client.js"
 export { initializeLanguage } from "./initializeLanguage.client.js"
+export { generateAlternateLinks } from "./alternateLinks.js"
 
 // Routing Strategies
 export * from "./routing-strategy/strategies"

--- a/inlang/source-code/paraglide/paraglide-next/src/app/index.server.tsx
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/index.server.tsx
@@ -4,6 +4,7 @@ export { default as LanguageProvider } from "./providers/LanguageProvider.js"
 export { Middleware } from "./middleware"
 export { Navigation } from "./navigation/navigation.server.js"
 export { initializeLanguage } from "./initializeLanguage.server.js"
+export { generateAlternateLinks } from "./alternateLinks.js"
 
 // Routing Strategies
 export * from "./routing-strategy/strategies"

--- a/inlang/source-code/paraglide/paraglide-next/src/app/utils/format.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/utils/format.ts
@@ -6,7 +6,7 @@ import { stringify as stringifyQS } from "qs"
 // also add slashes for an empty protocol
 const slashedProtocols: readonly string[] = ["http:", "https:", "ftp:", "gopher:", "file:", ""]
 
-export function format(url: UrlObject) {
+export function format(url: UrlObject): string {
 	const protocol = url.protocol
 		? url.protocol.endsWith(":")
 			? url.protocol
@@ -20,7 +20,7 @@ export function format(url: UrlObject) {
 		? auth +
 		  //escape ipv6 addresses with brackets
 		  (!url.hostname.includes(":") ? url.hostname : `[${url.hostname}]`) +
-		  (url.host ? `:${url.port}` : "")
+		  (url.port ? `:${url.port}` : "")
 		: undefined
 
 	let pathname = url.pathname || ""


### PR DESCRIPTION
Paraglide-Next currently uses the `Link` HTTP Header to tell search engines about versions of the site in other languages. Many people, myself included, prefer using `<link rel="alternate"` tags instead, as these aren't reliant on having control over the HTTP headers. This PR adds a convenient way of generating those