### PR TITLE
fixes unawaited getters, and wrong types for matchers in paraglide - …

### DIFF
--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -64,6 +64,9 @@
 		"prettier-plugin-jsdoc": "^1.3.0"
 	},
 	"devDependencies": {
+		"@inlang/sdk": "workspace:*",
+		"@lix-js/client": "workspace:*",
+		"@lix-js/fs": "workspace:*",
 		"@inlang/recommend-ninja": "workspace:*",
 		"@inlang/recommend-sherlock": "workspace:*",
 		"@rollup/plugin-terser": "0.4.3",

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile2/command.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/commands/compile2/command.ts
@@ -28,7 +28,7 @@ export const compileCommand2 = new Command()
 			fs: nodeFsPromises,
 		})
 
-		const errors = project.errors.get()
+		const errors = await project.errors.get()
 
 		if (errors.length > 0) {
 			const { nonFatalErrors, fatalErrors } = classifyProjectErrors(errors as any)

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/steps/run-compiler2.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/steps/run-compiler2.ts
@@ -18,7 +18,7 @@ export const runCompiler: CliStep<
 
 	const output = await compile({
 		bundles: bundles,
-		settings: ctx.project.settings.get(),
+		settings: await ctx.project.settings.get(),
 		projectId: undefined,
 		outputStructure: "message-modules",
 	})

--- a/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compiler/compile.ts
@@ -133,7 +133,7 @@ export const compile = async (args: CompileOptions): Promise<Record<string, stri
 			}
 		}
 
-		const messageIDs = compiledMessages.map((message) => message.source.id)
+		const messageIDs = compiledMessages.map((message: any) => message.source.id)
 
 		// add the barrel files
 		output["messages.js"] = [

--- a/inlang/source-code/paraglide/paraglide-js/src/compilerV2/compile.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compilerV2/compile.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe, vi, beforeEach } from "vitest"
 import { createProject as typescriptProject, ts } from "@ts-morph/bootstrap"
-import { BundleNested, ProjectSettings } from "@inlang/sdk2"
+import { type BundleNested, ProjectSettings } from "@inlang/sdk2"
 import { compile } from "./compile.js"
 import { rollup } from "rollup"
 import virtual from "@rollup/plugin-virtual"
