### PR TITLE
refactor: use updatable types

### DIFF
--- a/inlang/source-code/sdk2/src/database/createSchema.ts
+++ b/inlang/source-code/sdk2/src/database/createSchema.ts
@@ -1,0 +1,33 @@
+import { sql, type Kysely } from "kysely";
+import type { SqliteDatabase } from "sqlite-wasm-kysely";
+
+export async function createSchema(args: {
+	db: Kysely<any>;
+	sqlite: SqliteDatabase;
+}) {
+	return sql`
+CREATE TABLE bundle (
+  id TEXT PRIMARY KEY DEFAULT (bundle_id()),
+  alias TEXT NOT NULL
+);
+
+CREATE TABLE message (
+  id TEXT PRIMARY KEY DEFAULT (uuid_v4()), 
+  bundle_id TEXT NOT NULL,
+  locale TEXT NOT NULL,
+  declarations TEXT NOT NULL,
+  selectors TEXT NOT NULL
+);
+
+CREATE TABLE variant (
+  id TEXT PRIMARY KEY DEFAULT (uuid_v4()), 
+  message_id TEXT NOT NULL,
+  match TEXT NOT NULL,
+  pattern TEXT NOT NULL
+);
+  
+CREATE INDEX idx_message_bundle_id ON message (bundle_id);
+CREATE INDEX idx_variant_message_id ON variant (message_id);
+
+`.execute(args.db);
+}

--- a/inlang/source-code/sdk2/src/database/initDb.test.ts
+++ b/inlang/source-code/sdk2/src/database/initDb.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from "vitest";
 import { initDb } from "./initDb.js";
 import { isBundleId } from "../bundle-id/bundle-id.js";
 import { validate } from "uuid";
