### PR TITLE
use uuid 7 also when creating a new variant

### DIFF
--- a/inlang/source-code/sdk2/src/helper.ts
+++ b/inlang/source-code/sdk2/src/helper.ts
@@ -1,11 +1,10 @@
-import { v4 as uuid } from "uuid";
+import { v7 as uuid } from "uuid";
 import type { ProjectSettings } from "./json-schema/settings.js";
 import { humanId } from "./human-id/human-id.js";
 import type {
 	Bundle,
 	NewBundleNested,
 	NewMessageNested,
-	NewVariant,
 	Variant,
 } from "./database/schema.js";
 import type { Expression, Text } from "./json-schema/pattern.js";


### PR DESCRIPTION
While uuid created on the db was changed to uuid v7 in #3118 
The uuid in create Variant was still using the uuid v3 - this pr fixes this
