### PR TITLE
chore: clean up dependencies

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -64,8 +64,6 @@
 		"prettier-plugin-jsdoc": "^1.3.0"
 	},
 	"devDependencies": {
-		"@inlang/language-tag": "workspace:*",
-		"@inlang/plugin-message-format": "workspace:*",
 		"@inlang/recommend-ninja": "workspace:*",
 		"@inlang/recommend-sherlock": "workspace:*",
 		"@inlang/sdk": "workspace:*",
@@ -74,7 +72,6 @@
 		"@rollup/plugin-terser": "0.4.3",
 		"@rollup/plugin-virtual": "3.0.1",
 		"@ts-morph/bootstrap": "0.20.0",
-		"@types/minimist": "1.2.3",
 		"@types/node": "^20.12.7",
 		"@types/prettier": "^3.0.0",
 		"@vitest/coverage-v8": "0.34.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1520,6 +1520,9 @@ importers:
       '@inlang/detect-json-formatting':
         specifier: workspace:*
         version: link:../../detect-json-formatting
+      '@inlang/sdk2':
+        specifier: workspace:*
+        version: link:../../sdk2
       commander:
         specifier: 11.1.0
         version: 11.1.0
@@ -1542,12 +1545,6 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(prettier@3.3.3)
     devDependencies:
-      '@inlang/language-tag':
-        specifier: workspace:*
-        version: link:../../versioned-interfaces/language-tag
-      '@inlang/plugin-message-format':
-        specifier: workspace:*
-        version: link:../../plugins/inlang-message-format
       '@inlang/recommend-ninja':
         specifier: workspace:*
         version: link:../../recommendations/recommend-ninja
@@ -1557,9 +1554,6 @@ importers:
       '@inlang/sdk':
         specifier: workspace:*
         version: link:../../sdk
-      '@inlang/sdk2':
-        specifier: workspace:*
-        version: link:../../sdk2
       '@lix-js/client':
         specifier: workspace:*
         version: link:../../../../lix/packages/client
@@ -1575,9 +1569,6 @@ importers:
       '@ts-morph/bootstrap':
         specifier: 0.20.0
         version: 0.20.0
-      '@types/minimist':
-        specifier: 1.2.3
-        version: 1.2.3
       '@types/node':
         specifier: ^20.12.7
         version: 20.14.14


### PR DESCRIPTION
Saw in https://github.com/opral/monorepo/pull/3071 that some dependencies are not used. This pr removes unused dependencies. 

Test are running through with one odd error. I assume it's unrelated to paraglide js, given that the path is some paraglide adapter `An error occurred while parsing "/Users/samuel/git-repos/opral-monorepo/inlang/source-code/paraglide/paraglide-sveltekit/example/tsconfig.json"`


![CleanShot 2024-08-22 at 18 10 16@2x](https://github.com/user-attachments/assets/dc049cfa-c916-47db-b4cc-53744ba9d42c)

