### PR TITLE
fix: backwards compatibility with lint rules

### DIFF
--- a/inlang/source-code/sdk2/src/plugin/importPlugins.test.ts
+++ b/inlang/source-code/sdk2/src/plugin/importPlugins.test.ts
@@ -44,3 +44,24 @@ test("if a fetch fails, a plugin import error is expected", async () => {
 	expect(result.errors.length).toBe(1);
 	expect(result.errors[0]).toBeInstanceOf(PluginImportError);
 });
+
+
+test("it should filter message lint rules for legacy reasons", async () => {
+	global.fetch = vi.fn().mockResolvedValue({
+		ok: true,
+		text: vi
+			.fn()
+			.mockResolvedValue("export default { id: 'messageLintRule.something' }"),
+	});
+
+	const result = await importPlugins({
+		settings: {
+			baseLocale: "en",
+			locales: ["en"],
+			modules: ["https://mock.com/module.js"],
+		},
+	});
+
+	expect(result.plugins.length).toBe(0);
+	expect(result.errors.length).toBe(0);
+});

--- a/inlang/source-code/sdk2/src/plugin/importPlugins.ts
+++ b/inlang/source-code/sdk2/src/plugin/importPlugins.ts
@@ -28,10 +28,15 @@ export async function importPlugins(args: {
 			}
 			const moduleWithMimeType =
 				"data:application/javascript," + encodeURIComponent(moduleAsText);
-			const { default: plugin } = await import(
+			const { default: module } = await import(
 				/* @vite-ignore */ moduleWithMimeType
 			);
-			plugins.push(plugin);
+			// old legacy message lint rules are not supported
+			// and ingored for backwards compatibility
+			if (module.id?.includes("messageLintRule")) {
+				continue;
+			}
+			plugins.push(module);
 		} catch (e) {
 			errors.push(new PluginImportError({ plugin: uri, cause: e as Error }));
 		}


### PR DESCRIPTION
closes https://github.com/opral/inlang-sdk/issues/169