### PR TITLE
add: where bundle id or alias query utility

### DIFF
--- a/inlang/source-code/sdk2/src/query-utilities/bundleIdOrAliasIs.test.ts
+++ b/inlang/source-code/sdk2/src/query-utilities/bundleIdOrAliasIs.test.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "vitest";
+import { bundleIdOrAliasIs } from "./bundleIdOrAliasIs.js";
+import { loadProjectInMemory } from "../project/loadProjectInMemory.js";
+import { newProject } from "../project/newProject.js";
+
+test("should return the bundle by id", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+	await project.db.insertInto("bundle").values({ id: "some-id" }).execute();
+
+	const bundle = await project.db
+		.selectFrom("bundle")
+		.selectAll()
+		.where(bundleIdOrAliasIs("some-id"))
+		.executeTakeFirst();
+
+	expect(bundle?.id).toBe("some-id");
+});
+
+test("it should return the bundle by alias", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+	await project.db
+		.insertInto("bundle")
+		.values([
+			{ id: "some-id", alias: { mock: "some-alias" } },
+			{
+				id: "some-id-2",
+				alias: { other: "another-alias" },
+			},
+		])
+		.execute();
+
+	const bundle = await project.db
+		.selectFrom("bundle")
+		.selectAll()
+		.where(bundleIdOrAliasIs("some-alias"))
+		.executeTakeFirst();
+
+	expect(bundle?.id).toBe("some-id");
+});
+
+test("it should return multiple bundles by alias", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+	await project.db
+		.insertInto("bundle")
+		.values([
+			{ id: "some-id", alias: { mock: "some-alias" } },
+			{ id: "some-id-2", alias: { other: "some-alias" } },
+			{ id: "some-id-3", alias: { other: "another-alias" } },
+		])
+		.execute();
+
+	const bundles = await project.db
+		.selectFrom("bundle")
+		.selectAll()
+		.where(bundleIdOrAliasIs("some-alias"))
+		.execute();
+
+	expect(bundles).toStrictEqual([
+		{ id: "some-id", alias: { mock: "some-alias" } },
+		{ id: "some-id-2", alias: { other: "some-alias" } },
+	]);
+
+	const byId = await project.db
+		.selectFrom("bundle")
+		.selectAll()
+		.where(bundleIdOrAliasIs("some-id"))
+		.execute();
+
+	expect(byId).toStrictEqual([
+		{ id: "some-id", alias: { mock: "some-alias" } },
+	]);
+});

--- a/inlang/source-code/sdk2/src/query-utilities/bundleIdOrAliasIs.ts
+++ b/inlang/source-code/sdk2/src/query-utilities/bundleIdOrAliasIs.ts
@@ -1,0 +1,33 @@
+/* eslint-disable unicorn/no-null */
+import { sql, type ExpressionBuilder } from "kysely";
+import type { InlangDatabaseSchema } from "../database/schema.js";
+
+/**
+ * Find a bundle by id or alias.
+ *
+ * @example
+ *   const bundle = await project.db
+ *     .selectFrom("bundle")
+ *     .where(bundleIdOrAliasIs("human_blue_moon"))
+ *     .execute();
+ *
+ *   const bundle = await selectBundleNested()
+ *     .where(bundleIdOrAliasIs("human_blue_moon"))
+ *     .execute();
+ */
+export function bundleIdOrAliasIs(idOrAlias: string) {
+	return (eb: ExpressionBuilder<InlangDatabaseSchema, "bundle">) =>
+		eb.or([
+			eb("bundle.id", "=", idOrAlias),
+			eb(
+				"bundle.id",
+				"in",
+				// @ts-expect-error - struggles with raw sql
+				sql`(
+					SELECT bundle.id
+					FROM bundle, json_each(bundle.alias)
+					WHERE json_each.value = ${idOrAlias}
+				)`
+			),
+		]);
+}


### PR DESCRIPTION
Closes https://github.com/opral/inlang-sdk/issues/192. Apps can now query by bundle id or alias. 

### Examples


```ts
const bundles = await project.db
  .selectFrom("bundle")
  .selectAll()
  .where(bundleIdOrAliasIs("some-id-or-alias"))
  .execute();
```

combining with other query utilities is possible 

```ts
const bundles = selectBundleNested(project.db)
  .where(bundleIdOrAliasIs("some-id-or-alias"))
  .execute();

```

### Additional information 

The power of exposing query utilities is wild. Mix & match whatever you want. 