### PR TITLE
Add: Import messages from local files

### DIFF
--- a/inlang/development-projects/inlang-nextjs/other-folder/backend.inlang/settings.json
+++ b/inlang/development-projects/inlang-nextjs/other-folder/backend.inlang/settings.json
@@ -11,10 +11,10 @@
 	],
 	"plugin.inlang.i18next": {
 		"pathPattern": {
-			"client-page": "./../../app/i18n/locales/{languageTag}/client-page.json",
-			"footer": "./../../app/i18n/locales/{languageTag}/footer.json",
-			"second-page": "./../../app/i18n/locales/{languageTag}/second-page.json",
-			"translation": "./../../app/i18n/locales/{languageTag}/translation.json"
+			"client-page": "./../app/i18n/locales/{languageTag}/client-page.json",
+			"footer": "./../app/i18n/locales/{languageTag}/footer.json",
+			"second-page": "./../app/i18n/locales/{languageTag}/second-page.json",
+			"translation": "./../app/i18n/locales/{languageTag}/translation.json"
 		}
 	},
 	"experimental": {

--- a/inlang/source-code/ide-extension/src/utilities/messages/messages.ts
+++ b/inlang/source-code/ide-extension/src/utilities/messages/messages.ts
@@ -12,6 +12,7 @@ import {
 	type BundleNested,
 	type IdeExtensionConfig,
 	type InlangProject,
+	pollQuery,
 } from "@inlang/sdk2"
 
 export function createMessageWebviewProvider(args: {
@@ -37,6 +38,13 @@ export function createMessageWebviewProvider(args: {
 		if (subscribedToProjectPath !== state().selectedProjectPath) {
 			subscribedToProjectPath = state().selectedProjectPath
 			// TODO: Uncomment when bundle subscribe is implemented
+			// TODO unsubscribe 
+			pollQuery(() => selectBundleNested(project.db).execute()).subscribe((newBundles) => {
+				bundles = newBundles
+				isLoading = false
+				updateWebviewContent()
+				// throttledUpdateWebviewContent()
+			})
 			// project.query.messages.getAll.subscribe((fetchedMessages: BundleNested[]) => {
 			// 	bundles = fetchedMessages ? [...fetchedMessages] : []
 			// 	isLoading = false

--- a/inlang/source-code/sdk2/package.json
+++ b/inlang/source-code/sdk2/package.json
@@ -16,7 +16,8 @@
 		"./src"
 	],
 	"scripts": {
-		"build": "npm run env-variables && tsc --build && npm run sentry:sourcemaps",
+		"prepublish": "npm run sentry:sourcemaps",
+		"build": "npm run env-variables && tsc --build",
 		"dev": "npm run env-variables && tsc --watch",
 		"env-variables": "node ./src/services/env-variables/createIndexFile.js",
 		"test": "npm run env-variables && tsc --noEmit && vitest run --passWithNoTests --coverage",

--- a/inlang/source-code/sdk2/src/import-export/index.ts
+++ b/inlang/source-code/sdk2/src/import-export/index.ts
@@ -26,7 +26,7 @@ export async function importFiles(opts: {
 		});
 	}
 
-	const { bundles } = plugin.importFiles({
+	const { bundles } = await plugin.importFiles({
 		files: opts.files,
 		settings: structuredClone(opts.settings),
 	});

--- a/inlang/source-code/sdk2/src/plugin/schema.ts
+++ b/inlang/source-code/sdk2/src/plugin/schema.ts
@@ -38,17 +38,17 @@ export type InlangPlugin<
 	toBeImportedFiles?: (args: {
 		settings: ProjectSettings & ExternalSettings;
 		nodeFs: NodeFsPromisesSubset;
-	}) => Promise<Array<ResourceFile>> | Array<ResourceFile>;
+	}) => MaybePromise<Array<ResourceFile>>;
 	importFiles?: (args: {
 		files: Array<ResourceFile>;
 		settings: ProjectSettings & ExternalSettings; // we expose the settings in case the importFunction needs to access the plugin config
-	}) => {
+	}) => MaybePromise<{
 		bundles: NewBundleNested[];
-	};
+	}>;
 	exportFiles?: (args: {
 		bundles: BundleNested[];
 		settings: ProjectSettings & ExternalSettings;
-	}) => Array<ResourceFile>;
+	}) => MaybePromise<Array<ResourceFile>>;
 	/**
 	 * @deprecated Use the `meta` field instead.
 	 */
@@ -89,3 +89,5 @@ type NodeFsPromisesSubset = {
 	readFile: (path: string) => Promise<Buffer>;
 	readdir: (path: string) => Promise<string[]>;
 };
+
+type MaybePromise<T> = T | Promise<T>;

--- a/inlang/source-code/sdk2/src/plugin/schema.ts
+++ b/inlang/source-code/sdk2/src/plugin/schema.ts
@@ -38,7 +38,7 @@ export type InlangPlugin<
 	toBeImportedFiles?: (args: {
 		settings: ProjectSettings & ExternalSettings;
 		nodeFs: NodeFsPromisesSubset;
-	}) => MaybePromise<Array<ResourceFile>>;
+	}) => MaybePromise<Array<Omit<ResourceFile, "pluginKey">>>;
 	importFiles?: (args: {
 		files: Array<ResourceFile>;
 		settings: ProjectSettings & ExternalSettings; // we expose the settings in case the importFunction needs to access the plugin config
@@ -73,10 +73,12 @@ export type InlangPlugin<
  *
  * https://github.com/opral/inlang-sdk/issues/136
  */
-type NodeFsPromisesSubsetLegacy = {
-	readFile: (path: string) => Promise<Buffer>;
+export type NodeFsPromisesSubsetLegacy = {
+	readFile:
+		| ((path: string) => Promise<ArrayBuffer>)
+		| ((path: string, options?: { encoding: "utf-8" }) => Promise<string>);
 	readdir: (path: string) => Promise<string[]>;
-	writeFile: (path: string, data: Buffer) => Promise<void>;
+	writeFile: (path: string, data: ArrayBuffer | string) => Promise<void>;
 	mkdir: (path: string) => Promise<void>;
 };
 
@@ -85,8 +87,8 @@ type NodeFsPromisesSubsetLegacy = {
  *
  * https://github.com/opral/inlang-sdk/issues/136
  */
-type NodeFsPromisesSubset = {
-	readFile: (path: string) => Promise<Buffer>;
+export type NodeFsPromisesSubset = {
+	readFile: (path: string) => Promise<ArrayBuffer>;
 	readdir: (path: string) => Promise<string[]>;
 };
 

--- a/inlang/source-code/sdk2/src/project/loadProjectFromDirectory.test.ts
+++ b/inlang/source-code/sdk2/src/project/loadProjectFromDirectory.test.ts
@@ -275,19 +275,17 @@ test("plugin calls that use fs should be intercepted to use an absolute path", a
 	process.cwd = () => "/";
 
 	const mockRepo = {
-		"/inlang/development-projects/inlang-nextjs/app/i18n/locales/en.json":
-			JSON.stringify({
-				key1: "value1",
-				key2: "value2",
-			}),
-		"/inlang/development-projects/inlang-nextjs/other-folder/backend.inlang/settings.json":
-			JSON.stringify({
-				baseLocale: "en",
-				locales: ["en", "de"],
-				"plugin.mock-plugin": {
-					pathPattern: "./../../app/i18n/locales/{locale}.json",
-				},
-			} satisfies ProjectSettings),
+		"/messages/en.json": JSON.stringify({
+			key1: "value1",
+			key2: "value2",
+		}),
+		"/project.inlang/settings.json": JSON.stringify({
+			baseLocale: "en",
+			locales: ["en", "de"],
+			"plugin.mock-plugin": {
+				pathPattern: "./messages/{locale}.json",
+			},
+		} satisfies ProjectSettings),
 	};
 
 	const mockPlugin: InlangPlugin = {
@@ -348,12 +346,12 @@ test("plugin calls that use fs should be intercepted to use an absolute path", a
 
 	const project = await loadProjectFromDirectoryInMemory({
 		fs: fs as any,
-		path: "/inlang/development-projects/inlang-nextjs/other-folder/backend.inlang",
+		path: "/project.inlang",
 		providePlugins: [mockPlugin],
 	});
 
 	expect(loadMessagesSpy).toHaveBeenCalled();
-	expect(fsReadFileSpy).toHaveBeenCalledWith("/messages/en.json");
+	expect(fsReadFileSpy).toHaveBeenCalledWith("/messages/en.json", undefined);
 
 	// todo test that saveMessages works too.
 	// await project.db.insertInto("bundle").defaultValues().execute();


### PR DESCRIPTION
Closes https://github.com/opral/inlang-sdk/issues/174. Messages can now be loaded in Sherlock (cc @felixhaeberle)


https://github.com/user-attachments/assets/2d46814e-bb79-4610-82a8-9b7c94bb37fc



**Changes**

- `plugin.loadMessages` receives a mapped fs that turns relative paths into absolute paths to maintain backward compatibility
- sherlock subscribes to bundles to display messages 

**Follow up todos**

- [ ] pass mapped fs to `plugin.saveMessages` and `plugin.toBeImportedFiles()` after https://github.com/opral/inlang-sdk/issues/159 is merged