### PR TITLE
add: file.metadata

### DIFF
--- a/inlang/source-code/sdk2/src/database/serializeJsonPlugin.ts
+++ b/inlang/source-code/sdk2/src/database/serializeJsonPlugin.ts
@@ -46,7 +46,7 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 				// @ts-ignore
 				const { value } = listNodeItem;
 
-				const serializedValue = maybeSerializeJson(value);
+				const serializedValue = serializeJson(value);
 
 				if (value === serializedValue) {
 					return listNodeItem;
@@ -57,23 +57,6 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 				return sql`json(${serializedValue})`.toOperationNode();
 			}),
 		});
-	}
-
-	/**
-	 * Directly transform the value to a json value.
-	 *
-	 * Input: { value: { a: 1 } }
-	 * Output: { value: "{ a: 1 }"" }
-	 */
-	protected override transformValue(node: ValueNode): ValueNode {
-		const { value } = node;
-
-		const serializedValue = maybeSerializeJson(value);
-
-		if (value === serializedValue) {
-			return node;
-		}
-		return { ...node, value: serializedValue };
 	}
 
 	override transformValues(node: ValuesNode): ValuesNode {
@@ -99,7 +82,7 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 	}
 }
 
-function maybeSerializeJson(value: any): any {
+function serializeJson(value: any): any {
 	if (
 		// binary data
 		value instanceof ArrayBuffer ||

--- a/inlang/source-code/sdk2/src/database/serializeJsonPlugin.ts
+++ b/inlang/source-code/sdk2/src/database/serializeJsonPlugin.ts
@@ -46,7 +46,7 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 				// @ts-ignore
 				const { value } = listNodeItem;
 
-				const serializedValue = serializeJson(value);
+				const serializedValue = maybeSerializeJson(value);
 
 				if (value === serializedValue) {
 					return listNodeItem;
@@ -57,6 +57,23 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 				return sql`json(${serializedValue})`.toOperationNode();
 			}),
 		});
+	}
+
+	/**
+	 * Directly transform the value to a json value.
+	 *
+	 * Input: { value: { a: 1 } }
+	 * Output: { value: "{ a: 1 }"" }
+	 */
+	protected override transformValue(node: ValueNode): ValueNode {
+		const { value } = node;
+
+		const serializedValue = maybeSerializeJson(value);
+
+		if (value === serializedValue) {
+			return node;
+		}
+		return { ...node, value: serializedValue };
 	}
 
 	override transformValues(node: ValuesNode): ValuesNode {
@@ -82,7 +99,7 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 	}
 }
 
