### PR TITLE
rework `createNewProjectHandler` & export `saveProjectToDirectory`

### DIFF
--- a/inlang/source-code/sdk2/src/index.ts
+++ b/inlang/source-code/sdk2/src/index.ts
@@ -1,6 +1,7 @@
 export { newProject } from "./project/newProject.js";
 export { loadProjectInMemory } from "./project/loadProjectInMemory.js";
 export { loadProjectFromDirectoryInMemory } from "./project/loadProjectFromDirectory.js";
+export { saveProjectToDirectory } from "./project/saveProjectToDirectory.js";
 export type { InlangProject } from "./project/api.js";
 export * from "./json-schema/settings.js";
 export * from "./json-schema/pattern.js";


### PR DESCRIPTION
cc SHERL-95

Implementaton is like

```ts
// The path to the project directory
const projectPath = normalizePath(`${workspaceFolderPath}/project.inlang`)

// Create a new project in memory
const project = await loadProjectInMemory({
	blob: await newProject(),
})

// Save the project blob as a directory
await saveProjectToDirectory({
	fs: nodeishFs,
	project,
	path: projectPath,
})
```