-import { createSchema } from "./schema.js";
+import { createSchema } from "./createSchema.js";
 
 test("bundle ids should have a default value", async () => {
 	const sqlite = await createInMemoryDatabase({
@@ -60,7 +60,8 @@ test("variant ids should default to uuid", async () => {
 		.insertInto("variant")
 		.values({
 			messageId: "mock",
-			match: "mock",
+			// @ts-expect-error - manually serialize
+			match: "{}",
 			// @ts-expect-error - manually serialize
 			pattern: JSON.stringify({}),
 		})

--- a/inlang/source-code/sdk2/src/database/schema.ts
+++ b/inlang/source-code/sdk2/src/database/schema.ts
@@ -1,7 +1,5 @@
-import type { Generated } from "kysely";
+import type { Generated, Insertable, Selectable, Updateable } from "kysely";
 import type { Bundle, Message, Variant } from "../schema/schemaV2.js";
-import type { SqliteDatabase } from "sqlite-wasm-kysely";
-import { sql, type Kysely } from "kysely";
 
 export type InlangDatabaseSchema = {
 	bundle: BundleTable;
@@ -21,33 +19,31 @@ type VariantTable = Omit<Variant, "id"> & {
 	id: Generated<string>;
 };
 
-export async function createSchema(args: {
-	db: Kysely<any>;
-	sqlite: SqliteDatabase;
-}) {
-	return sql`
-CREATE TABLE bundle (
-  id TEXT PRIMARY KEY DEFAULT (bundle_id()),
-  alias TEXT NOT NULL
-);
+export type NewBundle = Insertable<BundleTable>;
+export type BundleUpdate = Updateable<BundleTable>;
 
-CREATE TABLE message (
-  id TEXT PRIMARY KEY DEFAULT (uuid_v4()), 
-  bundle_id TEXT NOT NULL,
-  locale TEXT NOT NULL,
-  declarations TEXT NOT NULL,
-  selectors TEXT NOT NULL
-);
+export type NewMessage = Insertable<MessageTable>;
+export type MessageUpdate = Updateable<MessageTable>;
 
-CREATE TABLE variant (
-  id TEXT PRIMARY KEY DEFAULT (uuid_v4()), 
-  message_id TEXT NOT NULL,
-  match TEXT NOT NULL,
-  pattern TEXT NOT NULL
-);
-  
-CREATE INDEX idx_message_bundle_id ON message (bundle_id);
-CREATE INDEX idx_variant_message_id ON variant (message_id);
+export type NewVariant = Selectable<VariantTable>;
+export type VariantUpdate = Updateable<VariantTable>;
 
-`.execute(args.db);
-}
+export type MessageNested = Message & {
+	variants: Variant[];
+};
+export type NewMessageNested = NewMessage & {
+	variants: NewVariant[];
+};
+export type MessageNestedUpdate = Updateable<MessageTable> & {
+	variants: VariantUpdate[];
+};
+
+export type BundleNested = Bundle & {
+	messages: MessageNested[];
+};
+export type NewBundleNested = NewBundle & {
+	messages: NewMessageNested[];
+};
+export type BundleNestedUpdate = BundleUpdate & {
+	messages: MessageNestedUpdate[];
+};

--- a/inlang/source-code/sdk2/src/helper.ts
+++ b/inlang/source-code/sdk2/src/helper.ts
@@ -1,15 +1,9 @@
 // @ts-ignore
 import { v4 as uuid } from "uuid";
-import type {
-	Bundle,
-	BundleNested,
-	Expression,
-	MessageNested,
-	Text,
-	Variant,
-} from "./schema/schemaV2.js";
+import type { Bundle, Expression, Text, Variant } from "./schema/schemaV2.js";
 import type { ProjectSettings } from "./schema/settings.js";
 import { generateBundleId } from "./bundle-id/bundle-id.js";
+import type { BundleNested, MessageNested } from "./database/schema.js";
 
 /**
  * create v2 Bundle with a random human ID

--- a/inlang/source-code/sdk2/src/index.ts
+++ b/inlang/source-code/sdk2/src/index.ts
@@ -17,3 +17,4 @@ export {
 export type { InlangDatabaseSchema } from "./database/schema.js";
 export type { ResourceFile } from "./project/api.js";
 export type { InlangPlugin } from "./plugin/schema.js";
+export * from "./database/schema.js";

--- a/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.test.ts
+++ b/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.test.ts
@@ -231,6 +231,7 @@ describe("plugin.diff.file", () => {
 				messageId: "1",
 				// @ts-expect-error - database expects stringified json
 				pattern: JSON.stringify([{ type: "text", value: "hello world" }]),
+				// @ts-expect-error - database expects stringified json
 				match: JSON.stringify({}),
 			})
 			.execute();
@@ -266,6 +267,7 @@ describe("plugin.diff.file", () => {
 					messageId: "1",
 					// @ts-expect-error - database expects stringified json
 					pattern: JSON.stringify([{ type: "text", value: "hello world" }]),
+					// @ts-expect-error - database expects stringified json
 					match: JSON.stringify({}),
 				},
 				{
@@ -273,6 +275,7 @@ describe("plugin.diff.file", () => {
 					messageId: "1",
 					// @ts-expect-error - database expects stringified json
 					pattern: JSON.stringify([{ type: "text", value: "hello world" }]),
+					// @ts-expect-error - database expects stringified json
 					match: JSON.stringify({}),
 				},
 			])
@@ -288,6 +291,7 @@ describe("plugin.diff.file", () => {
 					pattern: JSON.stringify([
 						{ type: "text", value: "hello world from Berlin" },
 					]),
+					// @ts-expect-error - database expects stringified json
 					match: JSON.stringify({}),
 				},
 				{
@@ -295,6 +299,7 @@ describe("plugin.diff.file", () => {
 					messageId: "1",
 					// @ts-expect-error - database expects stringified json
 					pattern: JSON.stringify([{ type: "text", value: "hello world" }]),
+					// @ts-expect-error - database expects stringified json
 					match: JSON.stringify({}),
 				},
 			])

--- a/inlang/source-code/sdk2/src/mock/mockhelper.ts
+++ b/inlang/source-code/sdk2/src/mock/mockhelper.ts
@@ -1,11 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type {
-	BundleNested,
-	Declaration,
-	Expression,
-	MessageNested,
-	Pattern,
-} from "../schema/schemaV2.js";
+import type { Declaration, Expression, Pattern } from "../schema/schemaV2.js";
 import { generateBundleId } from "../bundle-id/bundle-id.js";
 import {
 	inputNames,
@@ -15,6 +9,7 @@ import {
 } from "./mockdata.js";
 //@ts-ignore
 import { v4 } from "uuid";
+import type { BundleNested, MessageNested } from "../database/schema.js";
 
 export function generateUUID() {
 	return v4();

--- a/inlang/source-code/sdk2/src/mock/plural/bundle.ts
+++ b/inlang/source-code/sdk2/src/mock/plural/bundle.ts
@@ -1,4 +1,4 @@
-import type { BundleNested } from "../../schema/schemaV2.js";
+import type { BundleNested } from "../../database/schema.js";
 
 export const pluralBundle: BundleNested = {
 	id: "mock_bundle_human_id",

--- a/inlang/source-code/sdk2/src/plugin/schema.ts
+++ b/inlang/source-code/sdk2/src/plugin/schema.ts
@@ -1,8 +1,8 @@
 import type { TObject } from "@sinclair/typebox";
-import type { BundleNested } from "../schema/schemaV2.js";
 import type { MessageV1 } from "../schema/schemaV1.js";
 import type { ProjectSettings } from "../schema/settings.js";
 import type { ResourceFile } from "../project/api.js";
+import type { BundleNested, NewBundleNested } from "../database/schema.js";
 
 export type InlangPlugin<
 	ExternalSettings extends Record<string, any> | unknown = unknown
@@ -43,7 +43,7 @@ export type InlangPlugin<
 		files: Array<ResourceFile>;
 		settings: ProjectSettings & ExternalSettings; // we expose the settings in case the importFunction needs to access the plugin config
 	}) => {
-		bundles: BundleNested[];
+		bundles: NewBundleNested[];
 	};
 	exportFiles?: (args: {
 		bundles: BundleNested[];

--- a/inlang/source-code/sdk2/src/project/api.ts
+++ b/inlang/source-code/sdk2/src/project/api.ts
@@ -1,7 +1,9 @@
 import type { Kysely } from "kysely";
-import type { InlangDatabaseSchema } from "../database/schema.js";
+import type {
+	InlangDatabaseSchema,
+	NewBundleNested,
+} from "../database/schema.js";
 import type { InlangPlugin } from "../plugin/schema.js";
-import type { BundleNested } from "../schema/schemaV2.js";
 import type { ProjectSettings } from "../schema/settings.js";
 import type { Lix } from "@lix-js/sdk";
 import type { SqliteDatabase } from "sqlite-wasm-kysely";
@@ -33,7 +35,7 @@ export type InlangProject = {
 	importFiles: (args: {
 		pluginKey: InlangPlugin["key"];
 		files: ResourceFile[];
-	}) => Promise<BundleNested[]>;
+	}) => Promise<NewBundleNested[]>;
 	exportFiles: (args: {
 		pluginKey: InlangPlugin["key"];
 	}) => Promise<ResourceFile[]>;

--- a/inlang/source-code/sdk2/src/project/loadProject.test.ts
+++ b/inlang/source-code/sdk2/src/project/loadProject.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from "vitest";
 import { newProject } from "./newProject.js";
 import { loadProjectInMemory } from "./loadProjectInMemory.js";
-import { generateBundleId } from "../bundle-id/bundle-id.js";
-import { uuidv4 } from "@lix-js/sdk";
 
 test("it should persist changes of bundles, messages, and variants to lix ", async () => {
 	const file1 = await newProject();
@@ -10,7 +8,6 @@ test("it should persist changes of bundles, messages, and variants to lix ", asy
 	const bundle = await project1.db
 		.insertInto("bundle")
 		.values({
-			id: generateBundleId(),
 			// @ts-expect-error - manual stringification
 			alias: JSON.stringify({ default: "bundle1" }),
 		})
@@ -20,7 +17,6 @@ test("it should persist changes of bundles, messages, and variants to lix ", asy
 	const message = await project1.db
 		.insertInto("message")
 		.values({
-			id: uuidv4(),
 			bundle_id: bundle.id,
 			locale: "en",
 			// @ts-expect-error - manual stringification
@@ -34,9 +30,9 @@ test("it should persist changes of bundles, messages, and variants to lix ", asy
 	await project1.db
 		.insertInto("variant")
 		.values({
-			id: uuidv4(),
 			message_id: message.id,
-			match: "exact",
+			// @ts-expect-error - manual stringification
+			match: JSON.stringify({}),
 			// @ts-expect-error - manual stringification
 			pattern: "[]",
 		})

--- a/inlang/source-code/sdk2/src/project/loadProjectFromDirectory.ts
+++ b/inlang/source-code/sdk2/src/project/loadProjectFromDirectory.ts
@@ -7,7 +7,7 @@ import type fs from "node:fs/promises";
 import nodePath from "node:path";
 import type { InlangPlugin } from "../plugin/schema.js";
 import { insertBundleNested } from "../query-utilities/insertBundleNested.js";
-import { fromMessageV1 } from "./util/fromMessageV1.js";
+import { fromMessageV1 } from "../schema/migrations/fromMessageV1.js";
 
 /**
  * Loads a project from a directory.

--- a/inlang/source-code/sdk2/src/project/loadProjectInMemory.test.ts
+++ b/inlang/source-code/sdk2/src/project/loadProjectInMemory.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "vitest";
 import { newProject } from "./newProject.js";
 import { loadProjectInMemory } from "./loadProjectInMemory.js";
-import { generateBundleId } from "../bundle-id/bundle-id.js";
 
 test("roundtrip should succeed", async () => {
 	const file1 = await newProject();
@@ -15,7 +14,6 @@ test("roundtrip should succeed", async () => {
 	const insertedBundle = await project1.db
 		.insertInto("bundle")
 		.values({
-			id: generateBundleId(),
 			// @ts-expect-error - manual stringification
 			alias: JSON.stringify({ default: "bundle1" }),
 		})

--- a/inlang/source-code/sdk2/src/project/newProject.ts
+++ b/inlang/source-code/sdk2/src/project/newProject.ts
@@ -5,7 +5,7 @@ import {
 	createInMemoryDatabase,
 } from "sqlite-wasm-kysely";
 import { initDb } from "../database/initDb.js";
-import { createSchema } from "../database/schema.js";
+import { createSchema } from "../database/createSchema.js";
 
 /**
  * Creates a new inlang project.

--- a/inlang/source-code/sdk2/src/query-utilities/updateBundleNested.ts
+++ b/inlang/source-code/sdk2/src/query-utilities/updateBundleNested.ts
@@ -1,43 +1,33 @@
 import type { Kysely } from "kysely";
-import type { BundleNested } from "../schema/schemaV2.js";
-import { json } from "./toJSONRawBuilder.js";
-import type { InlangDatabaseSchema } from "../database/schema.js";
+import type {
+	BundleNestedUpdate,
+	InlangDatabaseSchema,
+} from "../database/schema.js";
 
 export const updateBundleNested = async (
 	db: Kysely<InlangDatabaseSchema>,
-	bundle: BundleNested
+	bundle: BundleNestedUpdate & {
+		id: string;
+		messages: { id: string; variants: { id: string }[] }[];
+	}
 ): Promise<void> => {
 	await db
 		.updateTable("bundle")
-		.set({
-			id: bundle.id,
-			alias: json(bundle.alias),
-		})
+		.set(bundle)
 		.where("id", "=", bundle.id)
 		.execute();
 
 	for (const message of bundle.messages) {
 		await db
 			.updateTable("message")
-			.set({
-				id: message.id,
-				bundleId: bundle.id,
-				locale: message.locale,
-				declarations: json(message.declarations),
-				selectors: json(message.selectors),
-			})
+			.set(message)
 			.where("id", "=", message.id)
 			.execute();
 
 		for (const variant of message.variants) {
 			await db
 				.updateTable("variant")
-				.set({
-					id: variant.id,
-					messageId: message.id,
-					match: json(variant.match),
-					pattern: json(variant.pattern),
-				})
+				.set(variant)
 				.where("id", "=", variant.id)
 				.execute();
 		}

--- a/inlang/source-code/sdk2/src/schema/migrations/fromMessageV1.test.ts
+++ b/inlang/source-code/sdk2/src/schema/migrations/fromMessageV1.test.ts
@@ -1,8 +1,7 @@
 import { test, expect } from "vitest";
 import { fromMessageV1 } from "./fromMessageV1.js";
 import { Value } from "@sinclair/typebox/value";
-import { MessageV1 } from "../../schema/schemaV1.js";
-import { BundleNested } from "../../schema/schemaV2.js";
+import { MessageV1 } from "../schemaV1.js";
 
 const messageV1: MessageV1 = {
 	id: "hello_world",
@@ -83,11 +82,9 @@ const bundle = {
 	],
 };
 
-test.todo("fromMessageV1", () => {
+test("fromMessageV1", () => {
 	expect(Value.Check(MessageV1, messageV1)).toBe(true);
-
 	const nestedBundle: unknown = fromMessageV1(messageV1, "mock");
-	expect(Value.Check(BundleNested, nestedBundle)).toBe(true);
 
 	expect(nestedBundle).toEqual(bundle);
 });

--- a/inlang/source-code/sdk2/src/schema/migrations/fromMessageV1.ts
+++ b/inlang/source-code/sdk2/src/schema/migrations/fromMessageV1.ts
@@ -1,14 +1,8 @@
 import { generateStableBundleId } from "../../bundle-id/bundle-id.js";
+import type { BundleNested, MessageNested } from "../../database/schema.js";
 import type { InlangPlugin } from "../../plugin/schema.js";
-import type { MessageV1, PatternV1 } from "../../schema/schemaV1.js";
-import type {
-	BundleNested,
-	Declaration,
-	Expression,
-	MessageNested,
-	Pattern,
-	Variant,
-} from "../../schema/schemaV2.js";
+import type { MessageV1, PatternV1 } from "../schemaV1.js";
+import type { Declaration, Expression, Pattern, Variant } from "../schemaV2.js";
 
 /**
  * Converts a MessageV1 into a BundleNested
@@ -58,6 +52,7 @@ export function fromMessageV1(
 			}
 
 			variants.push({
+				// @ts-expect-error - matching was not supported. no problem should arise
 				match: v1Variant.match,
 				pattern: fromPatternV1(v1Variant.pattern),
 				id: messageId + "_" + variantIndex,

--- a/inlang/source-code/sdk2/src/schema/migrations/toMessageV1.test.ts
+++ b/inlang/source-code/sdk2/src/schema/migrations/toMessageV1.test.ts
@@ -1,12 +1,10 @@
 import { test, expect } from "vitest";
 import { toMessageV1 } from "./toMessageV1.js";
 import { Value } from "@sinclair/typebox/value";
-import { MessageV1 } from "../../schema/schemaV1.js";
-import { BundleNested } from "../../schema/schemaV2.js";
+import { MessageV1 } from "../schemaV1.js";
+import type { BundleNested } from "../../database/schema.js";
 
 test("toMessageV1", () => {
-	expect(Value.Check(BundleNested, bundle)).toBe(true);
-
 	const message: unknown = toMessageV1(bundle, "mock");
 	expect(Value.Check(MessageV1, message)).toBe(true);
 
@@ -66,7 +64,7 @@ const bundle = {
 			variants: [
 				{
 					id: humanReadableId + "_en_1",
-					match: [],
+					match: {},
 					messageId: humanReadableId + "_en",
 					pattern: [
 						{

--- a/inlang/source-code/sdk2/src/schema/migrations/toMessageV1.ts
+++ b/inlang/source-code/sdk2/src/schema/migrations/toMessageV1.ts
@@ -1,15 +1,12 @@
+import type { BundleNested } from "../../database/schema.js";
 import type { InlangPlugin } from "../../plugin/schema.js";
 import type {
 	ExpressionV1,
 	MessageV1,
 	PatternV1,
 	VariantV1,
-} from "../../schema/schemaV1.js";
-import type {
-	BundleNested,
-	Expression,
-	Pattern,
-} from "../../schema/schemaV2.js";
+} from "../schemaV1.js";
+import type { Expression, Pattern } from "../schemaV2.js";
 
 /**
  * Converts a BundleNested into a legacy format.
@@ -33,7 +30,7 @@ export function toMessageV1(
 		for (const variant of message.variants) {
 			variants.push({
 				languageTag: message.locale,
-				match: variant.match,
+				match: [],
 				pattern: toV1Pattern(variant.pattern),
 			});
 		}

--- a/inlang/source-code/sdk2/src/schema/schemaV2.ts
+++ b/inlang/source-code/sdk2/src/schema/schemaV2.ts
@@ -67,18 +67,6 @@ export type Variant = Static<typeof Variant>;
 export const Variant = Type.Object({
 	id: Type.String(),
 	messageId: Type.String(),
-	match: Type.Any(), // TODO: Use appropriate Typebox type for JSONColumnType<Record<Expression["arg"]["name"], string>>
+	match: Type.Record(Type.String(), Type.String()),
 	pattern: Pattern,
 });
-
-export type MessageNested = Static<typeof MessageNested>;
-export const MessageNested = Type.Intersect([
-	Message,
-	Type.Object({ variants: Type.Array(Variant) }),
-]);
-
-export type BundleNested = Static<typeof BundleNested>;
-export const BundleNested = Type.Intersect([
-	Bundle,
-	Type.Object({ messages: Type.Array(MessageNested) }),
-]);


### PR DESCRIPTION
Follow up of #3076. 

- types are now exposed as `NewBundle`, `Bundle`, `BundleUpdate` to align with https://kysely.dev/docs/getting-started#types