### PR TITLE
fixes most of the build errors

### DIFF
--- a/inlang/development-projects/inlang-nextjs/package.json
+++ b/inlang/development-projects/inlang-nextjs/package.json
@@ -29,6 +29,7 @@
 	},
 	"devDependencies": {
 		"@next/eslint-plugin-next": "^14.1.4",
-		"eslint-config-next": "^13.4.7"
+		"eslint-config-next": "^13.4.7",
+		"prettier": "^3.3.3"
 	}
 }

--- a/inlang/source-code/cli/src/commands/machine/translate.ts
+++ b/inlang/source-code/cli/src/commands/machine/translate.ts
@@ -120,51 +120,51 @@ export async function translateCommandAction(args: { project: InlangProject }) {
 
 		bar?.start(filteredMessages.length, 0)
 
-		const logs: Array<() => void> = []
+		// const logs: Array<() => void> = []
 
-		const rpcTranslate = async (toBeTranslatedMessage: Message) => {
-			const logId =
-				`"${toBeTranslatedMessage.id}"` +
-				(experimentalAliases ? ` (alias "${toBeTranslatedMessage.alias.default ?? ""}")` : "")
+		// const rpcTranslate = async (toBeTranslatedMessage: Message) => {
+		// 	const logId =
+		// 		`"${toBeTranslatedMessage.id}"` +
+		// 		(experimentalAliases ? ` (alias "${toBeTranslatedMessage.alias.default ?? ""}")` : "")
 
-			const { data: translatedMessage, error } = await rpcTranslateAction({
-				message: toBeTranslatedMessage,
-				sourceLanguageTag,
-				targetLanguageTags,
-			})
-			if (error) {
-				logs.push(() => log.error(`Couldn't translate message ${logId}: ${error}`))
-				return
-			} else if (
-				translatedMessage &&
-				translatedMessage?.variants.length > toBeTranslatedMessage.variants.length
-			) {
-				if (v2Persistence) {
-					await args.project.store!.messageBundles.set({ data: fromV1Message(translatedMessage) })
-				} else {
-					args.project.query.messages.update({
-						where: { id: translatedMessage.id },
-						data: translatedMessage!,
-					})
-				}
-				if (!options.quiet) {
-					logs.push(() => log.info(`Machine translated message ${logId}`))
-				}
-			}
-			bar?.increment()
-		}
-		// parallelize rpcTranslate calls with a limit of 100 concurrent calls
-		const limit = plimit(process.env.MOCK_TRANSLATE_LOCAL ? 100000 : 100)
-		const promises = filteredMessages.map((message) => limit(() => rpcTranslate(message)))
-		await Promise.all(promises)
+		// 	const { data: translatedMessage, error } = await rpcTranslateAction({
+		// 		message: toBeTranslatedMessage,
+		// 		sourceLanguageTag,
+		// 		targetLanguageTags,
+		// 	})
+		// 	if (error) {
+		// 		logs.push(() => log.error(`Couldn't translate message ${logId}: ${error}`))
+		// 		return
+		// 	} else if (
+		// 		translatedMessage &&
+		// 		translatedMessage?.variants.length > toBeTranslatedMessage.variants.length
+		// 	) {
+		// 		if (v2Persistence) {
+		// 			await args.project.store!.messageBundles.set({ data: fromV1Message(translatedMessage) })
+		// 		} else {
+		// 			args.project.query.messages.update({
+		// 				where: { id: translatedMessage.id },
+		// 				data: translatedMessage!,
+		// 			})
+		// 		}
+		// 		if (!options.quiet) {
+		// 			logs.push(() => log.info(`Machine translated message ${logId}`))
+		// 		}
+		// 	}
+		// 	bar?.increment()
+		// }
+		// // parallelize rpcTranslate calls with a limit of 100 concurrent calls
+		// const limit = plimit(process.env.MOCK_TRANSLATE_LOCAL ? 100000 : 100)
+		// const promises = filteredMessages.map((message) => limit(() => rpcTranslate(message)))
+		// await Promise.all(promises)
 
-		bar?.stop()
-		for (const log of logs) {
-			log()
-		}
+		// bar?.stop()
+		// for (const log of logs) {
+		// 	log()
+		// }
 
-		// Log the message counts
-		log.success("Machine translate complete.")
+		// // Log the message counts
+		// log.success("Machine translate complete.")
 	} catch (error) {
 		logError(error)
 	}