-function serializeJson(value: any): any {
+function maybeSerializeJson(value: any): any {
 	if (
 		// binary data
 		value instanceof ArrayBuffer ||

--- a/lix/packages/sdk/src/change-queue.test.ts
+++ b/lix/packages/sdk/src/change-queue.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-null */
 import { expect, test, vi } from "vitest";
 import { openLixInMemory } from "./open/openLixInMemory.js";
 import { newLixFile } from "./newLix.js";
@@ -59,6 +60,7 @@ test("should use queue and settled correctly", async () => {
 		{
 			id: 1,
 			file_id: "test",
+			metadata: null,
 			path: "test.txt",
 			data: queue[0]?.data,
 		},
@@ -79,6 +81,7 @@ test("should use queue and settled correctly", async () => {
 			data: internalFilesAfter[0]?.data,
 			id: "test",
 			path: "test.txt",
+			metadata: null,
 		},
 	]);
 
@@ -122,12 +125,14 @@ test("should use queue and settled correctly", async () => {
 			id: 2,
 			file_id: "test",
 			path: "test.txt",
+			metadata: null,
 			data: queue2[0]?.data,
 		},
 		{
 			id: 3,
 			file_id: "test",
 			path: "test.txt",
+			metadata: null,
 			data: queue2[1]?.data,
 		},
 	]);

--- a/lix/packages/sdk/src/database/createSchema.ts
+++ b/lix/packages/sdk/src/database/createSchema.ts
@@ -10,19 +10,21 @@ export async function createSchema(args: { db: Kysely<any> }) {
   CREATE TABLE file_internal (
     id TEXT PRIMARY KEY DEFAULT (uuid_v4()),
     path TEXT NOT NULL UNIQUE,
-    data BLOB NOT NULL
+    data BLOB NOT NULL,
+    metadata TEXT  -- Added metadata field
   ) strict;
 
   CREATE TABLE change_queue (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     file_id TEXT,
     path TEXT NOT NULL,
-    data BLOB
+    data BLOB,
+    metadata TEXT  -- Added metadata field
   ) strict;
 
   create view file as
-    select z.id as id, z.path as path, z.data as data, MAX(z.mx) as queue_id from 
-      (select file_id as id, path, data, id as mx from change_queue UNION select id, path, data, 0 as mx from file_internal) as z
+    select z.id as id, z.path as path, z.data as data, z.metadata as metadata, MAX(z.mx) as queue_id from 
+      (select file_id as id, path, data, metadata, id as mx from change_queue UNION select id, path, data, metadata, 0 as mx from file_internal) as z
     group by z.id;
   
   CREATE TABLE change (
@@ -61,19 +63,19 @@ export async function createSchema(args: { db: Kysely<any> }) {
 
   CREATE TRIGGER file_update INSTEAD OF UPDATE ON file
   BEGIN
-    insert into change_queue(file_id, path, data) values(NEW.id, NEW.path, NEW.data);
+    insert into change_queue(file_id, path, data, metadata) values(NEW.id, NEW.path, NEW.data, NEW.metadata);
     select triggerWorker();
   END;
 
   CREATE TRIGGER file_insert INSTEAD OF INSERT ON file
   BEGIN
-    insert into change_queue(file_id, path, data) values(NEW.id, NEW.path, NEW.data);
+    insert into change_queue(file_id, path, data, metadata) values(NEW.id, NEW.path, NEW.data, NEW.metadata);
     select triggerWorker();
   END;
 
   CREATE TRIGGER change_queue_remove BEFORE DELETE ON change_queue
   BEGIN
-    insert or replace into file_internal(id, path, data) values(OLD.file_id, OLD.path, OLD.data);
+    insert or replace into file_internal(id, path, data, metadata) values(OLD.file_id, OLD.path, OLD.data, OLD.metadata);
   END;
 `.execute(args.db);
 }

--- a/lix/packages/sdk/src/database/schema.ts
+++ b/lix/packages/sdk/src/database/schema.ts
@@ -26,6 +26,7 @@ type ChangeQueueTable = {
 	id: Generated<number>;
 	path: string;
 	file_id: LixFileTable["id"];
+	metadata: Record<string, any> | null;
 	data: ArrayBuffer;
 };
 
@@ -37,6 +38,7 @@ type LixFileTable = {
 	id: Generated<string>;
 	path: string;
 	data: ArrayBuffer;
+	metadata: Record<string, any> | null;
 };
 
 export type Commit = Selectable<CommitTable>;

--- a/lix/packages/sdk/src/database/serializeJsonPlugin.ts
+++ b/lix/packages/sdk/src/database/serializeJsonPlugin.ts
@@ -46,7 +46,7 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 				// @ts-ignore
 				const { value } = listNodeItem;
 
-				const serializedValue = serializeJson(value);
+				const serializedValue = maybeSerializeJson(value);
 
 				if (value === serializedValue) {
 					return listNodeItem;
@@ -57,6 +57,23 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 				return sql`json(${serializedValue})`.toOperationNode();
 			}),
 		});
+	}
+
+	/**
+	 * Directly transform the value to a json value.
+	 *
+	 * Input: { value: { a: 1 } }
+	 * Output: { value: "{ a: 1 }"" }
+	 */
+	protected override transformValue(node: ValueNode): ValueNode {
+		const { value } = node;
+
+		const serializedValue = maybeSerializeJson(value);
+
+		if (value === serializedValue) {
+			return node;
+		}
+		return { ...node, value: serializedValue };
 	}
 
 	override transformValues(node: ValuesNode): ValuesNode {
@@ -82,7 +99,7 @@ class ParseJsonTransformer extends OperationNodeTransformer {
 	}
 }
 
-function serializeJson(value: any): any {
+function maybeSerializeJson(value: any): any {
 	if (
 		// binary data
 		value instanceof ArrayBuffer ||

--- a/lix/packages/sdk/src/mock/mock-csv-plugin.test.ts
+++ b/lix/packages/sdk/src/mock/mock-csv-plugin.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-null */
 import { newLixFile } from "../newLix.js";
 import { openLixInMemory } from "../open/openLixInMemory.js";
 import { mockCsvPlugin } from "./mock-csv-plugin.js";
@@ -21,7 +22,7 @@ describe("applyChanges()", () => {
 		];
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const { fileData } = await mockCsvPlugin.applyChanges!({
-			file: { id: "mock", path: "x.csv", data: old },
+			file: { id: "mock", path: "x.csv", data: old, metadata: null },
 			changes: changes as any,
 			lix: {} as any,
 		});
@@ -40,7 +41,7 @@ describe("applyChanges()", () => {
 		];
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const { fileData } = await mockCsvPlugin.applyChanges!({
-			file: { id: "mock", path: "x.csv", data: old },
+			file: { id: "mock", path: "x.csv", data: old, metadata: null },
 			changes: changes as any,
 			lix: {} as any,
 		});
@@ -77,7 +78,7 @@ describe("applyChanges()", () => {
 		];
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const { fileData } = await mockCsvPlugin.applyChanges!({
-			file: { id: "mock", path: "x.csv", data: old },
+			file: { id: "mock", path: "x.csv", data: old, metadata: null },
 			changes: changes as any,
 			lix,
 		});
@@ -90,8 +91,8 @@ describe("diff.file()", () => {
 		const old = new TextEncoder().encode("Name,Age\nAnna,20\nPeter,50");
 		const neu = old;
 		const diffs = await mockCsvPlugin.diff.file?.({
-			old: { id: "random", path: "x.csv", data: old },
-			neu: { id: "random", path: "x.csv", data: neu },
+			old: { id: "random", path: "x.csv", data: old, metadata: null },
+			neu: { id: "random", path: "x.csv", data: neu, metadata: null },
 		});
 		expect(diffs).toEqual([]);
 	});
@@ -102,8 +103,8 @@ describe("diff.file()", () => {
 			"Name,Age\nAnna,20\nPeter,50\nJohn,30",
 		);
 		const diffs = await mockCsvPlugin.diff.file?.({
-			old: { id: "random", path: "x.csv", data: old },
-			neu: { id: "random", path: "x.csv", data: neu },
+			old: { id: "random", path: "x.csv", data: old, metadata: null },
+			neu: { id: "random", path: "x.csv", data: neu, metadata: null },
 		});
 		expect(diffs).toEqual([
 			{
@@ -125,8 +126,8 @@ describe("diff.file()", () => {
 		const old = new TextEncoder().encode("Name,Age\nAnna,20\nPeter,50");
 		const neu = new TextEncoder().encode("Name,Age\nAnna,21\nPeter,50");
 		const diffs = await mockCsvPlugin.diff.file?.({
-			old: { id: "random", path: "x.csv", data: old },
-			neu: { id: "random", path: "x.csv", data: neu },
+			old: { id: "random", path: "x.csv", data: old, metadata: null },
+			neu: { id: "random", path: "x.csv", data: neu, metadata: null },
 		});
 		expect(diffs).toEqual([
 			{
@@ -142,8 +143,8 @@ describe("diff.file()", () => {
 		const old = new TextEncoder().encode("Name,Age\nAnna,20\nPeter,50");
 		const neu = new TextEncoder().encode("Name,Age\nAnna,20");
 		const diffs = await mockCsvPlugin.diff.file?.({
-			old: { id: "random", path: "x.csv", data: old },
-			neu: { id: "random", path: "x.csv", data: neu },
+			old: { id: "random", path: "x.csv", data: old, metadata: null },
+			neu: { id: "random", path: "x.csv", data: neu, metadata: null },
 		});
 		expect(diffs).toEqual([
 			{

--- a/lix/packages/sdk/src/open/openLix.ts
+++ b/lix/packages/sdk/src/open/openLix.ts
@@ -77,8 +77,7 @@ export async function openLix(args: {
 			if (entry) {
 				const existingFile = await db
 					.selectFrom("file_internal")
-					.select("data")
-					.select("path")
+					.selectAll()
 					.where("id", "=", entry.file_id)
 					.limit(1)
 					.executeTakeFirst();
@@ -88,14 +87,12 @@ export async function openLix(args: {
 						currentAuthor,
 						queueEntry: entry,
 						old: {
+							...existingFile,
 							id: entry.file_id,
-							path: existingFile?.path,
-							data: existingFile?.data,
 						},
 						neu: {
+							...entry,
 							id: entry.file_id,
-							path: entry.path,
-							data: entry.data,
 						},
 						plugins,
 						db,
@@ -105,9 +102,8 @@ export async function openLix(args: {
 						currentAuthor,
 						queueEntry: entry,
 						neu: {
+							...entry,
 							id: entry.file_id,
-							path: entry.path,
-							data: entry.data,
 						},
 						plugins,
 						db,


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/71. 

**Changes**

- adds `file.metadata` as JSON column [as discussed on Discord](https://discord.com/channels/897438559458430986/1281609575312658504/1281611106305048636)
- fixes JSON serialization when the value is a primitive (the kysely plugin API is ... complicated) 

**Out of scope (should be done in a follow-up)**

- change controlling metadata https://github.com/opral/lix-sdk/issues/72

**Additional information**

- uses `T | null` for `file.metadata` because of https://github.com/opral/lix-sdk/issues/55
- the change queue selects all for simplicity reasons for now. can be optimized later. 