### PR TITLE
refactor: remove `project.settled()` from public api

### DIFF
--- a/inlang/source-code/sdk2/src/project/api.ts
+++ b/inlang/source-code/sdk2/src/project/api.ts
@@ -34,7 +34,6 @@ export type InlangProject = {
 		set: (settings: ProjectSettings) => Promise<void>;
 		subscribe: Subscription<ProjectSettings>;
 	};
-	settled: () => Promise<void>;
 	lix: Lix;
 	importFiles: (args: {
 		pluginKey: InlangPlugin["key"];

--- a/inlang/source-code/sdk2/src/project/loadProject.test.ts
+++ b/inlang/source-code/sdk2/src/project/loadProject.test.ts
@@ -32,8 +32,6 @@ test("it should persist changes of bundles, messages, and variants to lix ", asy
 		})
 		.execute();
 
-	await project1.settled();
-
 	const file1AfterUpdates = await project1.toBlob();
 	await project1.close();
 


### PR DESCRIPTION
Closes https://github.com/opral/inlang-sdk/issues/175

- `project.settled()` was even used in any app
- a follow up PR should implement a proper queue for changes written to lix