### PR TITLE
`resolveConflict()` api

### DIFF
--- a/lix/packages/sdk/package.json
+++ b/lix/packages/sdk/package.json
@@ -15,12 +15,14 @@
 	},
 	"dependencies": {
 		"kysely": "^0.27.4",
+		"lodash-es": "^4.17.21",
 		"minimatch": "^10.0.1",
 		"prettier": "^3.3.3",
 		"sqlite-wasm-kysely": "workspace: *",
 		"uuid": "^10.0.0"
 	},
 	"devDependencies": {
+		"@types/lodash-es": "^4.17.12",
 		"@types/papaparse": "^5.3.14",
 		"@types/uuid": "^10.0.0",
 		"@vitest/coverage-v8": "^2.0.5",

--- a/lix/packages/sdk/src/index.ts
+++ b/lix/packages/sdk/src/index.ts
@@ -5,5 +5,7 @@ export * from "./schema.js";
 export { jsonObjectFrom, jsonArrayFrom } from "kysely/helpers/sqlite";
 export { v4 as uuidv4 } from "uuid";
 export * from "./types.js";
-export { merge } from "./merge/merge.js";
 export * from "./query-utilities/index.js";
+export * from "./resolve-conflict/errors.js";
+export { merge } from "./merge/merge.js";
+export { resolveConflict } from "./resolve-conflict/resolve-conflict.js";

--- a/lix/packages/sdk/src/newLix.ts
+++ b/lix/packages/sdk/src/newLix.ts
@@ -65,6 +65,7 @@ export async function newLixFile(): Promise<Blob> {
         conflicting_change_id TEXT NOT NULL,
         reason TEXT,
         meta TEXT,
+        resolved_with_change_id TEXT,
         PRIMARY KEY (change_id, conflicting_change_id)
       ) strict;
         

--- a/lix/packages/sdk/src/resolve-conflict/errors.ts
+++ b/lix/packages/sdk/src/resolve-conflict/errors.ts
@@ -1,0 +1,33 @@
+export class ResolveConflictError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ResolveConflictError";
+	}
+}
+
+export class ChangeDoesNotBelongToFileError extends ResolveConflictError {
+	constructor() {
+		super(
+			"The to be resolved change does not belong to the same file as the conflicting changes.",
+		);
+		this.name = "ChangeDoesNotBelongToFileError";
+	}
+}
+
+export class ChangeNotDirectChildOfConflictError extends ResolveConflictError {
+	constructor() {
+		super(
+			"The to be resolved change is not a direct child of the conflicting changes. The parent_id of the resolveWithChange must be the id of the conflict or the conflicting change.",
+		);
+		this.name = "ChangeNotDirectChildOfConflictError";
+	}
+}
+
+export class ChangeHasBeenMutatedError extends ResolveConflictError {
+	constructor() {
+		super(
+			"The to be resolved change already exists in the database and is not equal to the provided change. Changes are immutable. If you want to resolve a conflict by updating a change, create a new change.",
+		);
+		this.name = "ChangeHasBeenMutatedError";
+	}
+}

--- a/lix/packages/sdk/src/resolve-conflict/resolve-conflict.test.ts
+++ b/lix/packages/sdk/src/resolve-conflict/resolve-conflict.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-null */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { test, expect, vi } from "vitest";
 import { openLixInMemory } from "../open/openLixInMemory.js";
@@ -5,6 +6,11 @@ import { newLixFile } from "../newLix.js";
 import { resolveConflict } from "./resolve-conflict.js";
 import type { Change } from "../schema.js";
 import type { LixPlugin } from "../plugin.js";
