### PR TITLE
automatic serialization of json properties

### DIFF
--- a/inlang/source-code/fink2/src/helper/queryHelper.ts
+++ b/inlang/source-code/fink2/src/helper/queryHelper.ts
@@ -2,6 +2,10 @@ import { Bundle, InlangDatabaseSchema, Message, Variant } from "@inlang/sdk2";
 import { Kysely } from "kysely";
 import { json } from "./toJSONRawBuilder.ts";
 
+/**
+ * @deprecated json mapping happens automatically https://github.com/opral/monorepo/pull/3078 
+ *             use the query api directly.
+ */
 const queryHelper = {
 	bundle: {
 		/*

--- a/inlang/source-code/fink2/src/helper/toJSONRawBuilder.ts
+++ b/inlang/source-code/fink2/src/helper/toJSONRawBuilder.ts
@@ -1,5 +1,8 @@
 import { RawBuilder, sql } from "kysely";
 
+/**
+ * @deprecated json mapping happens automatically https://github.com/opral/monorepo/pull/3078 
+ */
 export function json<T>(value: T): RawBuilder<T> {
 	// NOTE we cant use jsonb for now since kisley
 	// - couldn't find out how to return json instead of bytes in a selectFrom(...).select statment

--- a/inlang/source-code/sdk2/src/database/initDb.test.ts
+++ b/inlang/source-code/sdk2/src/database/initDb.test.ts
@@ -70,3 +70,21 @@ test("variant ids should default to uuid", async () => {
 
 	expect(validate(variant.id)).toBe(true);
 });
+
+test("it should handle json serialization", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+	const db = initDb({ sqlite });
+	await createSchema({ db, sqlite });
+
+	const bundle = await db
+		.insertInto("bundle")
+		.values({
+			alias: { mock: "mock" },
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	expect(bundle.alias).toEqual({ mock: "mock" });
+});

--- a/inlang/source-code/sdk2/src/database/initDb.test.ts
+++ b/inlang/source-code/sdk2/src/database/initDb.test.ts
@@ -15,10 +15,9 @@ test("bundle ids should have a default value", async () => {
 	const bundle = await db
 		.insertInto("bundle")
 		.values({
-			// @ts-expect-error - manually serialize
-			alias: JSON.stringify({
+			alias: {
 				mock: "mock",
-			}),
+			},
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
@@ -38,10 +37,8 @@ test("message ids should default to uuid", async () => {
 		.values({
 			bundleId: "mock",
 			locale: "en",
-			// @ts-expect-error - manually serialize
-			selectors: JSON.stringify({ mock: "mock" }),
-			// @ts-expect-error - manually serialize
-			declarations: JSON.stringify({ mock: "mock" }),
+			selectors: [],
+			declarations: [],
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
@@ -60,10 +57,8 @@ test("variant ids should default to uuid", async () => {
 		.insertInto("variant")
 		.values({
 			messageId: "mock",
-			// @ts-expect-error - manually serialize
-			match: "{}",
-			// @ts-expect-error - manually serialize
-			pattern: JSON.stringify({}),
+			match: {},
+			pattern: [],
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();

--- a/inlang/source-code/sdk2/src/database/initDb.ts
+++ b/inlang/source-code/sdk2/src/database/initDb.ts
@@ -3,6 +3,7 @@ import type { InlangDatabaseSchema } from "./schema.js";
 import { createDialect, type SqliteDatabase } from "sqlite-wasm-kysely";
 import { v4 } from "uuid";
 import { generateBundleId } from "../bundle-id/bundle-id.js";
+import { SerializeJsonPlugin } from "./serializeJsonPlugin.js";
 
 export function initDb(args: { sqlite: SqliteDatabase }) {
 	initDefaultValueFunctions({ sqlite: args.sqlite });
@@ -10,7 +11,11 @@ export function initDb(args: { sqlite: SqliteDatabase }) {
 		dialect: createDialect({
 			database: args.sqlite,
 		}),
-		plugins: [new ParseJSONResultsPlugin(), new CamelCasePlugin()],
+		plugins: [
+			new ParseJSONResultsPlugin(),
+			new CamelCasePlugin(),
+			new SerializeJsonPlugin(),
+		],
 	});
 	return db;
 }

--- a/inlang/source-code/sdk2/src/database/serializeJsonPlugin.ts
+++ b/inlang/source-code/sdk2/src/database/serializeJsonPlugin.ts
@@ -1,0 +1,90 @@
+import {
+	OperationNodeTransformer,
+	sql,
+	ValueListNode,
+	ValueNode,
+	ValuesNode,
+	type KyselyPlugin,
+	type PluginTransformQueryArgs,
+	type PluginTransformResultArgs,
+	type QueryResult,
+	type RootOperationNode,
+	type UnknownRow,
+} from "kysely";
+
+export class SerializeJsonPlugin implements KyselyPlugin {
+	#parseJsonTransformer = new ParseJsonTransformer();
+
+	transformQuery(args: PluginTransformQueryArgs): RootOperationNode {
+		if (
+			args.node.kind === "InsertQueryNode" ||
+			args.node.kind === "UpdateQueryNode"
+		) {
+			const result = this.#parseJsonTransformer.transformNode(args.node);
+
+			return result;
+		}
+		return args.node;
+	}
+
+	async transformResult(
+		args: PluginTransformResultArgs
+	): Promise<QueryResult<UnknownRow>> {
+		return args.result;
+	}
+}
+
+class ParseJsonTransformer extends OperationNodeTransformer {
+	protected override transformValueList(node: ValueListNode): ValueListNode {
+		return super.transformValueList({
+			...node,
+			values: node.values.map((listNodeItem) => {
+				if (listNodeItem.kind !== "ValueNode") {
+					return listNodeItem;
+				}
+
+				// @ts-ignore
+				const { value } = listNodeItem;
+
+				const serializedValue = serializeJson(value);
+
+				if (value === serializedValue) {
+					return listNodeItem;
+				}
+
+				// TODO use jsonb. depends on parsing again
+				// https://github.com/opral/inlang-sdk/issues/132
+				return sql`json(${serializedValue})`.toOperationNode();
+			}),
+		});
+	}
+
+	override transformValues(node: ValuesNode): ValuesNode {
+		return super.transformValues({
+			...node,
+			values: node.values.map((valueItemNode) => {
+				if (valueItemNode.kind !== "PrimitiveValueListNode") {
+					return valueItemNode;
+				}
+
+				return {
+					kind: "ValueListNode",
+					values: valueItemNode.values.map(
+						(value) =>
+							({
+								kind: "ValueNode",
+								value,
+							} as ValueNode)
+					),
+				} as ValueListNode;
+			}),
+		});
+	}
+}
+
+function serializeJson(value: any): string {
+	if (typeof value === "object" || Array.isArray(value)) {
+		return JSON.stringify(value);
+	}
+	return value;
+}

--- a/inlang/source-code/sdk2/src/lix-plugin/applyChanges.test.ts
+++ b/inlang/source-code/sdk2/src/lix-plugin/applyChanges.test.ts
@@ -65,10 +65,9 @@ test("it should be able to delete", async () => {
 		.insertInto("bundle")
 		.values({
 			id: "mock",
-			// @ts-expect-error - todo auto serialize values
-			alias: JSON.stringify({
+			alias: {
 				foo: "mock-alias",
-			}),
+			},
 		})
 		.execute();
 

--- a/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.test.ts
+++ b/inlang/source-code/sdk2/src/lix-plugin/inlangLixPluginV1.test.ts
@@ -15,8 +15,7 @@ describe("plugin.diff.file", () => {
 			.insertInto("bundle")
 			.values({
 				id: "1",
-				// @ts-expect-error - database expects stringified json
-				alias: JSON.stringify({}),
+				alias: {},
 			})
 			.execute();
 		const path = "/db.sqlite";
@@ -45,13 +44,11 @@ describe("plugin.diff.file", () => {
 			.values([
 				{
 					id: "1",
-					// @ts-expect-error - database expects stringified json
-					alias: JSON.stringify({}),
+					alias: {},
 				},
 				{
 					id: "2",
-					// @ts-expect-error - database expects stringified json
-					alias: JSON.stringify({}),
+					alias: {},
 				},
 			])
 			.execute();
@@ -61,15 +58,13 @@ describe("plugin.diff.file", () => {
 			.values([
 				{
 					id: "1",
-					// @ts-expect-error - database expects stringified json
-					alias: JSON.stringify({
+					alias: {
 						default: "Peter Parker",
-					}),
+					},
 				},
 				{
 					id: "2",
-					// @ts-expect-error - database expects stringified json
-					alias: JSON.stringify({}),
+					alias: {},
 				},
 			])
 			.execute();
@@ -106,11 +101,9 @@ describe("plugin.diff.file", () => {
 			.insertInto("message")
 			.values({
 				id: "1",
-				// @ts-expect-error - database expects stringified json
-				declarations: JSON.stringify([]),
+				declarations: [],
 				bundleId: "unknown",
-				// @ts-expect-error - database expects stringified json
-				selectors: JSON.stringify({}),
+				selectors: [],
 				locale: "en",
 			})
 			.execute();
@@ -131,7 +124,7 @@ describe("plugin.diff.file", () => {
 					id: "1",
 					declarations: [],
 					bundleId: "unknown",
-					selectors: {},
+					selectors: [],
 					locale: "en",
 				},
 			} satisfies DiffReport,
@@ -144,20 +137,16 @@ describe("plugin.diff.file", () => {
 			.values([
 				{
 					id: "1",
-					// @ts-expect-error - database expects stringified json
-					declarations: JSON.stringify([]),
+					declarations: [],
+					selectors: [],
 					bundleId: "unknown",
-					// @ts-expect-error - database expects stringified json
-					selectors: JSON.stringify({}),
 					locale: "en",
 				},
 				{
 					id: "2",
-					// @ts-expect-error - database expects stringified json
-					declarations: JSON.stringify([]),
+					declarations: [],
 					bundleId: "unknown",
-					// @ts-expect-error - database expects stringified json
-					selectors: JSON.stringify({}),
+					selectors: [],
 					locale: "en",
 				},
 			])
@@ -168,20 +157,16 @@ describe("plugin.diff.file", () => {
 			.values([
 				{
 					id: "1",
-					// @ts-expect-error - database expects stringified json
-					declarations: JSON.stringify([]),
+					declarations: [],
 					bundleId: "unknown",
-					// @ts-expect-error - database expects stringified json
-					selectors: JSON.stringify({}),
+					selectors: [],
 					locale: "de",
 				},
 				{
 					id: "2",
-					// @ts-expect-error - database expects stringified json
-					declarations: JSON.stringify([]),
+					declarations: [],
 					bundleId: "unknown",
-					// @ts-expect-error - database expects stringified json
-					selectors: JSON.stringify({}),
+					selectors: [],
 					locale: "en",
 				},
 			])
@@ -209,14 +194,14 @@ describe("plugin.diff.file", () => {
 					id: "1",
 					declarations: [],
 					bundleId: "unknown",
-					selectors: {},
+					selectors: [],
 					locale: "en",
 				},
 				neu: {
 					id: "1",
 					declarations: [],
 					bundleId: "unknown",
-					selectors: {},
+					selectors: [],
 					locale: "de",
 				},
 			} satisfies DiffReport,
@@ -229,10 +214,8 @@ describe("plugin.diff.file", () => {
 			.values({
 				id: "1",
 				messageId: "1",
-				// @ts-expect-error - database expects stringified json
-				pattern: JSON.stringify([{ type: "text", value: "hello world" }]),
-				// @ts-expect-error - database expects stringified json
-				match: JSON.stringify({}),
+				pattern: [{ type: "text", value: "hello world" }],
+				match: {},
 			})
 			.execute();
 		const diffReports = await inlangLixPluginV1.diff.file!({
@@ -265,18 +248,14 @@ describe("plugin.diff.file", () => {
 				{
 					id: "1",
 					messageId: "1",
-					// @ts-expect-error - database expects stringified json
-					pattern: JSON.stringify([{ type: "text", value: "hello world" }]),
-					// @ts-expect-error - database expects stringified json
-					match: JSON.stringify({}),
+					pattern: [{ type: "text", value: "hello world" }],
+					match: {},
 				},
 				{
 					id: "2",
 					messageId: "1",
-					// @ts-expect-error - database expects stringified json
-					pattern: JSON.stringify([{ type: "text", value: "hello world" }]),
-					// @ts-expect-error - database expects stringified json
-					match: JSON.stringify({}),
+					pattern: [{ type: "text", value: "hello world" }],
+					match: {},
 				},
 			])
 			.execute();
@@ -287,20 +266,14 @@ describe("plugin.diff.file", () => {
 				{
 					id: "1",
 					messageId: "1",
-					// @ts-expect-error - database expects stringified json
-					pattern: JSON.stringify([
-						{ type: "text", value: "hello world from Berlin" },
-					]),
-					// @ts-expect-error - database expects stringified json
-					match: JSON.stringify({}),
+					pattern: [{ type: "text", value: "hello world from Berlin" }],
+					match: {},
 				},
 				{
 					id: "2",
 					messageId: "1",
-					// @ts-expect-error - database expects stringified json
-					pattern: JSON.stringify([{ type: "text", value: "hello world" }]),
-					// @ts-expect-error - database expects stringified json
-					match: JSON.stringify({}),
+					pattern: [{ type: "text", value: "hello world" }],
+					match: {},
 				},
 			])
 			.execute();
@@ -353,8 +326,7 @@ describe("plugin.diff.file", () => {
 			.insertInto("bundle")
 			.values({
 				id: "1",
-				// @ts-expect-error - database expects stringified json
-				alias: JSON.stringify({}),
+				alias: {},
 			})
 			.execute();
 

--- a/inlang/source-code/sdk2/src/project/loadProject.test.ts
+++ b/inlang/source-code/sdk2/src/project/loadProject.test.ts
@@ -8,8 +8,7 @@ test("it should persist changes of bundles, messages, and variants to lix ", asy
 	const bundle = await project1.db
 		.insertInto("bundle")
 		.values({
-			// @ts-expect-error - manual stringification
-			alias: JSON.stringify({ default: "bundle1" }),
+			alias: { default: "bundle1" },
 		})
 		.returning("id")
 		.executeTakeFirstOrThrow();
@@ -17,12 +16,10 @@ test("it should persist changes of bundles, messages, and variants to lix ", asy
 	const message = await project1.db
 		.insertInto("message")
 		.values({
-			bundle_id: bundle.id,
+			bundleId: bundle.id,
 			locale: "en",
-			// @ts-expect-error - manual stringification
-			declarations: "[]",
-			// @ts-expect-error - manual stringification
-			selectors: "[]",
+			declarations: [],
+			selectors: [],
 		})
 		.returning("id")
 		.executeTakeFirstOrThrow();
@@ -30,11 +27,9 @@ test("it should persist changes of bundles, messages, and variants to lix ", asy
 	await project1.db
 		.insertInto("variant")
 		.values({
-			message_id: message.id,
-			// @ts-expect-error - manual stringification
-			match: JSON.stringify({}),
-			// @ts-expect-error - manual stringification
-			pattern: "[]",
+			messageId: message.id,
+			match: {},
+			pattern: [],
 		})
 		.execute();
 

--- a/inlang/source-code/sdk2/src/project/loadProjectInMemory.test.ts
+++ b/inlang/source-code/sdk2/src/project/loadProjectInMemory.test.ts
@@ -14,8 +14,7 @@ test("roundtrip should succeed", async () => {
 	const insertedBundle = await project1.db
 		.insertInto("bundle")
 		.values({
-			// @ts-expect-error - manual stringification
-			alias: JSON.stringify({ default: "bundle1" }),
+			alias: { default: "bundle1" },
 		})
 		.returning("id")
 		.executeTakeFirstOrThrow();


### PR DESCRIPTION
Adds automatic serialization of JSON properties. 

**Before**

```diff 
db.insertInto("bundle").values({
  id: bundle.id,
-  // @ts-expect-error - manual serialization
-  alias: JSON.serialize({ "mock": "value" }),
});
```

**After**

```diff
db.insertInto("bundle").values({
  id: bundle.id,
+  alias: { "mock": "value" },
});
```