### PR TITLE
Update-bundle-component

### DIFF
--- a/inlang/source-code/bundle-component/package.json
+++ b/inlang/source-code/bundle-component/package.json
@@ -34,7 +34,6 @@
 		"@types/chroma-js": "^2.4.4",
 		"@vitest/coverage-v8": "^0.33.0",
 		"lit": "^3.1.2",
-		"npm": "^10.8.3",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"rollup": "3.29.1",

--- a/inlang/source-code/bundle-component/src/helper/patternToString.test.ts
+++ b/inlang/source-code/bundle-component/src/helper/patternToString.test.ts
@@ -12,7 +12,7 @@ describe("patternToString", () => {
 			{
 				type: "expression",
 				arg: {
-					type: "variable",
+					type: "variable-reference",
 					name: "name",
 				},
 			},

--- a/inlang/source-code/bundle-component/src/helper/stringToPattern.test.ts
+++ b/inlang/source-code/bundle-component/src/helper/stringToPattern.test.ts
@@ -16,7 +16,7 @@ describe("stringToPattern", () => {
 			{
 				type: "expression",
 				arg: {
-					type: "variable",
+					type: "variable-reference",
 					name: "name",
 				},
 			},

--- a/inlang/source-code/bundle-component/src/helper/stringToPattern.ts
+++ b/inlang/source-code/bundle-component/src/helper/stringToPattern.ts
@@ -30,7 +30,7 @@ const stringToPattern = (props: { text: string }): Pattern => {
 			pattern.push({
 				type: "expression",
 				arg: {
-					type: "variable",
+					type: "variable-reference",
 					name: match[1],
 				},
 			})

--- a/inlang/source-code/bundle-component/src/mock/messageBundle.ts
+++ b/inlang/source-code/bundle-component/src/mock/messageBundle.ts
@@ -1,40 +1,42 @@
-import type { BundleNested } from "@inlang/sdk2"
+import type { Bundle, Message, Variant } from "@inlang/sdk2"
 
-export const bundleWithoutSelectors: BundleNested = {
-	id: "message-bundle-id",
+export const exampleWithoutSelectors: {
+	bundles: Bundle[]
+	messages: Message[]
+	variants: Variant[]
+} = {
+	bundles: [
+		{
+			id: "message-bundle-id",
+			declarations: [],
+		},
+	],
 	messages: [
 		{
 			bundleId: "message-bundle-id",
 			id: "message-id-en",
 			locale: "en",
 			selectors: [],
-			declarations: [],
-			variants: [
-				{
-					messageId: "message-id-en",
-					id: "variant-id-en-*",
-					match: {},
-					pattern: [{ type: "text", value: "{count} new messages" }],
-				},
-			],
 		},
 		{
 			bundleId: "message-bundle-id",
 			id: "message-id-de",
 			locale: "de",
 			selectors: [],
-			declarations: [],
-			variants: [
-				{
-					messageId: "message-id-de",
-					id: "variant-id-de-*",
-					match: {},
-					pattern: [{ type: "text", value: "{count} neue Nachrichten" }],
-				},
-			],
 		},
 	],
-	// 	default: "frontend_button_text",
-	// 	ios: "frontendButtonText",
-	// },
+	variants: [
+		{
+			messageId: "message-id-en",
+			id: "variant-id-en-*",
+			match: {},
+			pattern: [{ type: "text", value: "{count} new messages" }],
+		},
+		{
+			messageId: "message-id-de",
+			id: "variant-id-de-*",
+			match: {},
+			pattern: [{ type: "text", value: "{count} neue Nachrichten" }],
+		},
+	],
 }

--- a/inlang/source-code/bundle-component/src/mock/pluralBundle.ts
+++ b/inlang/source-code/bundle-component/src/mock/pluralBundle.ts
@@ -1,0 +1,149 @@
+import type { Bundle, Message, Variant } from "@inlang/sdk2"
+
+export const examplePlural: {
+	bundles: Bundle[]
+	messages: Message[]
+	variants: Variant[]
+} = {
+	bundles: [
+		{
+			id: "mock_bundle_human_id",
+			declarations: [
+				{
+					type: "input-variable",
+					name: "numProducts",
+				},
+				{
+					type: "input-variable",
+					name: "count",
+				},
+				{
+					type: "input-variable",
+					name: "projectCount",
+				},
+			],
+		},
+	],
+	messages: [
+		{
+			bundleId: "mock_bundle_human_id",
+			id: "mock_message_id_de",
+			locale: "de",
+			selectors: [
+				{
+					type: "expression",
+					arg: {
+						type: "variable-reference",
+						name: "numProducts",
+					},
+					annotation: {
+						type: "function-reference",
+						name: "plural",
+						options: [],
+					},
+				},
+			],
+		},
+		{
+			bundleId: "mock_bundle_human_id",
+			id: "mock_message_id_en",
+			locale: "en",
+			selectors: [
+				{
+					type: "expression",
+					arg: {
+						type: "variable-reference",
+						name: "numProducts",
+					},
+					annotation: {
+						type: "function-reference",
+						name: "plural",
+						options: [],
+					},
+				},
+			],
+		},
+	],
+	variants: [
+		{
+			messageId: "mock_message_id_de",
+			id: "mock_variant_id_de_zero",
+			match: { numProducts: "zero" },
+			pattern: [
+				{
+					type: "text",
+					value: "Keine Produkte",
+				},
+			],
+		},
+		{
+			messageId: "mock_message_id_de",
+			id: "mock_variant_id_de_one",
+			match: { numProducts: "one" },
+			pattern: [
+				{
+					type: "text",
+					value: "Ein Produkt",
+				},
+			],
+		},
+		{
+			messageId: "mock_message_id_de",
+			id: "mock_variant_id_de_other",
+			match: { numProducts: "other" },
+			pattern: [
+				{
+					type: "expression",
+					arg: {
+						type: "variable-reference",
+						name: "numProducts",
+					},
+				},
+				{
+					type: "text",
+					value: " Produkte",
+				},
+			],
+		},
+		{
+			messageId: "mock_message_id_en",
+			id: "mock_variant_id_en_zero",
+			match: { numProducts: "zero" },
+			pattern: [
+				{
+					type: "text",
+					value: "No Products",
+				},
+			],
+		},
+		{
+			messageId: "mock_message_id_en",
+			id: "mock_variant_id_en_one",
+			match: { numProducts: "one" },
+			pattern: [
+				{
+					type: "text",
+					value: "A product",
+				},
+			],
+		},
+		{
+			messageId: "mock_message_id_en",
+			id: "mock_variant_id_en_other",
+			match: { numProducts: "other" },
+			pattern: [
+				{
+					type: "expression",
+					arg: {
+						type: "variable-reference",
+						name: "numProducts",
+					},
+				},
+				{
+					type: "text",
+					value: " products",
+				},
+			],
+		},
+	],
+}

--- a/inlang/source-code/bundle-component/src/stories/actions/add-input/inlang-add-input.mdx
+++ b/inlang/source-code/bundle-component/src/stories/actions/add-input/inlang-add-input.mdx
@@ -11,7 +11,7 @@ The component is currently only used inside of the bundle. That means that it ca
 <Canvas of={InlangAddInput.Example} />
 
 #### Props:
-- `messages`: The messages as Message[] to get inputs
+- `bundle`: The bundle
 
 #### Event:
 - `change`: The component dispatches a change event that contains all necessary information.

--- a/inlang/source-code/bundle-component/src/stories/actions/add-input/inlang-add-input.stories.ts
+++ b/inlang/source-code/bundle-component/src/stories/actions/add-input/inlang-add-input.stories.ts
@@ -1,8 +1,8 @@
-import { pluralBundle } from "@inlang/sdk2"
 import "./inlang-add-input.ts"
 import "./../../inlang-bundle.ts"
 import type { Meta, StoryObj } from "@storybook/web-components"
 import { html } from "lit"
+import { examplePlural } from "../../../mock/pluralBundle.ts"
 
 const meta: Meta = {
 	component: "inlang-add-input",
@@ -22,7 +22,7 @@ export const Example: StoryObj = {
 				}
 			</style>
 			<div class="container">
-				<inlang-add-input messages=${pluralBundle.messages}>Press me</inlang-add-input>
+				<inlang-add-input bundle=${examplePlural.bundles[0]}>Press me</inlang-add-input>
 			</div>`
 	},
 }

--- a/inlang/source-code/bundle-component/src/stories/actions/add-input/inlang-add-input.ts
+++ b/inlang/source-code/bundle-component/src/stories/actions/add-input/inlang-add-input.ts
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from "lit"
 import { customElement, property, state } from "lit/decorators.js"
 import { createChangeEvent } from "../../../helper/event.js"
-import type { Message } from "@inlang/sdk2"
+import type { Bundle } from "@inlang/sdk2"
 import { baseStyling } from "../../../styling/base.js"
 
 import SlDropdown from "@shoelace-style/shoelace/dist/components/dropdown/dropdown.component.js"
@@ -69,8 +69,8 @@ export default class InlangAddInput extends LitElement {
 		`,
 	]
 
-	@property({ type: Array })
-	messages: Message[] | undefined
+	@property({ type: Object })
+	bundle: Bundle
 
 	//state
 	@state()
@@ -114,29 +114,22 @@ export default class InlangAddInput extends LitElement {
 							@keydown=${(e: KeyboardEvent) => {
 								if (e.key === "Enter") {
 									if (this._newInput && this._newInput.trim() !== "") {
-										for (const message of this.messages ?? []) {
-											const newMessage = structuredClone(message)
-
-											newMessage.declarations.push({
-												type: "input",
-												name: this._newInput!,
-												// value: {
-												// 	type: "expression",
-												// 	arg: {
-												// 		type: "variable",
-												// 		name: this._newInput!,
-												// 	},
-												// },
+										this.dispatchEvent(
+											createChangeEvent({
+												type: "Bundle",
+												operation: "update",
+												newData: {
+													...this.bundle,
+													declarations: [
+														...this.bundle.declarations,
+														{
+															name: this._newInput,
+															type: "input-variable",
+														},
+													],
+												},
 											})
-
-											this.dispatchEvent(
-												createChangeEvent({
-													type: "Message",
-													operation: "update",
-													newData: newMessage,
-												})
-											)
-										}
+										)
 									}
 
 									this._newInput = ""

--- a/inlang/source-code/bundle-component/src/stories/actions/add-selector/inlang-add-selector.ts
+++ b/inlang/source-code/bundle-component/src/stories/actions/add-selector/inlang-add-selector.ts
@@ -3,10 +3,11 @@ import { customElement, property, state } from "lit/decorators.js"
 import { createChangeEvent } from "../../../helper/event.js"
 import { baseStyling } from "../../../styling/base.js"
 import {
-	createVariant,
 	type Message,
-	type MessageNested,
 	type Expression,
+	type Bundle,
+	type Variant,
+	uuidv4,
 	Declaration,
 } from "@inlang/sdk2"
 
@@ -161,10 +162,13 @@ export default class InlangAddSelector extends LitElement {
 	]
 
 	@property()
-	message?: MessageNested | undefined
+	bundle: Bundle
 
 	@property()
-	messages?: MessageNested | undefined
+	message: Message
+
+	@property()
+	variants: Variant[]
 
 	@state()
 	private _input: string | undefined
@@ -189,15 +193,16 @@ export default class InlangAddSelector extends LitElement {
 
 	private _getInputs = () => {
 		const inputs: Declaration[] = []
-		if (this.messages) {
-			for (const message of this.messages as unknown as Message[]) {
-				for (const declaration of message.declarations) {
-					if (declaration.type === "input" && !inputs.some((d) => d.name === declaration.name)) {
-						inputs.push(declaration)
-					}
-				}
+
+		for (const declaration of this.bundle.declarations) {
+			if (
+				declaration.type === "input-variable" &&
+				!inputs.some((d) => d.name === declaration.name)
+			) {
+				inputs.push(declaration)
 			}
 		}
+
 		return inputs
 	}
 
@@ -212,7 +217,7 @@ export default class InlangAddSelector extends LitElement {
 		if (this._input && this.message) {
 			// get variant matcher
 			const message = structuredClone(this.message)
-			const _variantsMatcher = (message ? message.variants : []).map((variant) => variant.match)
+			const _variantsMatcher = (message ? this.variants : []).map((variant) => variant.match)
 
 			// Step 1 | add selector to message
 			this._updateSelector()
@@ -234,30 +239,22 @@ export default class InlangAddSelector extends LitElement {
 
 	private _addInput = () => {
 		if (this._isNewInput && this._newInputSting && this._newInputSting.length > 0) {
-			for (const message of (this.messages as any as Message[]) || []) {
-				const newMessage = structuredClone(message)
-
-				newMessage.declarations.push({
-					type: "input",
-					name: this._newInputSting,
-					// value: {
-					// 	type: "expression",
-					// 	arg: {
-					// 		type: "variable",
-					// 		name: this._newInputSting,
-					// 	},
-					// },
+			this.dispatchEvent(
+				createChangeEvent({
+					type: "Bundle",
+					operation: "update",
+					newData: {
+						...this.bundle,
+						declarations: [
+							...this.bundle.declarations,
+							{
+								name: this._newInputSting,
+								type: "input-variable",
+							},
+						],
+					},
 				})
-
-				this.dispatchEvent(
-					createChangeEvent({
-						type: "Message",
-						operation: "update",
-						newData: newMessage,
-					})
-				)
-			}
-			this._input = this._newInputSting
+			)
 		}
 	}
 
@@ -266,11 +263,11 @@ export default class InlangAddSelector extends LitElement {
 			this.message.selectors.push({
 				type: "expression",
 				arg: {
-					type: "variable",
+					type: "variable-reference",
 					name: this._input,
 				},
 				annotation: {
-					type: "function",
+					type: "function-reference",
 					name: this._function || "plural",
 					options: [],
 				},
@@ -287,7 +284,7 @@ export default class InlangAddSelector extends LitElement {
 
 	private _addMatchToExistingVariants = () => {
 		if (this.message && this._input) {
-			for (const variant of this.message.variants) {
+			for (const variant of this.variants) {
 				variant.match[this._input] = "*"
 
 				this.dispatchEvent(
@@ -301,14 +298,16 @@ export default class InlangAddSelector extends LitElement {
 		}
 	}
 
+	// TODO verify if this is needed from UX perspective.
 	private _addVariantsFromNewCombinations = (newCombinations: Array<Record<string, string>>) => {
 		if (this.message) {
 			for (const combination of newCombinations) {
-				const newVariant = createVariant({
+				const newVariant: Variant = {
+					id: uuidv4(),
+					pattern: [],
 					messageId: this.message.id,
 					match: combination,
-					text: "",
-				})
+				}
 
 				this.dispatchEvent(
 					createChangeEvent({

--- a/inlang/source-code/bundle-component/src/stories/inlang-bundle.mdx
+++ b/inlang/source-code/bundle-component/src/stories/inlang-bundle.mdx
@@ -23,7 +23,6 @@ The compoent allows the following:
 
 #### Props:
 - `bundle`: The bundle as Bundle (not BundleNested)
-- `messages`: The messages as Message[] (for input handling)
 
 #### Event:
 - `change`: The component dispatches a change event that contains the message information.

--- a/inlang/source-code/bundle-component/src/stories/message/inlang-message.mdx
+++ b/inlang/source-code/bundle-component/src/stories/message/inlang-message.mdx
@@ -18,7 +18,8 @@ The compoent allows the following:
 <Canvas of={InlangMessage.Example} />
 
 #### Props:
-- `message`: The message as MessageNested (might change to Message type in the future)
+- `message`: The message
+- `variants`: The variants of the message
 
 #### Event:
 - `change`: The component dispatches a change event that contains the message information.

--- a/inlang/source-code/bundle-component/src/stories/message/inlang-message.stories.ts
+++ b/inlang/source-code/bundle-component/src/stories/message/inlang-message.stories.ts
@@ -37,7 +37,6 @@ export const Example: StoryObj = {
 				case "Message":
 					if (!data.newData) break
 					newMessage["selectors"] = (data.newData as Message).selectors
-					newMessage["declarations"] = (data.newData as Message).declarations
 					break
 				case "Variant":
 					if (data.operation === "delete") {
@@ -84,7 +83,6 @@ export const MessageInBundle: StoryObj = {
 				case "Message":
 					if (!data.newData) break
 					newMessage["selectors"] = (data.newData as Message).selectors
-					newMessage["declarations"] = (data.newData as Message).declarations
 					break
 				case "Variant":
 					if (data.operation === "delete") {

--- a/inlang/source-code/bundle-component/src/stories/message/inlang-message.ts
+++ b/inlang/source-code/bundle-component/src/stories/message/inlang-message.ts
@@ -1,4 +1,4 @@
-import type { MessageNested, ProjectSettings } from "@inlang/sdk2"
+import type { Message, ProjectSettings, Variant } from "@inlang/sdk2"
 import { createVariant } from "@inlang/sdk2"
 import { LitElement, css, html } from "lit"
 import { customElement, property } from "lit/decorators.js"
@@ -165,7 +165,10 @@ export default class InlangMessage extends LitElement {
 	]
 
 	@property()
-	message: MessageNested | undefined
+	message: Message
+
+	@property()
+	variants: Variant[]
 
 	@property({ type: Object })
 	settings: ProjectSettings | undefined
@@ -184,13 +187,11 @@ export default class InlangMessage extends LitElement {
 			</div>
 			<div class="message-body">
 				${(this.message && this.message.selectors.length > 0) ||
-				(this.message && this.message.variants.length > 1 && this.message.selectors.length === 0)
+				(this.message && this.variants.length > 1 && this.message.selectors.length === 0)
 					? html`<div
 							class=${`message-header` +
 							` ` +
-							(this.message.variants && this.message.variants.length === 0
-								? `no-bottom-border`
-								: ``)}
+							(this.variants && this.variants.length === 0 ? `no-bottom-border` : ``)}
 					  >
 							<div class="selector-container">
 								${this.message.selectors.map(
@@ -207,7 +208,7 @@ export default class InlangMessage extends LitElement {
 												@click=${() => {
 													if (this.message) {
 														// remove matches from underlying variants
-														for (const variant of this.message.variants) {
+														for (const variant of this.variants) {
 															const matchObj = Object.fromEntries(
 																Object.entries(variant.match).filter(
 																	([key]) => key !== selector.arg.name

--- a/inlang/source-code/bundle-component/tsconfig.json
+++ b/inlang/source-code/bundle-component/tsconfig.json
@@ -8,6 +8,8 @@
 		"moduleResolution": "Node16",
 		"declarationMap": true,
 		"experimentalDecorators": true,
+		// lit uses decorators. in order to avoid errors, we need to set this to true
+		"strictPropertyInitialization": false,
 		"useDefineForClassFields": false,
 		"types": [],
 		"outDir": "./dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,9 +212,6 @@ importers:
       lit:
         specifier: ^3.1.2
         version: 3.2.0
-      npm:
-        specifier: ^10.8.3
-        version: 10.8.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -13281,80 +13278,6 @@ packages:
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  npm@10.8.3:
-    resolution: {integrity: sha512-0IQlyAYvVtQ7uOhDFYZCGK8kkut2nh8cpAdA9E6FvRSJaTgtZRZgNjlC5ZCct//L73ygrpY93CxXpRJDtNqPVg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - cli-columns
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmhook
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - normalize-package-data
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
-      - write-file-atomic
 
   npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
@@ -30840,8 +30763,6 @@ snapshots:
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
-
-  npm@10.8.3: {}
 
   npmlog@5.0.1:
     dependencies:


### PR DESCRIPTION
Part of https://github.com/opral/monorepo/pull/3138

- Simplify change handling by not using bundle nested 
    - Side effect: enabled upcoming bundle deletion 
- Removes the need to pass bundle nested into bundle component
- Separates message nested in message component to message: Message and variants: Variants to get away from complicated nesting logic