+import {
+	ChangeDoesNotBelongToFileError,
+	ChangeHasBeenMutatedError,
+	ChangeNotDirectChildOfConflictError,
+} from "./errors.js";
 
 test("it should resolve a conflict by applying the change and mark the conflict as resolved with the applied change", async () => {
 	const mockChanges: Change[] = [
@@ -95,20 +101,360 @@ test("it should resolve a conflict by applying the change and mark the conflict 
 	expect(resolvedConflict.resolved_with_change_id).toBe(changes[0]!.id);
 });
 
-test.todo(
-	"resolving a conflict should throw if the change to resolve with is not a direct child of the conflicting changes",
-);
+test("it should throw if the to be resolved with change already exists in the database but is not equal (change immutability is violated)", async () => {
+	const mockChanges: Change[] = [
+		{
+			id: "change1",
+			operation: "create",
+			plugin_key: "plugin1",
+			type: "mock",
+			file_id: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value1",
+			}),
+		},
+		{
+			id: "change2",
+			operation: "create",
+			file_id: "mock",
+			plugin_key: "plugin1",
+			type: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value2",
+			}),
+		},
+	];
 
-test.todo(
-	"resolving a conflict should throw if the change to resolve with does not belong to the same file as the conflicting changes",
-);
+	const mockPlugin: LixPlugin = {
+		key: "plugin1",
+		glob: "*",
+		applyChanges: vi.fn().mockResolvedValue({
+			fileData: new TextEncoder().encode(
+				mockChanges[0]?.value as unknown as string,
+			),
+		}),
+		diff: {
+			file: vi.fn(),
+		},
+	};
 
-test.todo(
-	"resolving a conflict should throw if the plugin does not support applying changes",
-);
+	const lix = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
 
-test.todo("resolving a conflict should throw if the file does not exist");
+	await lix.db
+		.insertInto("file")
+		.values({ id: "mock", path: "mock", data: new Uint8Array() })
+		.execute();
 
