### PR TITLE
fix: broken link in 'Build a Global Svelte App' guide

### DIFF
--- a/inlang/guides/build-a-global-svelte-app/build-a-global-svelte-app.md
+++ b/inlang/guides/build-a-global-svelte-app/build-a-global-svelte-app.md
@@ -123,6 +123,6 @@ Paraglide-SvelteKit provides convenient functions for this. `i18n.route(translat
 
 Paraglide-SvelteKit has a few more features that you might want to check out, such as localized paths. Read more about it in the [Paraglide-SvelteKit Documentation](https://inlang.com/m/dxnzrydw/paraglide-sveltekit-i18n).
 
-Checkout the example GitHub](https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-sveltekit/example) or on [StackBlitz](https://stackblitz.com/~/github.com/lorissigrist/paraglide-sveltekit-example)
+[Checkout the example GitHub](https://github.com/opral/monorepo/tree/main/inlang/source-code/paraglide/paraglide-sveltekit/example) or on [StackBlitz](https://stackblitz.com/~/github.com/lorissigrist/paraglide-sveltekit-example)
 
 If you have any questions, feel free to ask them in our [Discord](https://discord.gg/CNPfhWpcAa) or open a discussion on [GitHub](https://github.com/opral/monorepo/discussions).


### PR DESCRIPTION
There's currently a broken link in the guide. This should fix it.

<img width="988" alt="Screenshot 2024-08-08 at 8 19 12 PM" src="https://github.com/user-attachments/assets/5ca6e053-6452-4bd2-8a85-6106bbb2552a">
