### PR TITLE
follow up rename variable to reference

### DIFF
--- a/inlang/source-code/sdk2/src/json-schema/old-v1-message/fromMessageV1.ts
+++ b/inlang/source-code/sdk2/src/json-schema/old-v1-message/fromMessageV1.ts
@@ -39,7 +39,7 @@ export function fromMessageV1(
 			type: "expression",
 			annotation: undefined,
 			arg: {
-				type: "variable",
+				type: "variable-reference",
 				name: name,
 			},
 		}));
@@ -110,7 +110,7 @@ function fromPatternV1(pattern: PatternV1): Pattern {
 				return {
 					type: "expression",
 					arg: {
-						type: "variable",
+						type: "variable-reference",
 						name: element.name,
 					},
 				};

--- a/inlang/source-code/sdk2/src/json-schema/old-v1-message/toMessageV1.ts
+++ b/inlang/source-code/sdk2/src/json-schema/old-v1-message/toMessageV1.ts
@@ -85,7 +85,7 @@ function toV1Expression(expression: Expression): ExpressionV1 {
 			"Cannot convert an expression with an annotation to the v1 format"
 		);
 
-	if (expression.arg.type !== "variable") {
+	if (expression.arg.type !== "variable-reference") {
 		throw new Error("Can only convert variable references to the v1 format");
 	}
 

--- a/inlang/source-code/sdk2/src/json-schema/pattern.ts
+++ b/inlang/source-code/sdk2/src/json-schema/pattern.ts
@@ -2,7 +2,7 @@ import { Type, type Static } from "@sinclair/typebox";
 
 export type VariableReference = Static<typeof VariableReference>;
 export const VariableReference = Type.Object({
-	type: Type.Literal("variable"),
+	type: Type.Literal("variable-reference"),
 	name: Type.String(),
 });
 
@@ -20,7 +20,7 @@ export const Option = Type.Object({
 
 export type FunctionReference = Static<typeof FunctionReference>;
 export const FunctionReference = Type.Object({
-	type: Type.Literal("function"),
+	type: Type.Literal("function-reference"),
 	name: Type.String(),
 	options: Type.Array(Option),
 });

--- a/inlang/source-code/sdk2/src/mock/bundle.ts
+++ b/inlang/source-code/sdk2/src/mock/bundle.ts
@@ -31,11 +31,11 @@ export const pluralBundle: BundleNested = {
 				{
 					type: "expression",
 					arg: {
-						type: "variable",
+						type: "variable-reference",
 						name: "numProducts",
 					},
 					annotation: {
-						type: "function",
+						type: "function-reference",
 						name: "plural",
 						options: [],
 					},
@@ -72,7 +72,7 @@ export const pluralBundle: BundleNested = {
 						{
 							type: "expression",
 							arg: {
-								type: "variable",
+								type: "variable-reference",
 								name: "numProducts",
 							},
 						},
@@ -98,11 +98,11 @@ export const pluralBundle: BundleNested = {
 				{
 					type: "expression",
 					arg: {
-						type: "variable",
+						type: "variable-reference",
 						name: "numProducts",
 					},
 					annotation: {
-						type: "function",
+						type: "function-reference",
 						name: "plural",
 						options: [],
 					},
@@ -139,7 +139,7 @@ export const pluralBundle: BundleNested = {
 						{
 							type: "expression",
 							arg: {
-								type: "variable",
+								type: "variable-reference",
 								name: "numProducts",
 							},
 						},


### PR DESCRIPTION
follow up of #3125 which is a nice to have and could be merged but it's not crucial: 

- change `type: variable` to `type:variable-reference` to align with naming and avoid confusions like https://github.com/opral/monorepo/pull/3125/files#r1761844043 
- change `type: function` to `type: function-refernece` to align with naming of the TS type and avoid confusions 