@@ -22,7 +22,7 @@ const mockBundles: BundleNested[] = [
 				variants: [
 					{
 						id: "happy_elephant_message_en_variant_one",
-						match: [],
+						match: {},
 						messageId: "happy_elephant_message_en",
 						pattern: [{ type: "text", value: "A simple message." }],
 					},
@@ -46,7 +46,7 @@ const mockBundles: BundleNested[] = [
 					{
 						id: "sad_penguin_message_en_variant_one",
 						messageId: "sad_penguin_message_en",
-						match: [],
+						match: {},
 						pattern: [{ type: "text", value: "A simple message." }],
 					},
 				],
@@ -61,7 +61,7 @@ const mockBundles: BundleNested[] = [
 					{
 						id: "sad_penguin_message_en_us_variant_one",
 						messageId: "sad_penguin_message_en_us",
-						match: [],
+						match: {},
 						pattern: [
 							{ type: "text", value: "FUCKTARD. I am from New York. This is a simple message!" },
 						],
@@ -78,7 +78,7 @@ const mockBundles: BundleNested[] = [
 					{
 						id: "sad_penguin_message_de_variant_one",
 						messageId: "sad_penguin_message_de",
-						match: [],
+						match: {},
 						pattern: [{ type: "text", value: "Eine einfache Nachricht." }],
 					},
 				],
@@ -107,7 +107,7 @@ const mockBundles: BundleNested[] = [
 					{
 						id: "depressed_dog_en_variant_one",
 						messageId: "depressed_dog_en",
-						match: [],
+						match: {},
 						pattern: [
 							{ type: "text", value: "Good morning " },
 							{ type: "expression", arg: { type: "variable", name: "name" } },
@@ -132,7 +132,7 @@ const mockBundles: BundleNested[] = [
 					{
 						id: "depressed_dog_de_variant_one",
 						messageId: "depressed_dog_de",
-						match: [],
+						match: {},
 						pattern: [
 							{ type: "text", value: "Guten Morgen " },
 							{ type: "expression", arg: { type: "variable", name: "name" } },
@@ -170,7 +170,7 @@ const mockBundles: BundleNested[] = [
 					{
 						id: "insane_cats_en_variant_one",
 						messageId: "insane_cats_en",
-						match: [],
+						match: {},
 						pattern: [
 							{ type: "text", value: "Hello " },
 							{ type: "expression", arg: { type: "variable", name: "name" } },
@@ -202,7 +202,7 @@ const mockBundles: BundleNested[] = [
 					{
 						id: "insane_cats_de_variant_one",
 						messageId: "insane_cats_de",
-						match: [],
+						match: {},
 						pattern: [
 							{ type: "text", value: "Hallo " },
 							{ type: "expression", arg: { type: "variable", name: "name" } },

--- a/inlang/source-code/paraglide/paraglide-js/src/compilerV2/compileMessage.test.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compilerV2/compileMessage.test.ts
@@ -32,13 +32,13 @@ describe("compileMessage", () => {
 				{
 					id: "1",
 					messageId: "some_message",
-					match: ["1", "2"],
+					match: { firstInput: "1", secondInput: "2" },
 					pattern: [{ type: "text", value: "One" }],
 				},
 				{
 					id: "2",
 					messageId: "some_message",
-					match: ["*", "*"],
+					match: { firstInput: "*", secondInput: "*" },
 					pattern: [{ type: "text", value: "Many" }],
 				},
 			],

--- a/inlang/source-code/paraglide/paraglide-js/src/compilerV2/compileMessage.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/compilerV2/compileMessage.ts
@@ -1,4 +1,5 @@
 import type { MessageNested, Variant } from "@inlang/sdk2"
+
 import { compilePattern } from "./compilePattern.js"
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js"
 import { compileExpression } from "./compileExpression.js"
@@ -50,13 +51,15 @@ function compileMessageWithMultipleVariants(message: MessageNested): Compilation
 		const compiledPattern = compilePattern(message.locale, variant.pattern)
 		const typeRestrictions = compiledPattern.typeRestrictions
 
-		const allWildcards: boolean = variant.match.every((m: string) => m === "*")
+		const allWildcards: boolean = Object.values(variant.match).every((m: string) => m === "*")
 		if (allWildcards)
 			return { code: `return ${compiledPattern.code}`, typeRestrictions, source: variant }
 
-		const conditions: string[] = (variant.match as string[])
-			.filter((m) => m !== "*")
-			.map((m, i) => `selectors[${i}] === "${escapeForDoubleQuoteString(m)}"`)
+		const conditions: string[] = []
+		// TODO @samuelstroschein seems like paraglide is not yet aware of the matching record and bases on indexes for matching
+		// 	const conditions: string[] = (variant.match as string[])
+		// .filter((m) => m !== "*")
+		// .map((m, i) => `selectors[${i}] === "${escapeForDoubleQuoteString(m)}"`)
 
 		return {
 			code: `if (${conditions.join(" && ")}) return ${compiledPattern.code}`,

--- a/inlang/source-code/paraglide/paraglide-unplugin/package.json
+++ b/inlang/source-code/paraglide/paraglide-unplugin/package.json
@@ -56,6 +56,7 @@
 		"@types/node": "20.9.3",
 		"typescript": "^5.5.2",
 		"vite": "^4.5.0",
-		"vitest": "0.34.3"
+		"vitest": "0.34.3",
+		"prettier": "^3.3.3"
 	}
 }

--- a/inlang/source-code/paraglide/paraglide-vite/package.json
+++ b/inlang/source-code/paraglide/paraglide-vite/package.json
@@ -49,6 +49,7 @@
 	"devDependencies": {
 		"@types/node": "20.9.3",
 		"typescript": "^5.5.2",
-		"vitest": "0.34.3"
+		"vitest": "0.34.3",
+		"prettier": "^3.3.3"
 	}
 }

--- a/inlang/source-code/sdk2/src/database/schema.ts
+++ b/inlang/source-code/sdk2/src/database/schema.ts
@@ -55,6 +55,7 @@ type MessageTable = {
 type VariantTable = {
 	id: Generated<string>;
 	messageId: string;
+	
 	match: Generated<Record<string, string>>;
 	pattern: Generated<Pattern>;
 };


### PR DESCRIPTION
…still todo left

@samuelstroschein ParaglideJs doesn't handle named matchers - it still expects the matchers to be an array and use the index to map selectors. I fixed various types and mocks but want to focus on the loadProjectFromDirectory and since i am not sure whats the state of paraglide is i just made it compile with a todo - ping me if i can support 