### PR TITLE
Paraglide-Next: Fix paths segments that start with language tags being edited

### DIFF
--- a/.changeset/plenty-roses-grab.md
+++ b/.changeset/plenty-roses-grab.md
@@ -1,0 +1,7 @@
+---
+"@inlang/paraglide-next": patch
+---
+
+fix issue where path-segments that start with a language tag confused the router.
+
+Eg: `/entropy` would match the language `en` & be resolved to `/tropy`

--- a/inlang/source-code/paraglide/paraglide-next/src/app/routing-strategy/strats/prefixStrategy.test.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/routing-strategy/strats/prefixStrategy.test.ts
@@ -47,6 +47,10 @@ describe("getCanonicalPath", () => {
 		expect(getCanonicalPath("/en/translated/1", "en")).toBe("/canonical-translated/1")
 		expect(getCanonicalPath("/de-CH/uebersetzt/1", "de-CH")).toBe("/canonical-translated/1")
 	})
+
+	it("does not get confused by a path that starts with a language tag", () => {
+		expect(getCanonicalPath("/de-something-else", "de")).toBe("/de-something-else")
+	})
 })
 
 describe("getLocalisedPath", () => {

--- a/inlang/source-code/paraglide/paraglide-next/src/app/routing-strategy/strats/prefixStrategy.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/routing-strategy/strats/prefixStrategy.ts
@@ -103,8 +103,10 @@ export function PrefixStrategy<T extends string>({
 		// get the prefix for this language
 		const prefix = resolvedPrefixes[locale] ?? locale
 
-		const pathWithoutLocale: `/${string}` = localisedPath.startsWith(`/${prefix}`)
-			? ((localisedPath.replace(`/${prefix}`, "") || "/") as `/${string}`)
+		const pathWithoutLocale: `/${string}` = localisedPath.startsWith(`/${prefix}/`)
+			? (localisedPath.replace(`/${prefix}`, "") as `/${string}`)
+			: localisedPath === `/${prefix}`
+			? "/"
 			: localisedPath
 
 		for (const [canonicalPathDefinition, translationsForPath] of Object.entries(
@@ -166,7 +168,10 @@ export function PrefixStrategy<T extends string>({
 			const pathWithoutBase = request.nextUrl.pathname
 
 			const entries = Object.entries(resolvedPrefixes) as [T, string][]
-			const entry = entries.find(([, prefix]) => pathWithoutBase.startsWith(`/${prefix}`))
+			const entry = entries.find(
+				([, prefix]) =>
+					pathWithoutBase.startsWith(`/${prefix}/`) || pathWithoutBase === `/${prefix}`
+			)
 			const detected = entry?.[0]
 
 			// If no prefix is detected and prefixDefault is "never" -> use default language


### PR DESCRIPTION
Fixes an issue where path-segments that start with a language tag matched the router. 

Eg: `/entropy` would match the language `en` and be resolved to `/tropy`