### PR TITLE
follow up: explicit variable types

### DIFF
--- a/inlang/source-code/sdk2/src/json-schema/old-v1-message/fromMessageV1.ts
+++ b/inlang/source-code/sdk2/src/json-schema/old-v1-message/fromMessageV1.ts
@@ -67,7 +67,7 @@ export function fromMessageV1(
 
 		//Create an input declaration for each variable and selector we need
 		const declarations: Declaration[] = [...variableNames].map((name) => ({
-			type: "input",
+			type: "input-variable",
 			name,
 			value: {
 				type: "expression",

--- a/inlang/source-code/sdk2/src/json-schema/pattern.ts
+++ b/inlang/source-code/sdk2/src/json-schema/pattern.ts
@@ -38,9 +38,9 @@ export const Text = Type.Object({
 	value: Type.String(),
 });
 
-export type Input = Static<typeof Input>;
-export const Input = Type.Object({
-	type: Type.Literal("input"),
+export type InputVariable = Static<typeof InputVariable>;
+export const InputVariable = Type.Object({
+	type: Type.Literal("input-variable"),
 	name: Type.String(),
 	// future
 	// registryType: Type.String(),
@@ -48,13 +48,13 @@ export const Input = Type.Object({
 
 export type LocalVariable = Static<typeof LocalVariable>;
 export const LocalVariable = Type.Object({
-	type: Type.Literal("local"),
+	type: Type.Literal("local-variable"),
 	name: Type.String(),
 	value: Expression,
 });
 
 export type Declaration = Static<typeof Declaration>;
-export const Declaration = Type.Union([Input, LocalVariable]);
+export const Declaration = Type.Union([InputVariable, LocalVariable]);
 
 export type Pattern = Static<typeof Pattern>;
 export const Pattern = Type.Array(Type.Union([Text, Expression]));

--- a/inlang/source-code/sdk2/src/mock/bundle.ts
+++ b/inlang/source-code/sdk2/src/mock/bundle.ts
@@ -15,15 +15,15 @@ export const pluralBundle: BundleNested = {
 			locale: "de",
 			declarations: [
 				{
-					type: "input",
+					type: "input-variable",
 					name: "numProducts",
 				},
 				{
-					type: "input",
+					type: "input-variable",
 					name: "count",
 				},
 				{
-					type: "input",
+					type: "input-variable",
 					name: "projectCount",
 				},
 			],
@@ -90,7 +90,7 @@ export const pluralBundle: BundleNested = {
 			locale: "en",
 			declarations: [
 				{
-					type: "input",
+					type: "input-variable",
 					name: "numProducts",
 				},
 			],


### PR DESCRIPTION
Follow up of #3125 that can be accepted or rejected independently. This is a nice feature that will lead to minimal breaking code in dependents of the sdk2. 

**Changes**

- explicit `input variable` and `local variable` to align the concept of "a message can reference (local|input|global) variables"

