### PR TITLE
add: `change.operation`

### DIFF
--- a/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.test.ts
+++ b/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.test.ts
@@ -30,7 +30,7 @@ describe("plugin.diff.file", () => {
 		expect(diffReports).toEqual([
 			{
 				type: "bundle",
-				operation: "insert",
+				operation: "create",
 				old: undefined,
 				neu: { id: "1", alias: {} },
 			} satisfies DiffReport,
@@ -121,7 +121,7 @@ describe("plugin.diff.file", () => {
 		expect(diffReports).toEqual([
 			{
 				type: "message",
-				operation: "insert",
+				operation: "create",
 				old: undefined,
 				neu: {
 					id: "1",
@@ -238,7 +238,7 @@ describe("plugin.diff.file", () => {
 		expect(diffReports).toEqual([
 			{
 				type: "variant",
-				operation: "insert",
+				operation: "create",
 				old: undefined,
 				neu: {
 					id: "1",
@@ -372,7 +372,7 @@ describe("plugin.diff.variant", () => {
 		};
 		const diff = await inlangLixPluginV1.diff.variant({ old, neu });
 		expect(diff).toEqual([
-			{ operation: "insert", type: "variant", neu, old } satisfies DiffReport,
+			{ operation: "create", type: "variant", neu, old } satisfies DiffReport,
 		]);
 	});
 });

--- a/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.ts
+++ b/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.ts
@@ -111,7 +111,7 @@ function jsonStringifyComparison({
 	type: "bundle" | "message" | "variant";
 }): DiffReport[] {
 	if (old === undefined && neu) {
-		return [{ type, old, neu, operation: "insert" } satisfies DiffReport];
+		return [{ type, old, neu, operation: "create" } satisfies DiffReport];
 	} else if (old !== undefined && neu === undefined) {
 		return [{ type, old, neu, operation: "delete" } satisfies DiffReport];
 	} else if (old && neu) {

--- a/lix/packages/sdk/src/newLix.ts
+++ b/lix/packages/sdk/src/newLix.ts
@@ -32,7 +32,7 @@ export async function newLixFile(): Promise<Blob> {
         file_id TEXT NOT NULL,
         plugin_key TEXT NOT NULL,
         operation TEXT NOT NULL,
-        value TEXT NULL,
+        value TEXT,
         meta TEXT,
         commit_id TEXT
         ) strict;

--- a/lix/packages/sdk/src/newLix.ts
+++ b/lix/packages/sdk/src/newLix.ts
@@ -31,6 +31,7 @@ export async function newLixFile(): Promise<Blob> {
         type TEXT NOT NULL,
         file_id TEXT NOT NULL,
         plugin_key TEXT NOT NULL,
+        operation TEXT NOT NULL,
         value TEXT NULL,
         meta TEXT,
         commit_id TEXT

--- a/lix/packages/sdk/src/open/openLix.test.ts
+++ b/lix/packages/sdk/src/open/openLix.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest"
 import { openLixInMemory } from "./openLixInMemory.js"
 import { newLixFile } from "../newLix.js"
 import type { LixPlugin } from "../plugin.js"
+import { uuidv4 } from "../index.js"
 
 test("providing plugins should be possible", async () => {
 	const mockPlugin: LixPlugin = {
@@ -11,4 +12,46 @@ test("providing plugins should be possible", async () => {
 	}
 	const lix = await openLixInMemory({ blob: await newLixFile(), providePlugins: [mockPlugin] })
 	expect(lix.plugins).toContain(mockPlugin)
+})
+
+test.todo("changes should contain the operation reported by diffs", async () => {
+	const mockPlugin: LixPlugin = {
+		key: "mock-plugin",
+		glob: "*",
+		diff: {
+			file: async ({ neu }) => {
+				const json = JSON.parse(new TextDecoder().decode(neu))
+				return [
+					{
+						type: "mock",
+						operation: "insert",
+						old: undefined,
+						neu: {
+							id: "uuid",
+							name: json["name"],
+						},
+					},
+				]
+			},
+		},
+	}
+	const mockJson = {
+		name: "Darth Vader",
+	}
+	const lix = await openLixInMemory({ blob: await newLixFile(), providePlugins: [mockPlugin] })
+	await lix.db
+		.insertInto("file")
+		.values({
+			id: uuidv4(),
+			path: "/mock-file.json",
+			data: new TextEncoder().encode(JSON.stringify(mockJson)),
+		})
+		.execute()
+	// workaround for settled
+	await new Promise((resolve) => setTimeout(resolve, 1000))
+	// TODO selectFrom change doesn't resolve
+	const changes = await lix.db.selectFrom("change").selectAll().execute()
+	expect(changes.length).toBe(1)
+	expect(changes[1]?.operation).toBe("insert")
+	expect(changes[1]?.value?.name).toBe("Darth Vader")
 })

--- a/lix/packages/sdk/src/open/openLix.test.ts
+++ b/lix/packages/sdk/src/open/openLix.test.ts
@@ -24,7 +24,7 @@ test.todo("changes should contain the operation reported by diffs", async () => 
 				return [
 					{
 						type: "mock",
-						operation: "insert",
+						operation: "create",
 						old: undefined,
 						neu: {
 							id: "uuid",

--- a/lix/packages/sdk/src/open/openLix.test.ts
+++ b/lix/packages/sdk/src/open/openLix.test.ts
@@ -20,7 +20,7 @@ test.todo("changes should contain the operation reported by diffs", async () => 
 		glob: "*",
 		diff: {
 			file: async ({ neu }) => {
-				const json = JSON.parse(new TextDecoder().decode(neu))
+				const json = JSON.parse(new TextDecoder().decode(neu?.data))
 				return [
 					{
 						type: "mock",

--- a/lix/packages/sdk/src/open/openLix.ts
+++ b/lix/packages/sdk/src/open/openLix.ts
@@ -182,7 +182,7 @@ async function handleFileChange(args: {
 					.values({
 						id: v4(),
 						type: diff.type,
-						file_id: args.fileId,
+						file_id: fileId,
 						operation: diff.operation,
 						plugin_key: plugin.key,
 						// @ts-expect-error - database expects stringified json

--- a/lix/packages/sdk/src/open/openLix.ts
+++ b/lix/packages/sdk/src/open/openLix.ts
@@ -177,6 +177,7 @@ async function handleFileChange(args: {
 						id: v4(),
 						type: diff.type,
 						file_id: args.fileId,
+						operation: diff.operation,
 						plugin_key: plugin.key,
 						// @ts-expect-error - database expects stringified json
 						value: JSON.stringify(diff.value),
@@ -233,6 +234,7 @@ async function handleFileChange(args: {
 				.where("commit_id", "is", null)
 				.set({
 					id: v4(),
+					operation: diff.operation,
 					// @ts-expect-error - database expects stringified json
 					value: JSON.stringify(diff.value),
 					meta: JSON.stringify(diff.meta),
@@ -264,6 +266,7 @@ async function handleFileInsert(args: {
 					type: diff.type,
 					file_id: args.fileId,
 					plugin_key: plugin.key,
+					operation: diff.operation,
 					// @ts-expect-error - database expects stringified json
 					value: JSON.stringify(diff.value),
 					meta: JSON.stringify(diff.meta),

--- a/lix/packages/sdk/src/plugin.test-d.ts
+++ b/lix/packages/sdk/src/plugin.test-d.ts
@@ -1,7 +1,6 @@
-// @ts-nocheck
 // TODO implement this test
 
-import type { LixPlugin } from "./plugin.js"
+import type { DiffReport, LixPlugin } from "./plugin.js"
 
 type Types = {
 	bundle: { id: string; name: string }
@@ -9,7 +8,9 @@ type Types = {
 	variant: { id: string; day: string }
 }
 
-const x: LixPlugin<Types> = {
+// ------------------- PLUGIN -------------------
+
+const plugin: LixPlugin<Types> = {
 	key: "inlang-lix-plugin-v1",
 	glob: "*",
 	diff: {
@@ -18,21 +19,49 @@ const x: LixPlugin<Types> = {
 		},
 		bundle: ({ old, neu }) => {
 			// expect old and neu to be of type Types["bundle"]
+			// @ts-expect-error - TODO
 			old satisfies Types["bundle"]
+			// @ts-expect-error - TODO
 			neu satisfies Types["bundle"]
 			throw new Error("Not implemented")
 		},
 		message: ({ old, neu }) => {
 			// expect old and neu to be of type Types["message"]
+			// @ts-expect-error - TODO
 			old satisfies Types["message"]
+			// @ts-expect-error - TODO
 			neu satisfies Types["message"]
 			throw new Error("Not implemented")
 		},
 		variant: ({ old, neu }) => {
 			// expect old and neu to be of type Types["variant"]
+			// @ts-expect-error - TODO
 			old satisfies Types["variant"]
+			// @ts-expect-error - TODO
 			neu satisfies Types["variant"]
 			throw new Error("Not implemented")
 		},
 	},
+}
+
+// ------------------- DIFF REPORT -------------------
+
+const diffReport: DiffReport = {} as any
+
+// expect that old is undefined and neu is defined
+if (diffReport.operation === "create") {
+	diffReport.old satisfies undefined
+	diffReport.neu satisfies Record<string, any>
+}
+
+// expect that old and neu are both defined
+if (diffReport.operation === "update") {
+	diffReport.old satisfies Record<string, any>
+	diffReport.neu satisfies Record<string, any>
+}
+
+// expect that neu is undefined and old is defined
+if (diffReport.operation === "delete") {
+	diffReport.old satisfies Record<string, any>
+	diffReport.neu satisfies undefined
 }

--- a/lix/packages/sdk/src/plugin.ts
+++ b/lix/packages/sdk/src/plugin.ts
@@ -35,14 +35,14 @@ type MaybePromise<T> = T | Promise<T>
  */
 export type DiffReport = {
 	type: string
-	operation: "insert" | "update" | "delete"
+	operation: "create" | "update" | "delete"
 	old?: Record<string, any> & { id: string }
 	neu?: Record<string, any> & { id: string }
 	meta?: Record<string, any>
 } & (DiffReportInsertion | DiffReportUpdate | DiffReportDeletion)
 
 type DiffReportInsertion = {
-	operation: "insert"
+	operation: "create"
 	old: undefined
 	neu: Record<string, any> & {
 		id: string

--- a/lix/packages/sdk/src/schema.ts
+++ b/lix/packages/sdk/src/schema.ts
@@ -39,6 +39,12 @@ export type Change = {
 	 * in case the user changes the plugin configuration.
 	 */
 	plugin_key: LixPlugin["key"]
+	/**
+	 * The operation that was performed.
+	 *
+	 * The operation is taken from the diff reports.
+	 */
+	operation: "insert" | "update" | "delete"
 
 	/**
 	 * The type of change that was made.

--- a/lix/packages/sdk/src/schema.ts
+++ b/lix/packages/sdk/src/schema.ts
@@ -44,7 +44,7 @@ export type Change = {
 	 *
 	 * The operation is taken from the diff reports.
 	 */
-	operation: "insert" | "update" | "delete"
+	operation: "create" | "update" | "delete"
 
 	/**
 	 * The type of change that was made.


### PR DESCRIPTION
## Context

Apps can't know if a change was an insert, update, or a delete. This is a follow up of https://github.com/opral/monorepo/pull/3043. 

## Proposal 

Expose the `operation` information that differs provide in a change. Apps will be able to display if a change was/is an insert, update, or deletion.  

```diff

export type Change = {
	id: string
	file_id: LixFile["id"]
	commit_id?: Commit["id"]
	plugin_key: LixPlugin["key"]
+	operation: "insert" | "update" | "delete"
	type: string
	value?: 
	meta?: string // JSONB
}


```

## Additional information

Testing with finkv2 indicates that everything works as expected. However, the written unit test is failing because the query `await lix.selectFrom("changes")` doesn't resolve. Don't know why. Works in fink. 