### PR TITLE
refactor: expose lix file

### DIFF
--- a/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.test.ts
+++ b/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.test.ts
@@ -18,10 +18,14 @@ describe("plugin.diff.file", () => {
 				alias: JSON.stringify({}),
 			})
 			.execute();
+		const path = "/db.sqlite";
 		const diffReports = await inlangLixPluginV1.diff.file!({
 			old: undefined,
-			neu: contentFromDatabase(neuProject._sqlite),
-			path: "/db.sqlite",
+			neu: {
+				id: "uuid",
+				path,
+				data: contentFromDatabase(neuProject._sqlite),
+			},
 		});
 		expect(diffReports).toEqual([
 			{
@@ -68,11 +72,20 @@ describe("plugin.diff.file", () => {
 				},
 			])
 			.execute();
+
 		const diffReports = await inlangLixPluginV1.diff.file!({
-			old: contentFromDatabase(oldProject._sqlite),
-			neu: contentFromDatabase(neuProject._sqlite),
-			path: "/db.sqlite",
+			old: {
+				id: "uuid",
+				path: "/db.sqlite",
+				data: contentFromDatabase(oldProject._sqlite),
+			},
+			neu: {
+				id: "uuid",
+				path: "/db.sqlite",
+				data: contentFromDatabase(neuProject._sqlite),
+			},
 		});
+
 		expect(diffReports).toEqual([
 			{
 				type: "bundle",
@@ -99,8 +112,11 @@ describe("plugin.diff.file", () => {
 			.execute();
 		const diffReports = await inlangLixPluginV1.diff.file!({
 			old: undefined,
-			neu: contentFromDatabase(neuProject._sqlite),
-			path: "/db.sqlite",
+			neu: {
+				id: "uuid",
+				path: "/db.sqlite",
+				data: contentFromDatabase(neuProject._sqlite),
+			},
 		});
 		expect(diffReports).toEqual([
 			{
@@ -167,9 +183,16 @@ describe("plugin.diff.file", () => {
 			])
 			.execute();
 		const diffReports = await inlangLixPluginV1.diff.file!({
-			old: contentFromDatabase(oldProject._sqlite),
-			neu: contentFromDatabase(neuProject._sqlite),
-			path: "/db.sqlite",
+			old: {
+				id: "uuid",
+				path: "/db.sqlite",
+				data: contentFromDatabase(oldProject._sqlite),
+			},
+			neu: {
+				id: "uuid",
+				path: "/db.sqlite",
+				data: contentFromDatabase(neuProject._sqlite),
+			},
 		});
 		expect(diffReports).toEqual([
 			{
@@ -206,8 +229,11 @@ describe("plugin.diff.file", () => {
 			.execute();
 		const diffReports = await inlangLixPluginV1.diff.file!({
 			old: undefined,
-			neu: contentFromDatabase(neuProject._sqlite),
-			path: "/db.sqlite",
+			neu: {
+				id: "uuid",
+				path: "/db.sqlite",
+				data: contentFromDatabase(neuProject._sqlite),
+			},
 		});
 		expect(diffReports).toEqual([
 			{
@@ -267,9 +293,16 @@ describe("plugin.diff.file", () => {
 			])
 			.execute();
 		const diffReports = await inlangLixPluginV1.diff.file!({
-			old: contentFromDatabase(oldProject._sqlite),
-			neu: contentFromDatabase(neuProject._sqlite),
-			path: "/db.sqlite",
+			old: {
+				id: "uuid",
+				path: "/db.sqlite",
+				data: contentFromDatabase(oldProject._sqlite),
+			},
+			neu: {
+				id: "uuid",
+				path: "/db.sqlite",
+				data: contentFromDatabase(neuProject._sqlite),
+			},
 		});
 		expect(diffReports).toEqual([
 			{

--- a/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.ts
+++ b/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.ts
@@ -21,19 +21,19 @@ export const inlangLixPluginV1: LixPlugin<{
 	// },
 	diff: {
 		// TODO does not account for deletions
-		file: async ({ old, neu, path }) => {
+		file: async ({ old, neu }) => {
 			// can only handle the database for now
-			if (path === undefined || path?.endsWith("db.sqlite") === false) {
+			if (neu === undefined || neu.path?.endsWith("db.sqlite") === false) {
 				return [];
 			}
 			const result: DiffReport[] = [];
 			const oldDb = old
-				? initKysely({ sqlite: await loadDatabaseInMemory(old) })
+				? initKysely({ sqlite: await loadDatabaseInMemory(old.data) })
 				: undefined;
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			const newDb = neu
 				? initKysely({
-						sqlite: await loadDatabaseInMemory(neu),
+						sqlite: await loadDatabaseInMemory(neu.data),
 				  })
 				: undefined;
 			const newProjectBundles = await newDb

--- a/lix/packages/sdk/src/open/openLix.ts
+++ b/lix/packages/sdk/src/open/openLix.ts
@@ -39,15 +39,21 @@ export async function openLix(args: {
 
 	args.database.createFunction({
 		name: "handle_file_change",
-		arity: 4,
+		arity: 6,
 		// @ts-expect-error - dynamic function
-		xFunc: (_, fileId: any, oldData: any, neuData: any, path: any) => {
+		xFunc: (_, ...args) => {
 			maybePendingPromises.push(
 				handleFileChange({
-					fileId,
-					path,
-					oldData,
-					neuData,
+					old: {
+						id: args[0] as any,
+						path: args[1] as any,
+						data: args[2] as any,
+					},
+					neu: {
+						id: args[3] as any,
+						path: args[4] as any,
+						data: args[5] as any,
+					},
 					plugins,
 					db,
 				})
@@ -59,7 +65,7 @@ export async function openLix(args: {
 	await sql`
 	CREATE TEMP TRIGGER file_modified AFTER UPDATE ON file
 	BEGIN
-	  SELECT handle_file_change(NEW.id, OLD.data, NEW.data, OLD.path);
+	  SELECT handle_file_change(NEW.id, NEW.path, NEW.data, OLD.id, OLD.path, OLD.data);
 	END;
 	`.execute(db)
 
@@ -67,14 +73,16 @@ export async function openLix(args: {
 		name: "handle_file_insert",
 		arity: 3,
 		// @ts-expect-error - dynamic function
-		xFunc: (_, fileId: any, newData: any, path: any) => {
+		xFunc: (_, id: any, path: any, data: any) => {
 			maybePendingPromises.push(
 				handleFileInsert({
-					fileId,
-					newData,
+					neu: {
+						id,
+						path,
+						data,
+					},
 					plugins,
 					db,
-					path,
 				})
 			)
 			return
@@ -84,7 +92,7 @@ export async function openLix(args: {
 	await sql`
 	CREATE TEMP TRIGGER file_inserted AFTER INSERT ON file
 	BEGIN
-	  SELECT handle_file_insert(NEW.id, NEW.data, NEW.path);
+	  SELECT handle_file_insert(NEW.id, NEW.path, NEW.data);
 	END;
 	`.execute(db)
 
@@ -142,18 +150,16 @@ async function loadPlugins(db: Kysely<LixDatabase>) {
 // }
 
 async function handleFileChange(args: {
-	fileId: LixFile["id"]
-	path: LixFile["path"]
-	oldData: LixFile["data"]
-	neuData: LixFile["data"]
+	old: LixFile
+	neu: LixFile
 	plugins: LixPlugin[]
 	db: Kysely<LixDatabase>
 }) {
+	const fileId = args.neu?.id ?? args.old?.id
 	for (const plugin of args.plugins) {
 		const diffs = await plugin.diff?.file?.({
-			old: args.oldData,
-			neu: args.neuData,
-			path: args.path,
+			old: args.old,
+			neu: args.neu,
 		})
 		for (const diff of diffs ?? []) {
 			// assume an insert or update operation as the default
@@ -164,7 +170,7 @@ async function handleFileChange(args: {
 				.selectAll()
 				.where((eb) => eb.ref("value", "->>").key("id"), "=", id)
 				.where("type", "=", diff.type)
-				.where("file_id", "=", args.fileId)
+				.where("file_id", "=", fileId)
 				.where("plugin_key", "=", plugin.key)
 				.where("commit_id", "is", null)
 				.executeTakeFirst()
@@ -176,7 +182,7 @@ async function handleFileChange(args: {
 					.values({
 						id: v4(),
 						type: diff.type,
-						file_id: args.fileId,
+						file_id: fileId,
 						plugin_key: plugin.key,
 						// @ts-expect-error - database expects stringified json
 						value: JSON.stringify(diff.value),
@@ -191,7 +197,7 @@ async function handleFileChange(args: {
 				.selectAll()
 				.where((eb) => eb.ref("value", "->>").key("id"), "=", id)
 				.where("type", "=", diff.type)
-				.where("file_id", "=", args.fileId)
+				.where("file_id", "=", fileId)
 				.where("commit_id", "is not", null)
 				.where("plugin_key", "=", plugin.key)
 				.innerJoin("commit", "commit.id", "change.commit_id")
@@ -212,7 +218,7 @@ async function handleFileChange(args: {
 						.deleteFrom("change")
 						.where((eb) => eb.ref("value", "->>").key("id"), "=", id)
 						.where("type", "=", diff.type)
-						.where("file_id", "=", args.fileId)
+						.where("file_id", "=", fileId)
 						.where("plugin_key", "=", plugin.key)
 						.where("commit_id", "is", null)
 						.execute()
@@ -228,7 +234,7 @@ async function handleFileChange(args: {
 				.updateTable("change")
 				.where((eb) => eb.ref("value", "->>").key("id"), "=", id)
 				.where("type", "=", diff.type)
-				.where("file_id", "=", args.fileId)
+				.where("file_id", "=", fileId)
 				.where("plugin_key", "=", plugin.key)
 				.where("commit_id", "is", null)
 				.set({
@@ -244,17 +250,14 @@ async function handleFileChange(args: {
 
 // creates initial commit
 async function handleFileInsert(args: {
-	fileId: LixFile["id"]
-	path: LixFile["path"]
-	newData: LixFile["data"]
+	neu: LixFile
 	plugins: LixPlugin[]
 	db: Kysely<LixDatabase>
 }) {
 	for (const plugin of args.plugins) {
 		const diffs = await plugin.diff?.file?.({
 			old: undefined,
-			neu: args.newData,
-			path: args.path,
+			neu: args.neu,
 		})
 		for (const diff of diffs ?? []) {
 			await args.db
@@ -262,7 +265,7 @@ async function handleFileInsert(args: {
 				.values({
 					id: v4(),
 					type: diff.type,
-					file_id: args.fileId,
+					file_id: args.neu.id,
 					plugin_key: plugin.key,
 					// @ts-expect-error - database expects stringified json
 					value: JSON.stringify(diff.value),
@@ -287,7 +290,7 @@ async function handleFileInsert(args: {
 			return await args.db
 				.updateTable("change")
 				.where("commit_id", "is", null)
-				.where("file_id", "=", args.fileId)
+				.where("file_id", "=", args.neu.id)
 				.set({
 					commit_id: commit.id,
 				})

--- a/lix/packages/sdk/src/plugin.ts
+++ b/lix/packages/sdk/src/plugin.ts
@@ -14,13 +14,7 @@ export type LixPlugin<T extends Record<string, Record<string, unknown>> = Record
 		(() => HTMLElement) | undefined
 	>
 	diff: {
-		file?: (args: {
-			old?: LixFile["data"]
-			neu?: LixFile["data"]
-			// TODO remove this hack in favor of
-			// providing the entire lix file object
-			path?: LixFile["path"]
-		}) => MaybePromise<Array<DiffReport>>
+		file?: (args: { old?: LixFile; neu?: LixFile }) => MaybePromise<Array<DiffReport>>
 	} & Record<
 		// other primitives
 		keyof T,


### PR DESCRIPTION
## Context

While writing the inlang lix plugin, I ran into the problem that I needed more information than the Blob of the file. Specifically, the information of the `path` was crucial as the inlang lix plugin diffs various files (settings.json, db.sqlite, ...). 

I added a workaround by exposing `path` to the differ. 

```ts
diff: {
  file: async ({ old, neu, path })
}
```

## Proposal 

Expose `LixFile` as `old` `neu` arguments for the differ.

```diff
diff: {
-  file?: (args: { old?: LixFile['data']; neu?: LixFile['data'] }) 
+  file?: (args: { old?: LixFile; neu?: LixFile }) 
}

```

The workaround works but it felt like exposing the lixfile type would be the way to go. Eventually, a differ might need all data in a lix file. Instead of adding more and more arguments to `diff.file`, it seems easier to expose the lix file type. 

- (+) solves a requirement for the inlang lix plugin 
- (+) avoids adding more and more arguments to the differ that are contained in the lix file itself (like path)
- (-) leaks the `LixFile` to plugins. a breaking change would require `diff.fileV2` that seems to be good practice anyways