### PR TITLE
lix merge

### DIFF
--- a/lix/packages/csv-app/src/csv-view.ts
+++ b/lix/packages/csv-app/src/csv-view.ts
@@ -49,13 +49,12 @@ export class CsvView extends BaseElement {
 					.where("commit_id", "is", null)
 					.execute()
 
-				const conflicts = []
-				// await this.lix?.db
-				// 	.selectFrom("change")
-				// 	.selectAll()
-				// 	.where("file_id", "=", this.fileId)
-				// 	.where("conflict", "is not", null)
-				// 	.execute()
+				const conflicts = await this.lix?.db
+					.selectFrom("change")
+					.selectAll()
+					.where("file_id", "=", this.fileId)
+					.where("conflict", "is not", null)
+					.execute()
 
 				const changes = await this.lix?.db
 					.selectFrom("change")

--- a/lix/packages/sdk/package.json
+++ b/lix/packages/sdk/package.json
@@ -16,6 +16,7 @@
 	"dependencies": {
 		"kysely": "^0.27.4",
 		"minimatch": "^10.0.1",
+		"papaparse": "^5.4.1",
 		"prettier": "^3.3.3",
 		"sqlite-wasm-kysely": "workspace: *",
 		"uuid": "^10.0.0"

--- a/lix/packages/sdk/src/change-queue.test.ts
+++ b/lix/packages/sdk/src/change-queue.test.ts
@@ -87,6 +87,7 @@ test("should use queue and settled correctly", async () => {
 	expect(changes).toEqual([
 		{
 			id: changes[0]?.id!,
+			conflict: null,
 			parent_id: null,
 			type: "text",
 			file_id: "test",
@@ -145,6 +146,7 @@ test("should use queue and settled correctly", async () => {
 		{
 			id: updatedChanges[0]?.id!,
 			parent_id: null,
+			conflict: null,
 			type: "text",
 			file_id: "test",
 			operation: "update",

--- a/lix/packages/sdk/src/commit.test.ts
+++ b/lix/packages/sdk/src/commit.test.ts
@@ -66,6 +66,7 @@ test("should be able to add and commit changes", async () => {
 			id: changes[0]?.id!,
 			parent_id: null,
 			type: "text",
+			conflict: null,
 			file_id: "test",
 			plugin_key: "mock-plugin",
 			value: {
@@ -101,6 +102,7 @@ test("should be able to add and commit changes", async () => {
 			type: "text",
 			file_id: "test",
 			plugin_key: "mock-plugin",
+			conflict: null,
 			value: {
 				id: "test",
 				text: "inserted text",
@@ -141,6 +143,7 @@ test("should be able to add and commit changes", async () => {
 			type: "text",
 			file_id: "test",
 			plugin_key: "mock-plugin",
+			conflict: null,
 			value: {
 				id: "test",
 				text: "inserted text",
@@ -155,6 +158,7 @@ test("should be able to add and commit changes", async () => {
 			type: "text",
 			file_id: "test",
 			plugin_key: "mock-plugin",
+			conflict: null,
 			value: {
 				id: "test",
 				text: "updated text",

--- a/lix/packages/sdk/src/file-handlers.ts
+++ b/lix/packages/sdk/src/file-handlers.ts
@@ -3,6 +3,7 @@ import type { LixDatabase, LixFile } from "./schema.js";
 import type { LixPlugin } from "./plugin.js";
 import { minimatch } from "minimatch";
 import { Kysely } from "kysely";
+import { getChangeHistory } from "./get-change-history.js";
 
 // start a new normalize path function that has the absolute minimum implementation.
 function normalizePath(path: string) {
@@ -10,62 +11,6 @@ function normalizePath(path: string) {
 		return "/" + path;
 	}
 	return path;
-}
-
-async function getChangeHistory({
-	atomId,
-	depth,
-	fileId,
-	pluginKey,
-	diffType,
-	db,
-}: {
-	atomId: string;
-	depth: number;
-	fileId: string;
-	pluginKey: string;
-	diffType: string;
-	db: Kysely<LixDatabase>;
-}): Promise<any[]> {
-	if (depth > 1) {
-		// TODO: walk change parents until depth
-		throw new Error("depth > 1 not supported yet");
-	}
-
-	const { commit_id } = await db
-		.selectFrom("ref")
-		.select("commit_id")
-		.where("name", "=", "current")
-		.executeTakeFirstOrThrow();
-
-	let nextCommitId = commit_id;
-	let firstChange;
-	while (!firstChange && nextCommitId) {
-		const commit = await db
-			.selectFrom("commit")
-			.selectAll()
-			.where("id", "=", nextCommitId)
-			.executeTakeFirst();
-
-		if (!commit) {
-			break;
-		}
-		nextCommitId = commit.parent_id;
-
-		firstChange = await db
-			.selectFrom("change")
-			.selectAll()
-			.where("commit_id", "=", commit.id)
-			.where((eb) => eb.ref("value", "->>").key("id"), "=", atomId)
-			.where("plugin_key", "=", pluginKey)
-			.where("file_id", "=", fileId)
-			.where("type", "=", diffType)
-			.executeTakeFirst();
-	}
-
-	const changes: any[] = [firstChange];
-
-	return changes;
 }
 
 // creates initial changes for new files

--- a/lix/packages/sdk/src/get-change-history.ts
+++ b/lix/packages/sdk/src/get-change-history.ts
@@ -1,0 +1,58 @@
+import { Kysely } from "kysely";
+import type { LixDatabase } from "./schema.js";
+
+export async function getChangeHistory({
+	atomId,
+	depth,
+	fileId,
+	pluginKey,
+	diffType,
+	db,
+}: {
+	atomId: string;
+	depth: number;
+	fileId: string;
+	pluginKey: string;
+	diffType: string;
+	db: Kysely<LixDatabase>;
+}): Promise<any[]> {
+	if (depth > 1) {
+		// TODO: walk change parents until depth
+		throw new Error("depth > 1 not supported yet");
+	}
+
+	const { commit_id } = await db
+		.selectFrom("ref")
+		.select("commit_id")
+		.where("name", "=", "current")
+		.executeTakeFirstOrThrow();
+
+	let nextCommitId = commit_id;
+	let firstChange;
+	while (!firstChange && nextCommitId) {
+		const commit = await db
+			.selectFrom("commit")
+			.selectAll()
+			.where("id", "=", nextCommitId)
+			.executeTakeFirst();
+
+		if (!commit) {
+			break;
+		}
+		nextCommitId = commit.parent_id;
+
+		firstChange = await db
+			.selectFrom("change")
+			.selectAll()
+			.where("commit_id", "=", commit.id)
+			.where((eb) => eb.ref("value", "->>").key("id"), "=", atomId)
+			.where("plugin_key", "=", pluginKey)
+			.where("file_id", "=", fileId)
+			.where("type", "=", diffType)
+			.executeTakeFirst();
+	}
+
+	const changes: any[] = [firstChange];
+
+	return changes;
+}

--- a/lix/packages/sdk/src/merge.test.ts
+++ b/lix/packages/sdk/src/merge.test.ts
@@ -1,0 +1,378 @@
+import { expect, test } from "vitest";
+import { openLixInMemory } from "./open/openLixInMemory.js";
+import { newLixFile } from "./newLix.js";
+import type { LixPlugin } from "./plugin.js";
+import papaparse from "papaparse";
+
+test("be able to merge two lix files correctly", async () => {
+	const mockPlugin: LixPlugin = {
+		key: "csv",
+		glob: "*.csv",
+
+		merge: {
+			file: async ({ current, conflicts, changes }) => {
+				// incoming.  fileId
+				const currentParsed = current
+					? papaparse.parse(new TextDecoder().decode(current), {
+							header: true,
+						})
+					: undefined;
+
+				if (currentParsed === undefined) {
+					throw new Error("cannot parse file for merging ");
+				}
+
+				const resolved = [];
+				const unresolved = [];
+				for (const conflict of conflicts) {
+					// @ts-ignore
+					const { hasConflict, result } = await mockPlugin.merge.cell(conflict);
+
+					result && resolved.push([result]);
+					hasConflict && unresolved.push(conflict);
+				}
+
+				for (const change of [...changes, ...resolved]) {
+					const latestChange = change[0]; // only using latest change for simple merge cases
+					const [rowId, columnName] = latestChange.value.id.split("-");
+
+					// TODO: handle insert/ delete row
+					const existingRow = currentParsed.data.find(
+						(row: any) => row.id === rowId,
+					);
+					existingRow[columnName] = latestChange.value.text;
+				}
+
+				const resultBlob = new TextEncoder().encode(
+					papaparse.unparse(currentParsed),
+				);
+
+				return { result: resultBlob, unresolved };
+			},
+
+			cell: async ({ current, incoming, base }) => {
+				// always raise conflicts resolving column "v" for testing
+				if (current[0].value.id.endsWith("-v")) {
+					const diff = await mockPlugin.diff.cell({
+						old: current[0].value,
+						neu: incoming[0].value,
+					});
+
+					if (diff.length > 0) {
+						console.log({ current, incoming, base });
+						return { hasConflict: true };
+					}
+				}
+
+				let chosen;
+				// choose latest edit
+				if (current[0].created > incoming[0].created) {
+					chosen = current[0];
+				} else {
+					chosen = incoming[0];
+				}
+
+				return { result: chosen };
+			},
+		},
+
+		diff: {
+			file: async ({ old, neu }) => {
+				/** @type {import("@lix-js/sdk").DiffReport[]} */
+				const result = [];
+
+				const oldParsed = old
+					? papaparse.parse(new TextDecoder().decode(old.data), {
+							header: true,
+						})
+					: undefined;
+
+				const newParsed = neu
+					? papaparse.parse(new TextDecoder().decode(neu.data), {
+							header: true,
+						})
+					: undefined;
+
+				if (newParsed) {
+					for (const [i, row] of newParsed.data.entries()) {
+						const oldRow = oldParsed?.data[i];
+						for (const column in row) {
+							const id = `${row.id}-${column}`;
+
+							const diff = await mockPlugin.diff.cell({
+								old: oldRow
+									? {
+											id,
+											text: oldRow[column],
+										}
+									: undefined,
+								neu: {
+									id,
+									text: row[column],
+								},
+							});
+
+							if (diff.length > 0) {
+								result.push(...diff);
+							}
+						}
+					}
+				}
+
+				return result;
+			},
+
+			// @ts-ignore --  TODO: handle return cases for operation independent
+			cell: async ({ old, neu }: { old: any; neu: any }) => {
+				if (old?.text === neu?.text) {
+					return [];
+				} else {
+					return [
+						{
+							type: "cell",
+							operation: old && neu ? "update" : old ? "delete" : "create",
+							old: old,
+							neu: neu
+								? {
+										id: neu.id,
+										text: neu.text,
+									}
+								: undefined,
+						},
+					];
+				}
+			},
+		},
+	};
+	const lixA = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
+
+	const lixB = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
+
+	const enc = new TextEncoder();
+	await lixA.db
+		.insertInto("file")
+		.values({
+			id: "test",
+			path: "test.csv",
+			data: enc.encode("id,a,b,c\na1,1,2,3"),
+		})
+		.execute();
+
+	await lixB.db
+		.insertInto("file")
+		.values({
+			id: "test",
+			path: "test.csv",
+			data: enc.encode("id,a,b,c\na1,1,2,3"),
+		})
+		.execute();
+
+	await lixA.settled();
+
+	const changes = await lixA.db.selectFrom("change").selectAll().execute();
+
+	expect(changes).toEqual([
+		{
+			commit_id: null,
+			conflict: null,
+			file_id: "test",
+			id: changes[0]!.id,
+			meta: null,
+			operation: "create",
+			parent_id: null,
+			plugin_key: "csv",
+			type: "cell",
+			value: {
+				id: "a1-id",
+				text: "a1",
+			},
+		},
+		{
+			commit_id: null,
+			conflict: null,
+			file_id: "test",
+			id: changes[1]!.id,
+			meta: null,
+			operation: "create",
+			parent_id: null,
+			plugin_key: "csv",
+			type: "cell",
+			value: {
+				id: "a1-a",
+				text: "1",
+			},
+		},
+		{
+			commit_id: null,
+			conflict: null,
+			file_id: "test",
+			id: changes[2]!.id,
+			meta: null,
+			operation: "create",
+			parent_id: null,
+			plugin_key: "csv",
+			type: "cell",
+			value: {
+				id: "a1-b",
+				text: "2",
+			},
+		},
+		{
+			commit_id: null,
+			conflict: null,
+			file_id: "test",
+			id: changes[3]!.id,
+			meta: null,
+			operation: "create",
+			parent_id: null,
+			plugin_key: "csv",
+			type: "cell",
+			value: {
+				id: "a1-c",
+				text: "3",
+			},
+		},
+	]);
+
+	const mergeResult = await lixA
+		.merge({
+			incommingDb: lixB.db,
+			userId: "test user",
+		})
+		.catch((error) => {
+			return { error };
+		});
+
+	expect(mergeResult!.error.message).toBe(
+		"cannot merge on uncommited changes, pls commit first",
+	);
+
+	await lixA.commit({ userId: "tester", description: "test commit" });
+	await lixB.commit({ userId: "tester 2", description: "test commit b" });
+
+	const mergeResult2 = await lixA
+		.merge({
+			incommingDb: lixB.db,
+			userId: "test user",
+		})
+		.catch((error) => {
+			return { error };
+		});
+
+	expect(mergeResult2!.error.message).toEqual("no common ancestor found");
+
+	const lixC = await openLixInMemory({
+		blob: await lixA.toBlob(),
+		providePlugins: [mockPlugin],
+	});
+
+	const mergeResult3 = await lixA
+		.merge({
+			incommingDb: lixC.db,
+			userId: "test user",
+		})
+		.catch((error) => {
+			return { error };
+		});
+
+	expect(mergeResult3).toBe(undefined);
+
+	await lixA.db
+		.insertInto("file")
+		.values({
+			id: "test",
+			path: "test.csv",
+			data: enc.encode("id,a,b,c\na1,1 changed in a,2 changed in a,3"),
+		})
+		.execute();
+
+	await lixC.db
+		.insertInto("file")
+		.values({
+			id: "test",
+			path: "test.csv",
+			data: enc.encode("id,a,b,c\na1,1,2 changed in c,3 changed in c"),
+		})
+		.execute();
+
+	await lixA.commit({ userId: "tester", description: "test commit 2" });
+	await lixC.commit({ userId: "tester 2", description: "test commit 2C" });
+
+	await lixA.settled();
+
+	const mergeResult4 = await lixA
+		.merge({
+			incommingDb: lixC.db,
+			userId: "test user",
+		})
+		.catch((error) => {
+			return { error };
+		});
+
+	console.log(mergeResult4);
+
+	// // Test replacing uncommitted changes and multiple changes processing
+	// await lix.db
+	// 	.updateTable("file")
+	// 	.set({ data: enc.encode("test updated text") })
+	// 	.where("id", "=", "test")
+	// 	.execute();
+
+	// await lix.db
+	// 	.updateTable("file")
+	// 	.set({ data: enc.encode("test updated text second update") })
+	// 	.where("id", "=", "test")
+	// 	.execute();
+
+	// const queue2 = await lix.db.selectFrom("change_queue").selectAll().execute();
+	// expect(queue2).toEqual([
+	// 	{
+	// 		id: 2,
+	// 		file_id: "test",
+	// 		path: "test.txt",
+	// 		data: queue2[0]?.data,
+	// 	},
+	// 	{
+	// 		id: 3,
+	// 		file_id: "test",
+	// 		path: "test.txt",
+	// 		data: queue2[1]?.data,
+	// 	},
+	// ]);
+
+	// await lix.settled();
+
+	// expect(
+	// 	(await lix.db.selectFrom("change_queue").selectAll().execute()).length,
+	// ).toBe(0);
+
+	// const updatedChanges = await lix.db
+	// 	.selectFrom("change")
+	// 	.selectAll()
+	// 	.execute();
+
+	// expect(updatedChanges).toEqual([
+	// 	{
+	// 		id: updatedChanges[0]?.id!,
+	// 		parent_id: null,
+	// 		type: "text",
+	// 		file_id: "test",
+	// 		operation: "update",
+	// 		plugin_key: "mock-plugin",
+	// 		value: {
+	// 			id: "test",
+	// 			text: "updated text",
+	// 		},
+	// 		meta: null,
+	// 		commit_id: null,
+	// 	},
+	// ]);
+
+	//
+});

--- a/lix/packages/sdk/src/merge.ts
+++ b/lix/packages/sdk/src/merge.ts
@@ -1,0 +1,247 @@
+import { commit } from "./commit.js";
+import { v4 } from "uuid";
+
+function indexByFileId(changes: any) {
+	const changesByFileId: Record<string, any> = {};
+	changes.forEach((change: any) => {
+		if (!changesByFileId[change.file_id]) {
+			changesByFileId[change.file_id] = {};
+		}
+		if (!changesByFileId[change.file_id][change.value.id]) {
+			changesByFileId[change.file_id][change.value.id] = [];
+		}
+
+		changesByFileId[change.file_id][change.value.id].push(change);
+	});
+
+	return changesByFileId;
+}
+
+export async function merge({
+	db,
+	incommingDb,
+	plugins,
+	userId,
+}: {
+	db: any;
+	incommingDb: any;
+	plugins: any;
+	userId: string;
+}) {
+	const dirty = await db
+		.selectFrom("change")
+		.select("id")
+		.where("commit_id", "is", null)
+		.executeTakeFirst();
+
+	if (dirty) {
+		throw new Error("cannot merge on uncommited changes, pls commit first");
+	}
+
+	const hasConflicts = await db
+		.selectFrom("change")
+		.selectAll()
+		.where("conflict", "is not", null)
+		.executeTakeFirst();
+	if (hasConflicts) {
+		throw new Error("cannot merge on existing conflicts, pls resolve first");
+	}
+
+	const { commit_id: aHead } = await db
+		.selectFrom("ref")
+		.selectAll()
+		.where("name", "=", "current")
+		.executeTakeFirstOrThrow();
+
+	const { commit_id: bHead } = await incommingDb
+		.selectFrom("ref")
+		.selectAll()
+		.where("name", "=", "current")
+		.executeTakeFirstOrThrow();
+
+	if (aHead === bHead) {
+		return;
+	}
+	// TODO: use single join on attached database instead
+
+	const bOnlyCommits = [];
+	const bOnlyChanges = [];
+	let commonAncestor;
+	let currentBCommitId = bHead;
+	while (currentBCommitId) {
+		const commit = await incommingDb
+			.selectFrom("commit")
+			.selectAll()
+			.where("id", "=", currentBCommitId)
+			.executeTakeFirst();
+		if (!commit) {
+			break;
+		}
+
+		commonAncestor = await db
+			.selectFrom("commit")
+			.selectAll()
+			.where("id", "=", commit.id)
+			.executeTakeFirst();
+
+		if (commonAncestor) {
+			break;
+		}
+
+		bOnlyCommits.push(commit);
+		bOnlyChanges.push(
+			...(await incommingDb
+				.selectFrom("change")
+				.selectAll()
+				.where("commit_id", "=", commit.id)
+				.execute()),
+		);
+		currentBCommitId = commit.parent_id;
+	}
+
+	if (!commonAncestor) {
+		throw new Error("no common ancestor found");
+	}
+
+	const aOnlyChanges = [];
+	const aOnlyCommits = [];
+	let currentACommitId = aHead;
+	while (currentACommitId && currentACommitId !== commonAncestor.id) {
+		const commit = await db
+			.selectFrom("commit")
+			.selectAll()
+			.where("id", "=", currentACommitId)
+			.executeTakeFirst();
+
+		aOnlyCommits.push(commit);
+
+		aOnlyChanges.push(
+			...(await db
+				.selectFrom("change")
+				.selectAll()
+				.where("commit_id", "=", commit.id)
+				.execute()),
+		);
+
+		currentACommitId = commit.parent_id;
+	}
+
+	const aOnlyChangesByFileId = indexByFileId(aOnlyChanges);
+	const bOnlyChangesByFileId = indexByFileId(bOnlyChanges);
+
+	// FIXME: new files in a are ignored for now, could have info relevant for merging, so best to add this
+
+	const fileChanges: any[] = [];
+	for (const [fileId, atomChangesByAtomId] of Object.entries(
+		bOnlyChangesByFileId,
+	)) {
+		if (!aOnlyChangesByFileId[fileId]) {
+			console.warn("TODO: copy over new files fileId: " + fileId);
+			continue;
+		}
+
+		const fileChange: {
+			fileId: string;
+			changes: any[];
+			conflicts: any[];
+		} = {
+			fileId: fileId,
+			changes: [],
+			conflicts: [],
+		};
+		// @ts-ignore
+		for (const [atomId, atomChanges] of Object.entries(atomChangesByAtomId)) {
+			if (aOnlyChangesByFileId[fileId][atomId]) {
+				const current = aOnlyChangesByFileId[fileId][atomId];
+				const base = await db
+					.selectFrom("change")
+					.selectAll()
+					.where("id", "=", current.at(-1).parent_id)
+					.executeTakeFirstOrThrow();
+
+				fileChange.conflicts.push({ current, incoming: atomChanges, base });
+			} else {
+				fileChange.changes.push(atomChanges);
+			}
+		}
+
+		fileChanges.push(fileChange);
+	}
+
+	const mergeResults: any[] = [];
+	for (const fileChange of fileChanges) {
+		const { data: current } = await db
+			.selectFrom("file_internal")
+			.select("data")
+			.where("id", "=", fileChange.fileId)
+			.executeTakeFirst();
+
+		const { data: incoming } = await incommingDb
+			.selectFrom("file_internal")
+			.select("data")
+			.where("id", "=", fileChange.fileId)
+			.executeTakeFirst();
+
+		for (const plugin of plugins) {
+			const mergeRes = await plugin.merge!.file!({
+				current,
+				incoming,
+				...fileChange,
+			});
+
+			mergeResults.push({ fileId: fileChange.fileId, ...mergeRes });
+		}
+	}
+
+	for (const { fileId, result, unresolved } of mergeResults) {
+		if (result) {
+			await db
+				.updateTable("file")
+				.set({
+					data: result,
+				})
+				.where("id", "=", fileId)
+				.execute();
+		}
+
+		if (unresolved) {
+			for (const { current, incoming } of unresolved) {
+				const parent = await db
+					.selectFrom("change")
+					.select("id")
+					.where(
+						(eb: any) => eb.ref("value", "->>").key("id"),
+						"=",
+						current[0].value.id,
+					)
+					.where("type", "=", current[0].type)
+					.where("file_id", "=", current[0].file_id)
+					.where("plugin_key", "=", current[0].plugin_key)
+					.where("commit_id", "is not", null)
+					.executeTakeFirst();
+
+				await db
+					.insertInto("change")
+					.values({
+						id: v4(),
+						type: current[0].type,
+						operation: "update",
+						file_id: current[0].file_id,
+						plugin_key: current[0].plugin_key,
+						parent_id: parent?.id,
+						value: JSON.stringify(current[0].value),
+						conflict: JSON.stringify(incoming),
+					})
+					.execute();
+			}
+		}
+	}
+
+	// TODO: sync in the history from the incoming database and add a link in the merge commit
+	await commit({
+		db,
+		userId,
+		description: "Merge",
+		merge: true,
+	});
+}

--- a/lix/packages/sdk/src/newLix.ts
+++ b/lix/packages/sdk/src/newLix.ts
@@ -56,7 +56,9 @@ export async function newLixFile(): Promise<Blob> {
         operation TEXT NOT NULL,
         value TEXT,
         meta TEXT,
-        commit_id TEXT
+        commit_id TEXT,
+        -- this is an array of the json of the conflicting changes:
+        conflict TEXT
       ) strict;
         
       CREATE TABLE 'commit' (

--- a/lix/packages/sdk/src/plugin.ts
+++ b/lix/packages/sdk/src/plugin.ts
@@ -15,6 +15,7 @@ export type LixPlugin<
 		keyof T,
 		(() => HTMLElement) | undefined
 	>;
+	merge?: any;
 	diff: {
 		file?: (args: {
 			old?: LixFile;

--- a/lix/packages/sdk/src/schema.ts
+++ b/lix/packages/sdk/src/schema.ts
@@ -83,6 +83,8 @@ export type Change = {
 	value?: Record<string, any> & {
 		id: string;
 	}; // JSONB
+
+	conflict?: any[] | null;
 	/**
 	 * Additional metadata for the change used by the plugin
 	 * to process changes.


### PR DESCRIPTION
@samuelstroschein   a few things to note:

- no virtual commits for uncomited changes yet, as this is not the default behaviour for this commit logic and we did not find an agreement for an alternative commit logic, this would be a seperate feature that we can add later (but i can also add this tomorrow, just ping me if i should add this behaviour to this PR)
- the conflicts are back in the change entries, not their own table as this makes merging much simpler, the conflict column is an array of the conflicting changes json
- existing conflicts are not merged in yet, so you cannot merge before resolving the last conflicts but i will add this tomorrow
- a few types are still missing
