### PR TITLE
Sherlock Cache Crash

### DIFF
--- a/.changeset/big-queens-raise.md
+++ b/.changeset/big-queens-raise.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+fix crash associated with Inlang SDK caching

--- a/.changeset/funny-crabs-leave.md
+++ b/.changeset/funny-crabs-leave.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Better error-messages for cache-related issues

--- a/inlang/source-code/sdk/src/migrations/maybeAddModuleCache.ts
+++ b/inlang/source-code/sdk/src/migrations/maybeAddModuleCache.ts
@@ -33,7 +33,10 @@ export async function maybeAddModuleCache(args: {
 		try {
 			await args.repo.nodeishFs.writeFile(gitignorePath, EXPECTED_IGNORES.join("\n"))
 		} catch (e) {
-			throw new Error("[migrate:module-cache] Failed to create .gitignore", { cause: e })
+			// @ts-ignore
+			if (e.code && e.code !== "EISDIR" && e.code !== "EEXIST") {
+				throw new Error("[migrate:module-cache] Failed to create .gitignore", { cause: e })
+			}
 		}
 	}
 

--- a/inlang/source-code/sdk/src/migrations/maybeAddModuleCache.ts
+++ b/inlang/source-code/sdk/src/migrations/maybeAddModuleCache.ts
@@ -20,17 +20,29 @@ export async function maybeAddModuleCache(args: {
 
 	if (gitignoreExists) {
 		// non-destructively add any missing ignores
-		const gitignore = await args.repo.nodeishFs.readFile(gitignorePath, { encoding: "utf-8" })
-		const missingIgnores = EXPECTED_IGNORES.filter((ignore) => !gitignore.includes(ignore))
-		if (missingIgnores.length > 0) {
-			await args.repo.nodeishFs.appendFile(gitignorePath, "\n" + missingIgnores.join("\n"))
+		try {
+			const gitignore = await args.repo.nodeishFs.readFile(gitignorePath, { encoding: "utf-8" })
+			const missingIgnores = EXPECTED_IGNORES.filter((ignore) => !gitignore.includes(ignore))
+			if (missingIgnores.length > 0) {
+				await args.repo.nodeishFs.appendFile(gitignorePath, "\n" + missingIgnores.join("\n"))
+			}
+		} catch (error) {
+			throw new Error("[migrate:module-cache] Failed to update .gitignore", { cause: error })
 		}
 	} else {
-		await args.repo.nodeishFs.writeFile(gitignorePath, EXPECTED_IGNORES.join("\n"))
+		try {
+			await args.repo.nodeishFs.writeFile(gitignorePath, EXPECTED_IGNORES.join("\n"))
+		} catch (e) {
+			throw new Error("[migrate:module-cache] Failed to create .gitignore", { cause: e })
+		}
 	}
 
 	if (!moduleCacheExists) {
-		await args.repo.nodeishFs.mkdir(moduleCache, { recursive: true })
+		try {
+			await args.repo.nodeishFs.mkdir(moduleCache, { recursive: true })
+		} catch (e) {
+			throw new Error("[migrate:module-cache] Failed to create cache directory", { cause: e })
+		}
 	}
 }
 

--- a/inlang/source-code/sdk/src/resolve-modules/cache.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/cache.ts
@@ -39,7 +39,9 @@ async function writeModuleToCache(
 	if (writeFileResult.error) {
 		const dirPath = projectPath + `/cache/modules`
 		const createDirResult = await tryCatch(() => mkdir(dirPath, { recursive: true }))
-		if (createDirResult.error)
+
+		// @ts-ignore - If the directory exists we can ignore this error
+		if (createDirResult.error && createDirResult.error.code !== "EEXIST")
 			throw new Error("[sdk:module-cacke] failed to create cache-directory. Path: " + dirPath, {
 				cause: createDirResult.error,
 			})

--- a/inlang/source-code/sdk/src/resolve-modules/cache.ts
+++ b/inlang/source-code/sdk/src/resolve-modules/cache.ts
@@ -72,7 +72,17 @@ export function withCache(
 			else throw loaderResult.error
 		} else {
 			const moduleAsText = loaderResult.data
-			await writeModuleToCache(uri, moduleAsText, projectPath, nodeishFs.writeFile, nodeishFs.mkdir)
+			try {
+				await writeModuleToCache(
+					uri,
+					moduleAsText,
+					projectPath,
+					nodeishFs.writeFile,
+					nodeishFs.mkdir
+				)
+			} catch (error) {
+				// TODO trigger a warning
+			}
 			return moduleAsText
 		}
 	}


### PR DESCRIPTION
This PR:
- Fixes Sherlock's FS wrapper to no longer swallow arguments
- Adds better Errors to the SDK to make locating issues easier
- Makes sure the SDK no longer errors when it fails to write to the cache