### PR TITLE
add: `change.author`

### DIFF
--- a/lix/packages/sdk/src/change-queue.test.ts
+++ b/lix/packages/sdk/src/change-queue.test.ts
@@ -1,7 +1,7 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { openLixInMemory } from "./open/openLixInMemory.js";
 import { newLixFile } from "./newLix.js";
-import type { LixPlugin } from "./plugin.js";
+import type { DiffReport, LixPlugin } from "./plugin.js";
 
 test("should use queue and settled correctly", async () => {
 	const mockPlugin: LixPlugin = {
@@ -87,6 +87,7 @@ test("should use queue and settled correctly", async () => {
 	expect(changes).toEqual([
 		{
 			id: changes[0]?.id,
+			author: null,
 			created_at: changes[0]?.created_at,
 			parent_id: null,
 			type: "text",
@@ -144,6 +145,7 @@ test("should use queue and settled correctly", async () => {
 
 	expect(updatedChanges).toEqual([
 		{
+			author: null,
 			id: updatedChanges[0]?.id,
 			created_at: updatedChanges[0]?.created_at,
 			parent_id: null,
@@ -160,5 +162,78 @@ test("should use queue and settled correctly", async () => {
 		},
 	]);
 
-	await lix.commit({ userId: "tester", description: "test commit" });
+	await lix.commit({ description: "test commit" });
+});
+
+test("changes should contain the author", async () => {
+	const mockPlugin: LixPlugin = {
+		key: "mock-plugin",
+		glob: "*",
+		diff: {
+			file: vi.fn().mockResolvedValue([
+				{
+					type: "mock",
+					operation: "create",
+					old: undefined,
+					neu: {} as any,
+				},
+			] satisfies DiffReport[]),
+		},
+	};
+	const lix = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
+
+	await lix.currentAuthor.set("some-id");
+
+	// testing an insert
+
+	await lix.db
+		.insertInto("file")
+		.values({
+			id: "mock",
+			data: new Uint8Array(),
+			path: "/mock-file.json",
+		})
+		.execute();
+
+	await lix.settled();
+
+	const changes1 = await lix.db.selectFrom("change").selectAll().execute();
+
+	expect(changes1[0]?.author).toBe("some-id");
+
+	// testing an update
+
+	await lix.db
+		.updateTable("file")
+		.set({
+			data: new Uint8Array(),
+		})
+		.where("id", "=", "mock")
+		.execute();
+
+	await lix.settled();
+
+	const changes2 = await lix.db.selectFrom("change").selectAll().execute();
+
+	expect(changes2[1]?.author).toBe("some-id");
+
+	// testing setting the author
+	await lix.currentAuthor.set("some-other-id");
+
+	await lix.db
+		.updateTable("file")
+		.set({
+			data: new Uint8Array(),
+		})
+		.where("id", "=", "mock")
+		.execute();
+
+	await lix.settled();
+
+	const changes3 = await lix.db.selectFrom("change").selectAll().execute();
+
+	expect(changes3.at(-1)?.author).toBe("some-other-id");
 });

--- a/lix/packages/sdk/src/commit.test.ts
+++ b/lix/packages/sdk/src/commit.test.ts
@@ -66,6 +66,7 @@ test("should be able to add and commit changes", async () => {
 	expect(changes).toEqual([
 		{
 			id: changes[0]?.id,
+			author: null,
 			created_at: changes[0]?.created_at,
 			parent_id: null,
 			type: "text",
@@ -81,7 +82,7 @@ test("should be able to add and commit changes", async () => {
 		},
 	]);
 
-	await lix.commit({ userId: "tester", description: "test" });
+	await lix.commit({ description: "test" });
 
 	const secondRef = await lix.db
 		.selectFrom("ref")
@@ -100,6 +101,7 @@ test("should be able to add and commit changes", async () => {
 	expect(commitedChanges).toEqual([
 		{
 			id: commitedChanges[0]?.id,
+			author: null,
 			created_at: changes[0]?.created_at,
 			parent_id: null,
 			type: "text",
@@ -118,11 +120,11 @@ test("should be able to add and commit changes", async () => {
 	expect(commits).toEqual([
 		{
 			id: commits[0]?.id!,
+			author: null,
 			created: commits[0]?.created!,
 			created_at: commits[0]?.created_at!,
 			description: "test",
 			parent_id: "00000000-0000-0000-0000-000000000000",
-			user_id: "tester",
 		},
 	]);
 
@@ -142,6 +144,7 @@ test("should be able to add and commit changes", async () => {
 	expect(updatedChanges).toEqual([
 		{
 			id: updatedChanges[0]?.id!,
+			author: null,
 			created_at: updatedChanges[0]?.created_at,
 			parent_id: null,
 			type: "text",
@@ -157,6 +160,7 @@ test("should be able to add and commit changes", async () => {
 		},
 		{
 			id: updatedChanges[1]?.id!,
+			author: null,
 			parent_id: updatedChanges[0]?.id!,
 			created_at: updatedChanges[0]?.created_at,
 			type: "text",
@@ -172,24 +176,24 @@ test("should be able to add and commit changes", async () => {
 		},
 	]);
 
-	await lix.commit({ userId: "tester", description: "test 2" });
+	await lix.commit({ description: "test 2" });
 	const newCommits = await lix.db.selectFrom("commit").selectAll().execute();
 	expect(newCommits).toEqual([
 		{
 			id: newCommits[0]?.id!,
+			author: null,
 			created: commits[0]?.created!,
 			created_at: newCommits[0]?.created_at!,
 			description: "test",
 			parent_id: "00000000-0000-0000-0000-000000000000",
-			user_id: "tester",
 		},
 		{
 			id: newCommits[1]?.id!,
+			author: null,
 			created: commits[0]?.created!,
 			created_at: newCommits[1]?.created_at!,
 			description: "test 2",
 			parent_id: newCommits[0]?.id!,
-			user_id: "tester",
 		},
 	]);
 });

--- a/lix/packages/sdk/src/commit.ts
+++ b/lix/packages/sdk/src/commit.ts
@@ -4,9 +4,9 @@ import { v4 } from "uuid";
 
 export async function commit(args: {
 	db: Kysely<LixDatabase>;
-	userId: string;
+	currentAuthor?: string;
+	// TODO remove description
 	description: string;
-	// merge?: boolean
 }) {
 	const newCommitId = v4();
 
@@ -21,7 +21,7 @@ export async function commit(args: {
 			.insertInto("commit")
 			.values({
 				id: newCommitId,
-				user_id: args.userId,
+				author: args.currentAuthor,
 				// todo - use zoned datetime
 				description: args.description,
 				parent_id,

--- a/lix/packages/sdk/src/file-handlers.ts
+++ b/lix/packages/sdk/src/file-handlers.ts
@@ -73,6 +73,7 @@ export async function handleFileInsert(args: {
 	neu: LixFile;
 	plugins: LixPlugin[];
 	db: Kysely<LixDatabase>;
+	currentAuthor?: string;
 	queueEntry: any;
 }) {
 	const pluginDiffs: any[] = [];
@@ -104,6 +105,7 @@ export async function handleFileInsert(args: {
 						id: v4(),
 						type: diff.type,
 						file_id: args.neu.id,
+						author: args.currentAuthor,
 						plugin_key: pluginKey,
 						operation: diff.operation,
 						// @ts-expect-error - database expects stringified json
@@ -129,6 +131,7 @@ export async function handleFileChange(args: {
 	old: LixFile;
 	neu: LixFile;
 	plugins: LixPlugin[];
+	currentAuthor?: string;
 	db: Kysely<LixDatabase>;
 }) {
 	const fileId = args.neu?.id ?? args.old?.id;
@@ -221,6 +224,7 @@ export async function handleFileChange(args: {
 							.where("commit_id", "is", null)
 							.set({
 								id: v4(),
+								author: args.currentAuthor,
 								// @ts-expect-error - database expects stringified json
 								value: JSON.stringify(value),
 								operation: diff.operation,
@@ -237,6 +241,7 @@ export async function handleFileChange(args: {
 							type: diff.type,
 							file_id: fileId,
 							plugin_key: pluginKey,
+							author: args.currentAuthor,
 							parent_id: previousCommittedChange?.id,
 							// @ts-expect-error - database expects stringified json
 							value: JSON.stringify(value),

--- a/lix/packages/sdk/src/merge/merge.test.ts
+++ b/lix/packages/sdk/src/merge/merge.test.ts
@@ -469,7 +469,6 @@ test("it should naively copy changes from the sourceLix into the targetLix that 
 			id: "commit-1",
 			description: "",
 			parent_id: "0",
-			user_id: "",
 		},
 	];
 

--- a/lix/packages/sdk/src/newLix.test.ts
+++ b/lix/packages/sdk/src/newLix.test.ts
@@ -29,7 +29,6 @@ test("inserting a commit should auto fill the created_at column", async () => {
 		.insertInto("commit")
 		.values({
 			id: "test",
-			user_id: "test",
 			parent_id: "test",
 			description: "test",
 		})

--- a/lix/packages/sdk/src/newLix.ts
+++ b/lix/packages/sdk/src/newLix.ts
@@ -49,6 +49,7 @@ export async function newLixFile(): Promise<Blob> {
       
       CREATE TABLE change (
         id TEXT PRIMARY KEY,
+        author TEXT,
         parent_id TEXT,
         type TEXT NOT NULL,
         file_id TEXT NOT NULL,
@@ -70,7 +71,7 @@ export async function newLixFile(): Promise<Blob> {
         
       CREATE TABLE 'commit' (
         id TEXT PRIMARY KEY,
-        user_id TEXT NOT NULL,
+        author TEXT,
         parent_id TEXT NOT NULL,
         description TEXT NOT NULL,
         created TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,

--- a/lix/packages/sdk/src/schema.ts
+++ b/lix/packages/sdk/src/schema.ts
@@ -32,9 +32,9 @@ export type LixFile = {
 export type Commit = {
 	id: string; // uuid
 	// todo:
-	//  multiple users can commit one change
+	//  multiple authors can commit one change
 	//  think of real-time collaboration scenarios
-	user_id: string; // @relation to a user
+	author?: string;
 	description: string;
 	/**
 	 * @deprecated use created_at instead
@@ -46,9 +46,12 @@ export type Commit = {
 	// @relation changes: Change[]
 };
 
-export type Change<T extends Record<string, any> = Record<string, { id: string }>> = {
+export type Change<
+	T extends Record<string, any> = Record<string, { id: string }>,
+> = {
 	id: string;
 	parent_id?: Change["id"];
+	author?: string;
 	file_id: LixFile["id"];
 	/**
 	 * If no commit id exists on a change,


### PR DESCRIPTION
## Context

Closes https://github.com/opral/inlang-sdk/issues/133. 

### Changes

- adds `change.author` 
- refactors `commit.user_id` to `commit.author` for alignment with change.author
- marks `commit.author` as nullable (if a user did not "log in" or specified who they are, no author exists)

### Decisions

- only handles singular author case to avoid longer decision-making on https://github.com/opral/lix-sdk/issues/56 to unblock which will block fink
- does not introduce an `Account` table that author references for foreign key consistency because of https://github.com/opral/lix-sdk/issues/56