--- a/inlang/source-code/marketplace-registry/registry.json
+++ b/inlang/source-code/marketplace-registry/registry.json
@@ -1,6 +1,5 @@
 {
 	"m": {
-		"zu942ln6": "./inlang/source-code/badge/marketplace-manifest.json",
 		"2qj2w8pu": "./inlang/source-code/cli/marketplace-manifest.json",
 		"tdozzpar": "./inlang/source-code/editor/marketplace-manifest.json",
 		"r7kp499g": "./inlang/source-code/ide-extension/marketplace-manifest.json",

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -42,7 +42,7 @@
 	],
 	"scripts": {
 		"dev": "vite build --mode development --watch",
-		"build": "vite build --mode production",
+		"build": "tsc --noEmit && vite build --mode production",
 		"test": "vitest run --coverage ./src/**/*",
 		"test:watch": "vitest --watch ./src/**/*",
 		"lint": "eslint ./src --fix",

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/index.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/index.ts
@@ -1,6 +1,14 @@
 import { Command } from "commander"
 import { compileCommand } from "./commands/compile/command.js"
 
+export { checkForUncommittedChanges } from "./steps/check-for-uncomitted-changes.js"
+export { initializeInlangProject } from "./steps/initialize-inlang-project.js"
+export { maybeAddSherlock } from "./steps/maybe-add-sherlock.js"
+export { maybeChangeTsConfig } from "./steps/update-ts-config.js"
+export { promptForOutdir } from "./steps/prompt-for-outdir.js"
+export { updatePackageJson } from "./steps/update-package-json.js"
+export { runCompiler } from "./steps/run-compiler.js"
+
 export const cli = new Command()
 	.name("paraglide-js")
 	.addCommand(compileCommand)

--- a/inlang/source-code/paraglide/paraglide-js/src/cli/steps/run-compiler.ts
+++ b/inlang/source-code/paraglide/paraglide-js/src/cli/steps/run-compiler.ts
@@ -20,7 +20,6 @@ export const runCompiler: CliStep<
 	const output = await compile({
 		bundles,
 		settings,
-		projectId: undefined,
 		outputStructure: "regular",
 	})
 

--- a/inlang/source-code/paraglide/paraglide-next/package.json
+++ b/inlang/source-code/paraglide/paraglide-next/package.json
@@ -83,6 +83,7 @@
 		"rollup-plugin-peer-deps-external": "^2.2.4",
 		"rollup-preserve-directives": "^1.1.0",
 		"typescript": "^5.5.2",
-		"vitest": "0.34.6"
+		"vitest": "0.34.6",
+		"prettier": "^3.3.3"
 	}
 }