-test.todo(
-	"resolving a conflict with multiple conflicting changes should resolve all conflicts",
-);
+	const changes = await lix.db
+		.insertInto("change")
+		.values(mockChanges)
+		.returningAll()
+		.execute();
+
+	const conflict = await lix.db
+		.insertInto("conflict")
+		.values({
+			change_id: changes[0]!.id,
+			conflicting_change_id: changes[1]!.id,
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	await expect(
+		resolveConflict({
+			lix: lix,
+			conflict: conflict,
+			resolveWithChange: {
+				...changes[0]!,
+				// @ts-expect-error - manual stringification
+				value: JSON.stringify({
+					key: "mutated-value",
+				}),
+			},
+		}),
+	).rejects.toThrowError(new ChangeHasBeenMutatedError());
+});
+
+// the sequence of changes will be broken otherwise
+test("resolving a conflict should throw if the to be resolved with change is not a direct child of the conflicting changes", async () => {
+	const mockChanges: Change[] = [
+		{
+			id: "change1",
+			operation: "create",
+			plugin_key: "plugin1",
+			type: "mock",
+			file_id: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value1",
+			}),
+		},
+		{
+			id: "change2",
+			operation: "create",
+			file_id: "mock",
+			plugin_key: "plugin1",
+			type: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value2",
+			}),
+		},
+	];
+
+	const mockPlugin: LixPlugin = {
+		key: "plugin1",
+		glob: "*",
+		applyChanges: vi.fn().mockResolvedValue({
+			fileData: new TextEncoder().encode(
+				mockChanges[0]?.value as unknown as string,
+			),
+		}),
+		diff: {
+			file: vi.fn(),
+		},
+	};
+
+	const lix = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
+
+	await lix.db
+		.insertInto("file")
+		.values({ id: "mock", path: "mock", data: new Uint8Array() })
+		.execute();
+
+	const changes = await lix.db
+		.insertInto("change")
+		.values(mockChanges)
+		.returningAll()
+		.execute();
+
+	const conflict = await lix.db
+		.insertInto("conflict")
+		.values({
+			change_id: changes[0]!.id,
+			conflicting_change_id: changes[1]!.id,
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	await expect(
+		resolveConflict({
+			lix: lix,
+			conflict: conflict,
+			resolveWithChange: {
+				id: "new-change-3",
+				operation: "create",
+				file_id: "mock",
+				parent_id: undefined,
+				plugin_key: "plugin1",
+				type: "mock",
+				// @ts-expect-error - manual stringification
+				value: JSON.stringify({
+					key: "value3",
+				}),
+			},
+		}),
+	).rejects.toThrowError(new ChangeNotDirectChildOfConflictError());
+});
+
+// the sequence of changes will be broken otherwise
+test("resolving a conflict should throw if the change to resolve with does not belong to the same file as the conflicting changes", async () => {
+	const mockChanges: Change[] = [
+		{
+			id: "change1",
+			operation: "create",
+			plugin_key: "plugin1",
+			type: "mock",
+			file_id: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value1",
+			}),
+		},
+		{
+			id: "change2",
+			operation: "create",
+			file_id: "mock",
+			plugin_key: "plugin1",
+			type: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value2",
+			}),
+		},
+	];
+
+	const mockPlugin: LixPlugin = {
+		key: "plugin1",
+		glob: "*",
+		applyChanges: vi.fn().mockResolvedValue({
+			fileData: new TextEncoder().encode(
+				mockChanges[0]?.value as unknown as string,
+			),
+		}),
+		diff: {
+			file: vi.fn(),
+		},
+	};
+
+	const lix = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
+
+	await lix.db
+		.insertInto("file")
+		.values({ id: "mock", path: "mock", data: new Uint8Array() })
+		.execute();
+
+	const changes = await lix.db
+		.insertInto("change")
+		.values(mockChanges)
+		.returningAll()
+		.execute();
+
+	const conflict = await lix.db
+		.insertInto("conflict")
+		.values({
+			change_id: changes[0]!.id,
+			conflicting_change_id: changes[1]!.id,
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	await expect(
+		resolveConflict({
+			lix: lix,
+			conflict: conflict,
+			resolveWithChange: {
+				id: "new-change-3",
+				operation: "create",
+				file_id: "other-mock-file",
+				parent_id: changes[0]!.id,
+				plugin_key: "plugin1",
+				type: "mock",
+				// @ts-expect-error - manual stringification
+				value: JSON.stringify({
+					key: "value3",
+				}),
+			},
+		}),
+	).rejects.toThrowError(new ChangeDoesNotBelongToFileError());
+});
+
+test("resolving a conflict with a new change (likely the result of a merge resolution) should insert the change and mark the conflict as resolved with the new change", async () => {
+	const mockChanges: Change[] = [
+		{
+			id: "change1",
+			operation: "create",
+			plugin_key: "plugin1",
+			type: "mock",
+			file_id: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value1",
+			}),
+		},
+		{
+			id: "change2",
+			operation: "create",
+			file_id: "mock",
+			plugin_key: "plugin1",
+			type: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value2",
+			}),
+		},
+	];
+
+	const mockPlugin: LixPlugin = {
+		key: "plugin1",
+		glob: "*",
+		applyChanges: vi.fn().mockResolvedValue({
+			fileData: new TextEncoder().encode('{"key":"value3"}'),
+		}),
+		diff: {
+			file: vi.fn(),
+		},
+	};
+
+	const lix = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
+
+	await lix.db
+		.insertInto("file")
+		.values({ id: "mock", path: "mock", data: new Uint8Array() })
+		.execute();
+
+	const changes = await lix.db
+		.insertInto("change")
+		.values(mockChanges)
+		.returningAll()
+		.execute();
+
+	const conflict = await lix.db
+		.insertInto("conflict")
+		.values({
+			change_id: changes[0]!.id,
+			conflicting_change_id: changes[1]!.id,
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	await resolveConflict({
+		lix: lix,
+		conflict: conflict,
+		resolveWithChange: {
+			id: "new-change-3",
+			operation: "create",
+			file_id: "mock",
+			parent_id: changes[0]!.id,
+			plugin_key: "plugin1",
+			type: "mock",
+			value: {
+				// @ts-expect-error - manual stringification
+				key: "value3",
+			},
+		},
+	});
+
+	const resolvedConflict = await lix.db
+		.selectFrom("conflict")
+		.selectAll()
+		.where("change_id", "=", conflict.change_id)
+		.where("conflicting_change_id", "=", conflict.conflicting_change_id)
+		.executeTakeFirstOrThrow();
+
+	const fileAfterResolve = await lix.db
+		.selectFrom("file")
+		.selectAll()
+		.where("id", "=", changes[0]!.file_id)
+		.executeTakeFirstOrThrow();
+
+	const changesAfterResolve = await lix.db
+		.selectFrom("change")
+		.selectAll()
+		.execute();
+
+	expect(changesAfterResolve.length).toBe(3);
+	expect(resolvedConflict.resolved_with_change_id).toBe(
+		changesAfterResolve[2]?.id,
+	);
+	expect(changesAfterResolve[2]!.value).toStrictEqual({
+		key: "value3",
+	});
+	expect(new TextDecoder().decode(fileAfterResolve.data)).toBe(
+		'{"key":"value3"}',
+	);
+});

