### PR TITLE
chore: add scoped prettier config

### DIFF
--- a/lix/packages/sdk/.prettierrc.json
+++ b/lix/packages/sdk/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+	"useTabs": true
+}


### PR DESCRIPTION
## Context 

Having no scoped prettier config leads to "randomly" chosen prettier configs and constant diffs/merge conflicts because two people might use different formatting options. 

## Change

Add a scopped prettier config to ensure everyone uses the same formatting config. 

- uses default prettier config except that tabs are used (better for accessibility) 

- did not run format yet to avoid huge diffs until https://github.com/opral/monorepo/pull/3051, https://github.com/opral/monorepo/pull/3052 are merged