### PR TITLE
telemetry

### DIFF
--- a/inlang/source-code/sdk2/package.json
+++ b/inlang/source-code/sdk2/package.json
@@ -16,7 +16,7 @@
 		"./src"
 	],
 	"scripts": {
-		"build": "npm run env-variables && node  tsc --build",
+		"build": "npm run env-variables && tsc --build",
 		"dev": "npm run env-variables && tsc --watch",
 		"env-variables": "node ./src/services/env-variables/createIndexFile.js",
 		"test": "npm run env-variables && tsc --noEmit && vitest run --passWithNoTests --coverage",

--- a/inlang/source-code/sdk2/package.json
+++ b/inlang/source-code/sdk2/package.json
@@ -16,10 +16,11 @@
 		"./src"
 	],
 	"scripts": {
-		"build": "tsc --build",
-		"dev": "tsc --watch",
-		"test": "tsc --noEmit && vitest run --passWithNoTests --coverage",
-		"test:watch": "vitest",
+		"build": "npm run env-variables && node  tsc --build",
+		"dev": "npm run env-variables && tsc --watch",
+		"env-variables": "node ./src/services/env-variables/createIndexFile.js",
+		"test": "npm run env-variables && tsc --noEmit && vitest run --passWithNoTests --coverage",
+		"test:watch": "npm run env-variables && vitest",
 		"lint": "eslint ./src --fix",
 		"format": "prettier ./src --write",
 		"clean": "rm -rf ./dist ./node_modules"

--- a/inlang/source-code/sdk2/src/json-schema/settings.ts
+++ b/inlang/source-code/sdk2/src/json-schema/settings.ts
@@ -76,6 +76,16 @@ const SDKSettings = Type.Object({
 			}
 		)
 	),