--- a/lix/packages/sdk/src/resolve-conflict/resolve-conflict.test.ts
+++ b/lix/packages/sdk/src/resolve-conflict/resolve-conflict.test.ts
@@ -6,7 +6,7 @@ import { resolveConflict } from "./resolve-conflict.js";
 import type { Change } from "../schema.js";
 import type { LixPlugin } from "../plugin.js";
 
-test("it should resolve a conflict and apply the change", async () => {
+test("it should resolve a conflict by applying the change and mark the conflict as resolved with the applied change", async () => {
 	const mockChanges: Change[] = [
 		{
 			id: "change1",
@@ -90,10 +90,25 @@ test("it should resolve a conflict and apply the change", async () => {
 		.executeTakeFirstOrThrow();
 
 	const parsed = new TextDecoder().decode(fileAfterResolve.data);
-	console.log(parsed);
-
-	await lix.settled();
 
 	expect(parsed).toBe(mockChanges[0]!.value);
 	expect(resolvedConflict.resolved_with_change_id).toBe(changes[0]!.id);
 });
+
+test.todo(
+	"resolving a conflict should throw if the change to resolve with is not a direct child of the conflicting changes",
+);
+
+test.todo(
+	"resolving a conflict should throw if the change to resolve with does not belong to the same file as the conflicting changes",
+);
+
+test.todo(
+	"resolving a conflict should throw if the plugin does not support applying changes",
+);
+
+test.todo("resolving a conflict should throw if the file does not exist");
+
+test.todo(
+	"resolving a conflict with multiple conflicting changes should resolve all conflicts",
+);

--- a/lix/packages/sdk/src/resolve-conflict/resolve-conflict.test.ts
+++ b/lix/packages/sdk/src/resolve-conflict/resolve-conflict.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { test, expect, vi } from "vitest";
+import { openLixInMemory } from "../open/openLixInMemory.js";
+import { newLixFile } from "../newLix.js";
+import { resolveConflict } from "./resolve-conflict.js";
+import type { Change } from "../schema.js";
+import type { LixPlugin } from "../plugin.js";
+
+test("it should resolve a conflict and apply the change", async () => {
+	const mockChanges: Change[] = [
+		{
+			id: "change1",
+			operation: "create",
+			plugin_key: "plugin1",
+			type: "mock",
+			file_id: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value1",
+			}),
+		},
+		{
+			id: "change2",
+			operation: "create",
+			plugin_key: "plugin1",
+			file_id: "mock",
+			type: "mock",
+			// @ts-expect-error - manual stringification
+			value: JSON.stringify({
+				key: "value2",
+			}),
+		},
+	];
+
+	const mockPlugin: LixPlugin = {
+		key: "plugin1",
+		glob: "*",
+		applyChanges: vi.fn().mockResolvedValue({
+			fileData: new TextEncoder().encode(
+				mockChanges[0]?.value as unknown as string,
+			),
+		}),
+		diff: {
+			file: vi.fn(),
+		},
+	};
+
+	const lix = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
+
+	await lix.db
+		.insertInto("file")
+		.values({ id: "mock", path: "mock", data: new Uint8Array() })
+		.execute();
+
+	const changes = await lix.db
+		.insertInto("change")
+		.values(mockChanges)
+		.returningAll()
+		.execute();
+
+	const conflict = await lix.db
+		.insertInto("conflict")
+		.values({
+			change_id: changes[0]!.id,
+			conflicting_change_id: changes[1]!.id,
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	await resolveConflict({
+		lix: lix,
+		conflict: conflict,
+		resolveWithChange: changes[0]!,
+	});
+
+	const resolvedConflict = await lix.db
+		.selectFrom("conflict")
+		.selectAll()
+		.where("change_id", "=", conflict.change_id)
+		.where("conflicting_change_id", "=", conflict.conflicting_change_id)
+		.executeTakeFirstOrThrow();
+
+	const fileAfterResolve = await lix.db
+		.selectFrom("file")
+		.selectAll()
+		.where("id", "=", changes[0]!.file_id)
+		.executeTakeFirstOrThrow();
+
+	const parsed = new TextDecoder().decode(fileAfterResolve.data);
+	console.log(parsed);
+
+	await lix.settled();
+
+	expect(parsed).toBe(mockChanges[0]!.value);
+	expect(resolvedConflict.resolved_with_change_id).toBe(changes[0]!.id);
+});

--- a/lix/packages/sdk/src/resolve-conflict/resolve-conflict.ts
+++ b/lix/packages/sdk/src/resolve-conflict/resolve-conflict.ts
@@ -5,6 +5,7 @@ import {
 	ChangeHasBeenMutatedError,
 	ChangeNotDirectChildOfConflictError,
 } from "./errors.js";
+import { isEqual } from "lodash-es";
 
 /**
  * Resolves a conflict by applying the given change.
@@ -43,8 +44,7 @@ export async function resolveConflict(args: {
 
 	if (
 		existingResolvedChange &&
-		JSON.stringify(existingResolvedChange) !==
-			JSON.stringify(args.resolveWithChange)
+		isEqual(existingResolvedChange, args.resolveWithChange) === false
 	) {
 		throw new ChangeHasBeenMutatedError();
 	}

--- a/lix/packages/sdk/src/resolve-conflict/resolve-conflict.ts
+++ b/lix/packages/sdk/src/resolve-conflict/resolve-conflict.ts
@@ -81,7 +81,7 @@ export async function resolveConflict(args: {
 
 	await args.lix.db.transaction().execute(async (trx) => {
 		await trx
-			.updateTable("file_internal")
+			.updateTable("file")
 			.set("data", fileData)
 			.where("id", "=", args.resolveWithChange.file_id)
 			.execute();

--- a/lix/packages/sdk/src/resolve-conflict/resolve-conflict.ts
+++ b/lix/packages/sdk/src/resolve-conflict/resolve-conflict.ts
@@ -1,0 +1,116 @@
+import type { Change, Conflict } from "../schema.js";
+import type { Lix } from "../types.js";
+
+/**
+ * Resolves a conflict by applying the given change.
+ */
+export async function resolveConflict(args: {
+	lix: Lix;
+	conflict: Conflict;
+	resolveWithChange: Change;
+}): Promise<void> {
+	if (args.lix.plugins.length !== 1) {
+		throw new Error("Unimplemented. Only one plugin is supported for now");
+	}
+
+	if (args.conflict.resolved_with_change_id !== null) {
+		throw new Error("Conflict already resolved");
+	}
+
+	const plugin = args.lix.plugins[0];
+	if (plugin?.applyChanges === undefined) {
+		throw new Error(
+			"Plugin does not support applying changes and therefore cannot resolve conflicts",
+		);
+	}
+
+	const change = await args.lix.db
+		.selectFrom("change")
+		.selectAll()
+		.where("id", "=", args.conflict.change_id)
+		.executeTakeFirst();
+
+	const potentiallyExistingResolvedChange = await args.lix.db
+		.selectFrom("change")
+		.selectAll()
+		.where("id", "=", args.resolveWithChange.id)
+		.executeTakeFirst();
+
+	// verify that the existing change does not differ from the resolveWithChange
+	// (changes are immutable). A change that is the result of a merge resolution
+	// should be a new change.
+
+	if (
+		potentiallyExistingResolvedChange &&
+		JSON.stringify(potentiallyExistingResolvedChange) !==
+			JSON.stringify(args.resolveWithChange)
+	) {
+		throw new Error(
+			"The to be resolved change id already exists in the database but both changes not equal. Changes are immutable. If you want to resolve a conflict by updating a change, create a new change.",
+		);
+	}
+
+	// it's a new change (likely a result of a merge resolution)
+	if (potentiallyExistingResolvedChange === undefined) {
+		if (
+			// TODO a change can have multiple parents. Displaying branches and merges is not possible if we only allow one parent.
+			args.resolveWithChange.parent_id !== args.conflict.change_id ||
+			args.resolveWithChange.parent_id !== args.conflict.conflicting_change_id
+		) {
+			throw new Error(
+				"The to be resolved change is not a direct child of the conflicting changes. The parent_id of the resolveWithChange must be the id of the conflict or the conflicting change.",
+			);
+		} else if (args.resolveWithChange.file_id !== change?.file_id) {
+			throw new Error(
+				"The to be resolved change does not belong to the same file as the conflicting changes",
+			);
+		}
+	}
+
+	const file = await args.lix.db
+		.selectFrom("file")
+		.selectAll()
+		.where("id", "=", args.resolveWithChange.file_id)
+		.executeTakeFirstOrThrow();
+
+	const { fileData } = await plugin.applyChanges({
+		lix: args.lix,
+		file: file,
+		changes: [args.resolveWithChange],
+	});
+
+	await args.lix.db.transaction().execute(async (trx) => {
+		await trx
+			.updateTable("file_internal")
+			.set("data", fileData)
+			.where("id", "=", args.resolveWithChange.file_id)
+			.execute();
+
+		// The change does not exist yet. (likely a merge resolution which led to a new change)
+		if (potentiallyExistingResolvedChange === undefined) {
+			await trx
+				.insertInto("change")
+				.values({
+					...args.resolveWithChange,
+					// @ts-expect-error - manual stringification
+					value: JSON.stringify(args.resolveWithChange.value),
+					// @ts-expect-error - manual stringification
+					meta: JSON.stringify(args.resolveWithChange.meta),
+				})
+				.execute();
+		}
+
+		await trx
+			.updateTable("conflict")
+			.where((eb) =>
+				eb.and({
+					change_id: args.conflict.change_id,
+					conflicting_change_id: args.conflict.conflicting_change_id,
+					// should not mutate conflicts for now
+					resolved_with_change_id: undefined,
+				}),
+			)
+			.set("resolved_with_change_id", args.resolveWithChange.id)
+			.execute();
+	});
+}

--- a/lix/packages/sdk/src/schema.ts
+++ b/lix/packages/sdk/src/schema.ts
@@ -105,4 +105,11 @@ export type Conflict = {
 	reason?: string;
 	change_id: Change["id"];
 	conflicting_change_id: Change["id"];
+	/**
+	 * The change id that the conflict was resolved with.
+	 *
+	 * Can be the change_id, conflicting_change_id, or another change_id
+	 * that resulted from a merge.
+	 */
+	resolved_with_change_id?: Change["id"];
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3495,6 +3495,9 @@ importers:
       kysely:
         specifier: ^0.27.4
         version: 0.27.4
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
       minimatch:
         specifier: ^10.0.1
         version: 10.0.1
@@ -3508,6 +3511,9 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/papaparse':
         specifier: ^5.3.14
         version: 5.3.14
@@ -12836,6 +12842,12 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 20.14.14
+    dev: true
+
+  /@types/lodash-es@4.17.12:
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+    dependencies:
+      '@types/lodash': 4.17.7
     dev: true
 
   /@types/lodash.merge@4.6.7:
@@ -23078,6 +23090,10 @@ packages:
     dependencies:
       p-locate: 6.0.0
     dev: true
+
+  /lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
 
   /lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}


### PR DESCRIPTION
## Context

This PR introduces the possibility for apps to resolve conflicts. Closes https://github.com/opral/lix-sdk/issues/49

A conflict is resolved by providing a change, which does not necessarily create a new change. If the change does not exist in the database (a resolution via merging two changes that result in a new change, for example), the function inserts the change.  

```ts
await resolveConflict({
  lix, 
  conflict: conflict,
  resolveWithChange: changes[0],
});
```