### PR TITLE
Paraglide-SvelteKit Preserve query parameters when redirecting

### DIFF
--- a/.changeset/breezy-forks-check.md
+++ b/.changeset/breezy-forks-check.md
@@ -1,0 +1,11 @@
+---
+"@inlang/paraglide-sveltekit": patch
+---
+
+fix: Preserve query parameters when redirecting ([inlang-paraglide-js#168](https://github.com/opral/inlang-paraglide-js/issues/168))
+
+`i18n.handle` redirects requests if the pathname does not fit the detected language. Previously this would remove any query parameters from the URL. This is no longer the case.
+
+```ts
+redirect(303, "/login?from=/home") // will be redirected to /<lang>/login?from=/home
+``` 

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/redirect/+page.server.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/redirect/+page.server.ts
@@ -1,0 +1,9 @@
+import { redirect } from "@sveltejs/kit"
+
+export const prerender = false
+
+export const actions = {
+	redirect: async () => {
+		redirect(303, "/?redirected=true")
+	},
+}

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/redirect/+page.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/src/routes/redirect/+page.svelte
@@ -1,0 +1,3 @@
+<form method="post" action="?/redirect">
+    <button type="submit">Redirect</button>
+</form>

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.server.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.server.ts
@@ -8,6 +8,7 @@ import type { I18nConfig } from "../adapter.server.js"
 import type { RoutingStrategy } from "../strategy.js"
 import type { ParaglideLocals } from "../locals.js"
 import { ALSContext, GlobalContext, type Context } from "./utils.js"
+import { getHrefBetween } from "../utils/diff-urls.js"
 
 /**
  * The default lang attribute string that's in SvelteKit's `src/app.html` file.
@@ -117,13 +118,15 @@ export const createHandle = <T extends string>(
 			const localisedPathname = strategy.getLocalisedPath(localisedPath, lang)
 			const fullPath = serializeRoute(localisedPathname, base, suffix)
 
-			const url = new URL(event.url)
-			url.pathname = fullPath
+			const to = new URL(event.url)
+			to.pathname = fullPath
+
+			const href = getHrefBetween(event.url, to)
 
 			return new Response(undefined, {
 				status: 302,
 				headers: {
-					Location: url.href,
+					Location: href,
 				},
 			})
 		}

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.server.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/hooks/handle.server.ts
@@ -113,13 +113,17 @@ export const createHandle = <T extends string>(
 
 		if (lang !== langFromUrl && !i18n.exclude(localisedPath)) {
 			// redirect to the correct language
+
 			const localisedPathname = strategy.getLocalisedPath(localisedPath, lang)
 			const fullPath = serializeRoute(localisedPathname, base, suffix)
+
+			const url = new URL(event.url)
+			url.pathname = fullPath
 
 			return new Response(undefined, {
 				status: 302,
 				headers: {
-					Location: fullPath,
+					Location: url.href,
 				},
 			})
 		}


### PR DESCRIPTION
fix: Preserve query parameters when redirecting ([inlang-paraglide-js#168](https://github.com/opral/inlang-paraglide-js/issues/168))

`i18n.handle` redirects requests if the pathname does not fit the detected language. Previously this would remove any query parameters from the URL. This is no longer the case.

```ts
redirect(303, "/login?from=/home") // will be redirected to /<lang>/login?from=/home
``` 