+	telemetry: Type.Optional(
+		Type.Union(
+			[
+				Type.Literal("off", {
+					description: "No telemetry events ",
+				}),
+			],
+			{ description: "If not set, defaults to all" }
+		)
+	),
 	experimental: Type.Optional(
 		Type.Record(Type.String(), Type.Literal(true), {
 			title: "Experimental settings",

--- a/inlang/source-code/sdk2/src/project/loadProject.ts
+++ b/inlang/source-code/sdk2/src/project/loadProject.ts
@@ -47,16 +47,7 @@ export async function loadProject(args: {
 	 *
 	 * The app id can be removed at any time in the future
 	 */
-	applicationId?: string;
-	/**
-	 * The version of the application that is using the SDK.
-	 *
-	 * This is used for telemetry purposes. To derive insights like
-	 * which version of the SDK is used, how many projects are loaded, etc.
-	 *
-	 * The application version can be removed at any time in the future.
-	 */
-	applicationVersion?: string;
+	appId?: string;
 }): Promise<InlangProject> {
 	const db = initDb({ sqlite: args.sqlite });
 
@@ -103,8 +94,7 @@ export async function loadProject(args: {
 	maybeCaptureLoadedProject({
 		db,
 		state,
-		applicationId: args.applicationId,
-		applicationVersion: args.applicationVersion,
+		appId: args.appId,
 	});
 
 	return {

--- a/inlang/source-code/sdk2/src/project/maybeCaptureTelemetry.test.ts
+++ b/inlang/source-code/sdk2/src/project/maybeCaptureTelemetry.test.ts
@@ -45,8 +45,7 @@ test("it should capture as expected", async () => {
 
 	await maybeCaptureLoadedProject({
 		state: project as unknown as ProjectState,
-		applicationId: "test",
-		applicationVersion: "1.5.3",
+		appId: "test",
 		db: project.db,
 	});
 
@@ -54,8 +53,7 @@ test("it should capture as expected", async () => {
 		projectId: await project.id.get(),
 		settings: await project.settings.get(),
 		properties: {
-			applicationId: "test",
-			applicationVersion: "1.5.3",
+			appId: "test",
 			settings: await project.settings.get(),
 			pluginKeys: [],
 			sdkVersion: "1.0.0-mock",

--- a/inlang/source-code/sdk2/src/project/maybeCaptureTelemetry.test.ts
+++ b/inlang/source-code/sdk2/src/project/maybeCaptureTelemetry.test.ts
@@ -1,0 +1,67 @@
+import { expect, test, vi } from "vitest";
+import { loadProjectInMemory } from "./loadProjectInMemory.js";
+import { newProject } from "./newProject.js";
+import { maybeCaptureLoadedProject } from "./maybeCaptureTelemetry.js";
+import type { ProjectState } from "./state/state.js";
+import { capture } from "../services/telemetry/capture.js";
+
+test("it should capture as expected", async () => {
+	vi.mock("../services/telemetry/capture.js", async () => {
+		return {
+			capture: vi.fn(() => Promise.resolve()),
+		};
+	});
+
+	vi.mock("../services/env-variables/index", async () => {
+		return {
+			ENV_VARIABLES: {
+				PUBLIC_POSTHOG_TOKEN: "mock-defined",
+				SDK_VERSION: "1.0.0-mock",
+			},
+		};
+	});
+
+	const project = await loadProjectInMemory({
+		blob: await newProject(),
+	});
+
+	const bundle = await project.db
+		.insertInto("bundle")
+		.defaultValues()
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	const message = await project.db
+		.insertInto("message")
+		.values({ bundleId: bundle.id, locale: "en" })
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	await project.db
+		.insertInto("variant")
+		.values({ messageId: message.id })
+		.returningAll()
+		.executeTakeFirst();
+
+	await maybeCaptureLoadedProject({
+		state: project as unknown as ProjectState,
+		applicationId: "test",
+		applicationVersion: "1.5.3",
+		db: project.db,
+	});
+
+	expect(capture).toHaveBeenCalledWith("SDK loaded project", {
+		projectId: await project.id.get(),
+		settings: await project.settings.get(),
+		properties: {
+			applicationId: "test",
+			applicationVersion: "1.5.3",
+			settings: await project.settings.get(),
+			pluginKeys: [],
+			sdkVersion: "1.0.0-mock",
+			numBundles: 1,
+			numMessages: 1,
+			numVariants: 1,
+		},
+	});
+});

--- a/inlang/source-code/sdk2/src/project/maybeCaptureTelemetry.ts
+++ b/inlang/source-code/sdk2/src/project/maybeCaptureTelemetry.ts
@@ -6,8 +6,7 @@ import { ENV_VARIABLES } from "../services/env-variables/index.js";
 
 export async function maybeCaptureLoadedProject(args: {
 	state: ProjectState;
-	applicationId?: string;
-	applicationVersion?: string;
+	appId?: string;
 	db: Kysely<InlangDatabaseSchema>;
 }) {
 	const id = await args.state.id.get();
@@ -36,8 +35,7 @@ export async function maybeCaptureLoadedProject(args: {
 		settings,
 		properties: {
 			// Insight: Which app is used by the SDK
-			applicationId: args.applicationId,
-			applicationVersion: args.applicationVersion,
+			appId: args.appId,
 			// Insight: How many languages are used, etc.
 			settings,
 			// Insight on the used plugins (which one's to prioritize)

--- a/inlang/source-code/sdk2/src/project/maybeCaptureTelemetry.ts
+++ b/inlang/source-code/sdk2/src/project/maybeCaptureTelemetry.ts
@@ -1,0 +1,53 @@
+import { Kysely } from "kysely";
+import { capture } from "../services/telemetry/capture.js";
+import { type ProjectState } from "./state/state.js";
+import type { InlangDatabaseSchema } from "../database/schema.js";
+import { ENV_VARIABLES } from "../services/env-variables/index.js";
+
+export async function maybeCaptureLoadedProject(args: {
+	state: ProjectState;
+	applicationId?: string;
+	applicationVersion?: string;
+	db: Kysely<InlangDatabaseSchema>;
+}) {
+	const id = await args.state.id.get();
+	const settings = await args.state.settings.get();
+	const plugins = await args.state.plugins.get();
+
+	if (settings.telemetry === "off") {
+		return;
+	}
+
+	const bundles = await args.db
+		.selectFrom("bundle")
+		.select((s) => s.fn.count("id").as("count"))
+		.executeTakeFirst();
+	const messages = await args.db
+		.selectFrom("message")
+		.select((s) => s.fn.count("id").as("count"))
+		.executeTakeFirst();
+	const variants = await args.db
+		.selectFrom("variant")
+		.select((s) => s.fn.count("id").as("count"))
+		.executeTakeFirst();
+
+	await capture("SDK loaded project", {
+		projectId: id,
+		settings,
+		properties: {
+			// Insight: Which app is used by the SDK
+			applicationId: args.applicationId,
+			applicationVersion: args.applicationVersion,
+			// Insight: How many languages are used, etc.
+			settings,
+			// Insight on the used plugins (which one's to prioritize)
+			pluginKeys: plugins.map((plugin) => plugin.key),
+			// Insight: Which version of the SDK is used (can be used to deprecate old versions)
+			sdkVersion: ENV_VARIABLES.SDK_VERSION,
+			// Insight: Scale of projects (what project size to optimize for)
+			numBundles: bundles?.count,
+			numMessages: messages?.count,
+			numVariants: variants?.count,
+		},
+	});
+}

--- a/inlang/source-code/sdk2/src/project/state/id$.ts
+++ b/inlang/source-code/sdk2/src/project/state/id$.ts
@@ -1,5 +1,5 @@
 import { type Lix } from "@lix-js/sdk";
-import { map, share, type Observable } from "rxjs";
+import { filter, map, share, type Observable } from "rxjs";
 import { pollQuery } from "../../query-utilities/pollQuery.js";
 
 export function createId$(args: { lix: Lix }): Observable<string> {
@@ -8,8 +8,12 @@ export function createId$(args: { lix: Lix }): Observable<string> {
 			.selectFrom("file")
 			.where("path", "=", "/project_id")
 			.selectAll()
-			.executeTakeFirstOrThrow()
+			.executeTakeFirst()
 	).pipe(
+		// undefined can happen if a project has no id yet
+		// the project id will be automatically generated
+		// shortly after
+		filter((file) => file !== undefined),
 		map((file) => new TextDecoder().decode(file.data)),
 		share()
 	);

--- a/inlang/source-code/sdk2/src/services/env-variables/.gitignore
+++ b/inlang/source-code/sdk2/src/services/env-variables/.gitignore
@@ -1,0 +1,1 @@
+index.ts

--- a/inlang/source-code/sdk2/src/services/env-variables/createIndexFile.js
+++ b/inlang/source-code/sdk2/src/services/env-variables/createIndexFile.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-restricted-imports */
+/* eslint-disable no-undef */
+/**
+ * This script writes public environment variables
+ * to an importable env file.
+ *
+ * - The SDK must bundle this file with the rest of the SDK
+ * - This scripts avoids the need for a bundler
+ * - Must be ran before building the SDK
+ */
+
+import fs from "node:fs/promises";
+import url from "node:url";
+import path from "node:path";
+
+const dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const packageJson = JSON.parse(
+	await fs.readFile(path.resolve(dirname, "../../../package.json"), "utf-8")
+);
+
+await fs.writeFile(
+	dirname + "/index.ts",
+	`
+export const ENV_VARIABLES = {
+  PUBLIC_POSTHOG_TOKEN: "${process.env.PUBLIC_POSTHOG_TOKEN}",
+	SDK_VERSION: "${packageJson.version}",
+}
+`
+);
+
+// eslint-disable-next-line no-console
+// console.log("✅ Created env variable index file.");

--- a/inlang/source-code/sdk2/src/services/env-variables/index.d.ts
+++ b/inlang/source-code/sdk2/src/services/env-variables/index.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Avoiding TypeScript errors before the `createIndexFile` script
+ * is invoked by defining the type ahead of time.
+ */
+
+/**
+ * Env variables that are available at runtime.
+ */
+export declare const ENV_VARIABLES: {
+	PUBLIC_POSTHOG_TOKEN?: string;
+	/**
+	 * As defined in the package.json
+	 */
+	SDK_VERSION: string;
+};

--- a/inlang/source-code/sdk2/src/services/telemetry/capture.test.ts
+++ b/inlang/source-code/sdk2/src/services/telemetry/capture.test.ts
@@ -1,0 +1,48 @@
+import { expect, test, vi } from "vitest";
+import { capture } from "./capture.js";
+
+test("it should not capture if telemetry is off", async () => {
+	// @ts-expect-error
+	global.fetch = vi.fn(() => Promise.resolve());
+
+	vi.mock("../env-variables/index.js", async () => {
+		return {
+			ENV_VARIABLES: {
+				PUBLIC_POSTHOG_TOKEN: "mock-defined",
+			},
+		};
+	});
+
+	await capture("SDK loaded project", {
+		projectId: "test",
+		settings: {
+			telemetry: "off",
+		},
+		properties: {},
+	});
+
+	expect(global.fetch).not.toHaveBeenCalled();
+});
+
+test("it should not capture if telemetry is NOT off", async () => {
+	// @ts-expect-error
+	global.fetch = vi.fn(() => Promise.resolve());
+
+	vi.mock("../env-variables/index.js", async () => {
+		return {
+			ENV_VARIABLES: {
+				PUBLIC_POSTHOG_TOKEN: "mock-defined",
+			},
+		};
+	});
+
+	await capture("SDK loaded project", {
+		projectId: "test",
+		settings: {
+			telemetry: undefined,
+		},
+		properties: {},
+	});
+
+	expect(global.fetch).toHaveBeenCalled();
+});

--- a/inlang/source-code/sdk2/src/services/telemetry/capture.ts
+++ b/inlang/source-code/sdk2/src/services/telemetry/capture.ts
@@ -1,0 +1,100 @@
+// import { ENV_VARIABLES } from "../env-variables/index.js";
+
+import type { ProjectSettings } from "../../json-schema/settings.js";
+import { ENV_VARIABLES } from "../env-variables/index.js";
+
+/**
+ * List of telemetry events for typesafety.
+ *
+ * - prefix with `SDK` to avoid collisions with other apps
+ * - use past tense to indicate that the event is completed
+ */
+const events = ["SDK loaded project"] as const;
+
+/**
+ * Capture an event.
+ *
+ * - manually calling the PostHog API because the SDKs were not platform angostic (and generally bloated)
+ */
+export const capture = async (
+	event: (typeof events)[number],
+	args: {
+		projectId: string;
+		/**
+		 * Please use snake_case for property names.
+		 */
+		properties: Record<string, any>;
+		settings: Pick<ProjectSettings, "telemetry">;
+	}
+) => {
+	if (args.settings.telemetry === "off") {
+		return;
+	} else if (ENV_VARIABLES.PUBLIC_POSTHOG_TOKEN === undefined) {
+		return;
+	}
+	try {
+		await fetch("https://eu.posthog.com/capture/", {
+			method: "POST",
+			body: JSON.stringify({
+				api_key: ENV_VARIABLES.PUBLIC_POSTHOG_TOKEN,
+				event,
+				// id is "unknown" because no user information is available
+				distinct_id: "unknown",
+				properties: {
+					$groups: { project: args.projectId },
+					...args.properties,
+				},
+			}),
+		});
+		await identifyProject({
+			projectId: args.projectId,
+			// using the id for now as a name but can be changed in the future
+			// we need at least one property to make a project visible in the dashboar
+			properties: { name: args.projectId },
+		});
+	} catch (e) {
+		// TODO implement sentry logging
+		// do not console.log and avoid exposing internal errors to the user
+	}
+};
+
+/**
+ * Identifying a project is needed.
+ *
+ * Otherwise, the project will not be visible in the PostHog dashboard.
+ */
+const identifyProject = async (args: {
+	projectId: string;
+	/**
+	 * Please use snake_case for property names.
+	 */
+	properties: Record<string, any>;
+}) => {
+	// do not send events if the token is not set
+	// (assuming this eases testing)
+	if (ENV_VARIABLES.PUBLIC_POSTHOG_TOKEN === undefined) {
+		return;
+	}
+	try {
+		await fetch("https://eu.posthog.com/capture/", {
+			method: "POST",
+			body: JSON.stringify({
+				api_key: ENV_VARIABLES.PUBLIC_POSTHOG_TOKEN,
+				event: "$groupidentify",
+				// id is "unknown" because no user information is available
+				distinct_id: "unknown",
+				properties: {
+					$group_type: "project",
+					$group_key: args.projectId,
+					$group_set: {
+						...args.properties,
+					},
+				},
+			}),
+		});
+	} catch (e) {
+		// console.log(e);
+		// TODO implement sentry logging
+		// do not console.log and avoid exposing internal errors to the user
+	}
+};

--- a/lix/packages/sdk/src/open/openLix.ts
+++ b/lix/packages/sdk/src/open/openLix.ts
@@ -53,90 +53,100 @@ export async function openLix(args: {
 	// If a queue trigger happens during an existing queue run we might miss updates and use hasMoreEntriesSince to make sure there is always a final immediate queue worker execution
 	let hasMoreEntriesSince: number | undefined = undefined;
 	async function queueWorker(trail = false) {
-		if (pending && !trail) {
-			hasMoreEntriesSince = runNumber;
-			// console.log({ hasMoreEntriesSince });
-			return;
-		}
-		runNumber++;
+		try {
+			if (pending && !trail) {
+				hasMoreEntriesSince = runNumber;
+				// console.log({ hasMoreEntriesSince });
+				return;
+			}
+			runNumber++;
 
-		if (!pending) {
-			pending = new Promise((res) => {
-				resolve = res;
-			});
-		}
+			if (!pending) {
+				pending = new Promise((res) => {
+					resolve = res;
+				});
+			}
 
-		const entry = await db
-			.selectFrom("change_queue")
-			.selectAll()
-			.orderBy("id asc")
-			.limit(1)
-			.executeTakeFirst();
-
-		if (entry) {
-			const existingFile = await db
-				.selectFrom("file_internal")
-				.select("data")
-				.select("path")
-				.where("id", "=", entry.file_id)
+			const entry = await db
+				.selectFrom("change_queue")
+				.selectAll()
+				.orderBy("id asc")
 				.limit(1)
 				.executeTakeFirst();
 
-			if (existingFile?.data) {
-				await handleFileChange({
-					currentAuthor,
-					queueEntry: entry,
-					old: {
-						id: entry.file_id,
-						path: existingFile?.path,
-						data: existingFile?.data,
-					},
-					neu: {
-						id: entry.file_id,
-						path: entry.path,
-						data: entry.data,
-					},
-					plugins,
-					db,
-				});
-			} else {
-				await handleFileInsert({
-					currentAuthor,
-					queueEntry: entry,
-					neu: {
-						id: entry.file_id,
-						path: entry.path,
-						data: entry.data,
-					},
-					plugins,
-					db,
-				});
+			if (entry) {
+				const existingFile = await db
+					.selectFrom("file_internal")
+					.select("data")
+					.select("path")
+					.where("id", "=", entry.file_id)
+					.limit(1)
+					.executeTakeFirst();
+
+				if (existingFile?.data) {
+					await handleFileChange({
+						currentAuthor,
+						queueEntry: entry,
+						old: {
+							id: entry.file_id,
+							path: existingFile?.path,
+							data: existingFile?.data,
+						},
+						neu: {
+							id: entry.file_id,
+							path: entry.path,
+							data: entry.data,
+						},
+						plugins,
+						db,
+					});
+				} else {
+					await handleFileInsert({
+						currentAuthor,
+						queueEntry: entry,
+						neu: {
+							id: entry.file_id,
+							path: entry.path,
+							data: entry.data,
+						},
+						plugins,
+						db,
+					});
+				}
 			}
+
+			// console.log("getrting { numEntries }");
+
+			const { numEntries } = await db
+				.selectFrom("change_queue")
+				.select((eb) => eb.fn.count<number>("id").as("numEntries"))
+				.executeTakeFirstOrThrow();
+
+			// console.log({ numEntries });
+
+			if (
+				!hasMoreEntriesSince ||
+				(numEntries === 0 && hasMoreEntriesSince < runNumber)
+			) {
+				resolve!(); // TODO: fix type
+				pending = undefined;
+				hasMoreEntriesSince = undefined;
+				// console.log("resolving");
+			}
+
+			// TODO: handle endless tries on failing quee entries
+			// we either execute the queue immediately if we know there is more work or fall back to polling
+			setTimeout(() => queueWorker(true), hasMoreEntriesSince ? 0 : 1000);
+		} catch (e) {
+			// https://linear.app/opral/issue/LIXDK-102/re-visit-simplifying-the-change-queue-implementation
+
+			console.error(
+				"change queue failed (will remain so until rework of change queue): ",
+				e,
+			);
 		}
-
-		// console.log("getrting { numEntries }");
-
-		const { numEntries } = await db
-			.selectFrom("change_queue")
-			.select((eb) => eb.fn.count<number>("id").as("numEntries"))
-			.executeTakeFirstOrThrow();
-
-		// console.log({ numEntries });
-
-		if (
-			!hasMoreEntriesSince ||
-			(numEntries === 0 && hasMoreEntriesSince < runNumber)
-		) {
-			resolve!(); // TODO: fix type
-			pending = undefined;
-			hasMoreEntriesSince = undefined;
-			// console.log("resolving");
-		}
-
-		// TODO: handle endless tries on failing quee entries
-		// we either execute the queue immediately if we know there is more work or fall back to polling
-		setTimeout(() => queueWorker(true), hasMoreEntriesSince ? 0 : 1000);
 	}
+
 	queueWorker();
 
 	async function settled() {


### PR DESCRIPTION
## Context 

Closes telemetry and https://github.com/opral/inlang-sdk/issues/166. 

## Changes & Decisions

- adds `settings.telemetry : off` as settings similar to vscode https://code.visualstudio.com/docs/getstarted/telemetry
- adds env variables that are required for telemetry 
- adds SDK_VERSION to the `SDK loaded project` event to know what sdk versions users are on
- adds numbers of bundles, messages, and variants to know how large projects are 