### PR TITLE
chore: add mock type test

### DIFF
--- a/lix/packages/sdk/package.json
+++ b/lix/packages/sdk/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"build": "tsc --build",
-		"test": "vitest run",
+		"test": "tsc --noEmit && vitest run",
 		"test:watch": "vitest",
 		"dev": "tsc --watch",
 		"format": "prettier ./src --write"

--- a/lix/packages/sdk/src/plugin.test-d.ts
+++ b/lix/packages/sdk/src/plugin.test-d.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+
+import type { LixPlugin } from "./plugin.js"
+
+type Types = {
+	bundle: { id: string; name: string }
+	message: { id: string; color: string }
+	variant: { id: string; day: string }
+}
+
+const x: LixPlugin<Types> = {
+	key: "inlang-lix-plugin-v1",
+	glob: "*",
+	diff: {
+		file: () => {
+			throw new Error("Not implemented")
+		},
+		bundle: ({ old, neu }) => {
+			// expect old and neu to be of type Types["bundle"]
+			old satisfies Types["bundle"]
+			neu satisfies Types["bundle"]
+			throw new Error("Not implemented")
+		},
+		message: ({ old, neu }) => {
+			// expect old and neu to be of type Types["message"]
+			old satisfies Types["message"]
+			neu satisfies Types["message"]
+			throw new Error("Not implemented")
+		},
+		variant: ({ old, neu }) => {
+			// expect old and neu to be of type Types["variant"]
+			old satisfies Types["variant"]
+			neu satisfies Types["variant"]
+			throw new Error("Not implemented")
+		},
+	},
+}


### PR DESCRIPTION
**changes**

Adds a declaration test for the plugin API that has yet to be implemented (to not forget about it)

**why**

I wrote the plugin for inlang and was confused why `plugin.diff.variant` was not a variant but a union of every type the plugin defines. 

