### PR TITLE
exposes readBlob via lix client

### DIFF
--- a/lix/packages/client/src/git/readBlob.ts
+++ b/lix/packages/client/src/git/readBlob.ts
@@ -1,0 +1,18 @@
+import isoGit from "../../vendored/isomorphic-git/index.js"
+import type { RepoContext } from "../openRepository.js"
+
+export async function readBlob(
+	ctx: RepoContext,
+	cmdArgs: {
+		oid: string;
+		filepath?: string;
+	}
+) {
+	return await isoGit.readBlob({
+		fs: ctx.rawFs,
+		dir: ctx.dir,
+		oid: cmdArgs?.oid,
+		filepath: cmdArgs?.filepath,
+		cache: ctx.cache,
+	})
+}

--- a/lix/packages/client/src/openRepository.ts
+++ b/lix/packages/client/src/openRepository.ts
@@ -30,6 +30,7 @@ import { lixFs } from "./lixFs.js"
 
 // types
 import type { NodeishFilesystem } from "@lix-js/fs"
+import { readBlob } from "./git/readBlob.js"
 
 export type { RepoContext } from "./repoContext.js"
 export type { RepoState } from "./repoState.js"
@@ -94,6 +95,7 @@ export async function openRepository(
 		mergeUpstream: mergeUpstream.bind(undefined, ctx),
 		push: push.bind(undefined, ctx),
 		pull: pull.bind(undefined, ctx, state),
+		readBlob: readBlob.bind(undefined, ctx),
 
 		...(ctx.experimentalFeatures.lixFs ? lixFs(state.nodeishFs) : {}),
 


### PR DESCRIPTION
This PR exposes a readBlob function to via lix client to allow to read a content of a blob via oid directly. 