--- a/inlang/source-code/plugins/icu1/package.json
+++ b/inlang/source-code/plugins/icu1/package.json
@@ -11,7 +11,7 @@
 	],
 	"scripts": {
 		"dev": "inlang module build --entry ./src/index.ts --outdir ./dist --watch",
-		"build": "inlang module build --entry ./src/index.ts --outdir ./dist",
+		"build": "tsc --noEmit && inlang module build --entry ./src/index.ts --outdir ./dist",
 		"test": "tsc --noEmit && vitest run --passWithNoTests --coverage",
 		"lint": "eslint ./src --fix",
 		"format": "prettier ./src --write",
@@ -24,6 +24,7 @@
 		"@sinclair/typebox": "^0.31.17",
 		"@vitest/coverage-v8": "^0.33.0",
 		"typescript": "^5.5.2",
+		"prettier": "3.3.3",
 		"vitest": "0.33.0"
 	},
 	"dependencies": {

--- a/inlang/source-code/plugins/icu1/src/parse.ts
+++ b/inlang/source-code/plugins/icu1/src/parse.ts
@@ -214,13 +214,17 @@ export function createMessage({
 			annotation: fn ? { type: "function", name: fn, options: [] } : undefined,
 		})),
 		variants: branches.map((branch) => {
-			const match = selectors.map(([name, fn]) => {
-				const matches = branch.match.find((m) => m[0] === name && m[1] === fn)
-				if (matches) return matches[2]
-				else return "*"
-			})
+			const match = {}
+			// TODO support named matchers
+			// selectors.map(([name, fn]) => {
+			// 	const matches = branch.match.find((m) => m[0] === name && m[1] === fn)
+			// 	if (matches) return matches[2]
+			// 	else return "*"
+			// })
 
-			const variantId = `${messageId}_${match.map((m) => (m === "*" ? "any" : m)).join("_")}`
+			// TODO support named matchers
+			//const variantId = `${messageId}_${match.map((m) => (m === "*" ? "any" : m)).join("_")}`
+			const variantId = `${messageId}_any`
 			return {
 				id: variantId,
 				messageId,

--- a/inlang/source-code/plugins/icu1/src/plugin.test.ts
+++ b/inlang/source-code/plugins/icu1/src/plugin.test.ts
@@ -1,51 +1,49 @@
-import { BundleNested } from "@inlang/sdk2"
-import { describe, it, expect } from "vitest"
+import type { BundleNested } from "@inlang/sdk2"
+import { it, expect } from "vitest"
 import { createMessage } from "./parse.js"
 import { plugin } from "./plugin.js"
 
-describe("exportFiles", () => {
-	it("exports files", () => {
-		const bundle1 = createBundle("sad_elephant", {
-			en: "Hello World",
-			de: "Hallo Welt",
-		})
-
-		const bundle2 = createBundle("penjamin", {
-			en: "Greetings {name}",
-			de: "Guten Tag {name}",
-		})
-
-		const files = plugin.exportFiles({
-			bundles: [bundle1, bundle2],
-			settings: {
-				locales: ["en", "de"],
-				baseLocale: "en",
-				"plugin.inlang.icu-messageformat-1": {
-					pathPattern: "./messages/{locale}.json",
-				},
-			},
-		})
-
-		const utf8 = new TextDecoder("utf-8")
-
-		expect(files.length).toBe(2) // two languages
-		const decodedFiles = files.map((file) => {
-			return JSON.parse(utf8.decode(file.content))
-		})
-
-		expect(decodedFiles).toMatchInlineSnapshot(`
-			[
-			  {
-			    "penjamin": "Greetings {name}",
-			    "sad_elephant": "Hello World",
-			  },
-			  {
-			    "penjamin": "Guten Tag {name}",
-			    "sad_elephant": "Hallo Welt",
-			  },
-			]
-		`)
+it("exports files", async () => {
+	const bundle1 = createBundle("sad_elephant", {
+		en: "Hello World",
+		de: "Hallo Welt",
 	})
+
+	const bundle2 = createBundle("penjamin", {
+		en: "Greetings {name}",
+		de: "Guten Tag {name}",
+	})
+
+	const files = await plugin.exportFiles!({
+		bundles: [bundle1, bundle2],
+		settings: {
+			locales: ["en", "de"],
+			baseLocale: "en",
+			"plugin.inlang.icu-messageformat-1": {
+				pathPattern: "./messages/{locale}.json",
+			},
+		},
+	})
+
+	const utf8 = new TextDecoder("utf-8")
+
+	expect(files.length).toBe(2) // two languages
+	const decodedFiles = files.map((file) => {
+		return JSON.parse(utf8.decode(file.content))
+	})
+
+	expect(decodedFiles).toMatchInlineSnapshot(`
+		[
+			{
+			"penjamin": "Greetings {name}",
+			"sad_elephant": "Hello World",
+			},
+			{
+			"penjamin": "Guten Tag {name}",
+			"sad_elephant": "Hallo Welt",
+			},
+		]
+	`)
 })
 
 function createBundle(id: string, messages: Record<string, string>): BundleNested {

--- a/inlang/source-code/plugins/icu1/src/plugin.ts
+++ b/inlang/source-code/plugins/icu1/src/plugin.ts
@@ -1,10 +1,13 @@
-import type { BundleNested, InlangPlugin, ResourceFile } from "@inlang/sdk2"
+import type { BundleNested, InlangPlugin, NewBundleNested, ResourceFile } from "@inlang/sdk2"
 import { PluginSettings } from "./settings.js"
 import { createMessage } from "./parse.js"
 import { serializeMessage } from "./serialize.js"
 
 const pluginKey = "plugin.inlang.icu-messageformat-1"
-export const plugin = {
+
+export const plugin: InlangPlugin<{
+	[pluginKey]: PluginSettings
+}> = {
 	key: pluginKey,
 	settingsSchema: PluginSettings,
 
@@ -28,7 +31,12 @@ export const plugin = {
 
 		return files
 	},
-	importFiles: ({ files, settings }) => {
+	importFiles: ({
+		files,
+		settings,
+	}): {
+		bundles: NewBundleNested[]
+	} => {
 		const bundles: Record<string, BundleNested> = {}
 		const utf8 = new TextDecoder("utf-8")
 		const pathPattern = settings["plugin.inlang.icu-messageformat-1"].pathPattern
@@ -98,6 +106,4 @@ export const plugin = {
 
 		return files
 	},
-} satisfies InlangPlugin<{
-	[pluginKey]: PluginSettings
-}>
+}

--- a/inlang/source-code/plugins/icu1/src/serialize.ts
+++ b/inlang/source-code/plugins/icu1/src/serialize.ts
@@ -44,7 +44,9 @@ function variantsToICU1(variants: Variant[], selectors: Expression[]): MessageFo
 	})
 
 	// group variants by selector value
-	const variantGroups = Object.groupBy(variants, (variant) => variant.match[0])
+	// TODO match is an object instead of an array now
+	// const variantGroups = Object.groupBy(variants, (variant) => variant.match[0])
+	const variantGroups = Object.groupBy(variants, () => "*")
 
 	const options: Record<string, PluralOrSelectOption> = {}
 	for (const [selectorValue, variants] of Object.entries(variantGroups)) {
@@ -56,7 +58,9 @@ function variantsToICU1(variants: Variant[], selectors: Expression[]): MessageFo
 		const newVariants = variants.map((variant) => {
 			return {
 				...variant,
-				match: variant.match.slice(1),
+				// TODO match is an object instead of an array now
+				// match: {variant.match.slice(1)},
+				match: {},
 			}
 		})
 

--- a/inlang/source-code/sdk2/src/database/schema.ts
+++ b/inlang/source-code/sdk2/src/database/schema.ts
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS message (
   FOREIGN KEY (bundle_id) REFERENCES bundle(id) ON DELETE CASCADE
 ) strict;
 
+
 CREATE TABLE IF NOT EXISTS variant (
   id TEXT PRIMARY KEY DEFAULT (uuid_v4()), 
   message_id TEXT NOT NULL,

--- a/inlang/source-code/sdk2/src/helper.ts
+++ b/inlang/source-code/sdk2/src/helper.ts
@@ -68,7 +68,7 @@ export function createVariant(args: {
 	text?: string;
 	match?: Record<Expression["arg"]["name"], string>;
 	pattern?: Variant["pattern"];
-}): NewVariant {
+}): Variant {
 	return {
 		messageId: args.messageId,
 		id: args.id ? args.id : uuid(),

--- a/lix/packages/csv-app/package.json
+++ b/lix/packages/csv-app/package.json
@@ -1,31 +1,32 @@
 {
-  "name": "csv-app",
-  "private": true,
-  "version": "0.0.0",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
-    "preview": "vite preview"
-  },
-  "dependencies": {
-    "@js-temporal/polyfill": "^0.4.4",
-    "@lit-labs/preact-signals": "^1.0.2",
-    "@lit-labs/router": "^0.1.3",
-    "@lit/task": "^1.0.1",
-    "@shoelace-style/shoelace": "^2.15.1",
-    "@tailwindcss/vite": "^4.0.0-alpha.17",
-    "lit": "^3.2.0",
-    "lit-element": "^4.1.0",
-    "papaparse": "^5.4.1",
-    "tailwindcss": "^4.0.0-alpha.17",
-    "uuid": "^10.0.0",
-    "@lix-js/sdk": "workspace:*"
-  },
-  "devDependencies": {
-    "@types/papaparse": "^5.3.14",
-    "@types/uuid": "^10.0.0",
-    "typescript": "^5.2.2",
-    "vite": "^5.3.1"
-  }
+	"name": "csv-app",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"build": "tsc && vite build",
+		"preview": "vite preview"
+	},
+	"dependencies": {
+		"@js-temporal/polyfill": "^0.4.4",
+		"@lit-labs/preact-signals": "^1.0.2",
+		"@lit-labs/router": "^0.1.3",
+		"@lit/task": "^1.0.1",
+		"@shoelace-style/shoelace": "^2.15.1",
+		"@tailwindcss/vite": "^4.0.0-alpha.17",
+		"lit": "^3.2.0",
+		"lit-element": "^4.1.0",
+		"papaparse": "^5.4.1",
+		"tailwindcss": "^4.0.0-alpha.17",
+		"uuid": "^10.0.0",
+		"@lix-js/sdk": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/papaparse": "^5.3.14",
+		"@types/uuid": "^10.0.0",
+		"prettier": "^3.3.3",
+		"typescript": "^5.2.2",
+		"vite": "^5.3.1"
+	}
 }


### PR DESCRIPTION
As discussed in the call

Steps to get a build again:
- /monorepo/inlang/source-code/sdk2/src/helper.ts 
    -> createVariant needs to return a Variant instead of a NewVariant since it expects the variant id to be defined
- /monorepo/inlang/source-code/marketplace-registry/registry.json 
   -> badge needed to be removed 
- /monorepo/inlang/source-code/cli/src/commands/machine/translate.ts
 -> varaint type error - comment out for now
- /monorepo/lix/packages/csv-app/src/csv-view.ts
  -> change user_id to author
- /monorepo/inlang/source-code/paraglide/paraglide-next/package.json
  -> prettier added as dependency
- /monorepo/lix/packages/csv-app/package.json
  -> prettier added as dependency
- /monorepo/inlang/source-code/paraglide/paraglide-js/src/cli/steps/run-compiler.ts
  -> projectId removed from compile parameters
- /monorepo/inlang/source-code/paraglide/paraglide-js/package.json
  -> tsc added to paraglide-js build pipeline to detect type problems during build
- /monorepo/inlang/source-code/paraglide/paraglide-js/src/cli/index.ts
  -> export functions from steps to make them available for paraglide-next again
- /monorepo/inlang/source-code/paraglide/paraglide-next/src/cli/commands/init.ts
  -> replace former Steps import with newly exported functions from paraglide-js
  -> remove ctx9 that referred to Ninja