### PR TITLE
refactor: simplify match type

### DIFF
--- a/inlang/source-code/bundle-component/src/mock/pluralBundle.ts
+++ b/inlang/source-code/bundle-component/src/mock/pluralBundle.ts
@@ -54,9 +54,9 @@ export const examplePlural: {
 			id: "mock_variant_id_de_zero",
 			matches: [
 				{
-					type: "match",
-					name: "numProducts",
-					value: { type: "literal", value: "zero" },
+					type: "literal-match",
+					key: "numProducts",
+					value: "zero",
 				},
 			],
 			pattern: [
@@ -71,9 +71,9 @@ export const examplePlural: {
 			id: "mock_variant_id_de_one",
 			matches: [
 				{
-					type: "match",
-					name: "numProducts",
-					value: { type: "literal", value: "one" },
+					type: "literal-match",
+					key: "numProducts",
+					value: "one",
 				},
 			],
 			pattern: [
@@ -88,9 +88,9 @@ export const examplePlural: {
 			id: "mock_variant_id_de_other",
 			matches: [
 				{
-					type: "match",
-					name: "numProducts",
-					value: { type: "literal", value: "other" },
+					type: "literal-match",
+					key: "numProducts",
+					value: "other",
 				},
 			],
 			pattern: [
@@ -112,9 +112,9 @@ export const examplePlural: {
 			id: "mock_variant_id_en_zero",
 			matches: [
 				{
-					type: "match",
-					name: "numProducts",
-					value: { type: "literal", value: "zero" },
+					type: "literal-match",
+					key: "numProducts",
+					value: "zero",
 				},
 			],
 			pattern: [
@@ -129,9 +129,9 @@ export const examplePlural: {
 			id: "mock_variant_id_en_one",
 			matches: [
 				{
-					type: "match",
-					name: "numProducts",
-					value: { type: "literal", value: "one" },
+					type: "literal-match",
+					key: "numProducts",
+					value: "one",
 				},
 			],
 			pattern: [
@@ -146,9 +146,9 @@ export const examplePlural: {
 			id: "mock_variant_id_en_other",
 			matches: [
 				{
-					type: "match",
-					name: "numProducts",
-					value: { type: "literal", value: "other" },
+					type: "literal-match",
+					key: "numProducts",
+					value: "other",
 				},
 			],
 			pattern: [

--- a/inlang/source-code/bundle-component/src/stories/message/inlang-message.ts
+++ b/inlang/source-code/bundle-component/src/stories/message/inlang-message.ts
@@ -214,7 +214,7 @@ export default class InlangMessage extends LitElement {
 																	newData: {
 																		...variant,
 																		matches: variant.matches.filter(
-																			(match) => match["name"] !== selector.name
+																			(match) => match["key"] !== selector.name
 																		),
 																	},
 																})
@@ -274,9 +274,8 @@ export default class InlangMessage extends LitElement {
 										messageId: this.message.id,
 										// combine the matches that are already present with the new category -> like a matrix
 										matches: this.message.selectors.map((selector) => ({
-											type: "match",
-											name: selector.name,
-											value: { type: "catch-all" },
+											type: "catchall-match",
+											key: selector.name,
 										})),
 										pattern: [],
 									}

--- a/inlang/source-code/fink2/demo/bundles.ts
+++ b/inlang/source-code/fink2/demo/bundles.ts
@@ -154,12 +154,9 @@ export const demoBundles: BundleNested[] = [
 						id: "1458e8e3-c2e2-409c-949c-b4b214f4d094",
 						matches: [
 							{
-								type: "match",
-								name: "numTodos",
-								value: {
-									type: "literal",
-									value: "one",
-								},
+								type: "literal-match",
+								key: "numTodos",
+								value: "one",
 							},
 						],
 						pattern: [
@@ -181,12 +178,9 @@ export const demoBundles: BundleNested[] = [
 						id: "f0890476-ef1d-460f-8b17-bff2613c3fcb",
 						matches: [
 							{
-								type: "match",
-								name: "numTodos",
-								value: {
-									type: "literal",
-									value: "other",
-								},
+								type: "literal-match",
+								key: "numTodos",
+								value: "other",
 							},
 						],
 						pattern: [
@@ -221,12 +215,9 @@ export const demoBundles: BundleNested[] = [
 						id: "fc8c80af-0e34-47bf-bf49-7540bfa67531",
 						matches: [
 							{
-								type: "match",
-								name: "numTodos",
-								value: {
-									type: "literal",
-									value: "one",
-								},
+								type: "literal-match",
+								key: "numTodos",
+								value: "one",
 							},
 						],
 						pattern: [
@@ -241,12 +232,9 @@ export const demoBundles: BundleNested[] = [
 						id: "a63a9762-a86d-4c50-9cef-2dd1e91da424",
 						matches: [
 							{
-								type: "match",
-								name: "numTodos",
-								value: {
-									type: "literal",
-									value: "other",
-								},
+								type: "literal-match",
+								key: "numTodos",
+								value: "other",
 							},
 						],
 						pattern: [

--- a/inlang/source-code/ide-extension/src/decorations/contextTooltip.ts
+++ b/inlang/source-code/ide-extension/src/decorations/contextTooltip.ts
@@ -65,7 +65,7 @@ export async function contextTooltip(
 			// Get the variant from the message
 			const variant = message?.variants.find((v) =>
 				v.matches.find(
-					(m) => m.name === "locale" && m.value.type === "literal" && m.value?.value === locale
+					(m) => m.type === "literal-match" && m.key === "locale" && m.value === locale
 				)
 			)
 

--- a/inlang/source-code/sdk2/src/database/schema.ts
+++ b/inlang/source-code/sdk2/src/database/schema.ts
@@ -2,7 +2,6 @@ import type { Generated, Insertable, Selectable, Updateable } from "kysely";
 import type { SqliteDatabase } from "sqlite-wasm-kysely";
 import {
 	Declaration,
-	Literal,
 	Pattern,
 	VariableReference,
 } from "../json-schema/pattern.js";
@@ -84,10 +83,16 @@ type VariantTable = {
  * @example
  *   match = { type: "match", name: "gender", value: { type: "literal", value: "male"  }}
  */
-export type Match = {
-	type: "match";
-	name: VariableReference["name"];
-	value: Literal | { type: "catch-all" };
+export type Match = LiteralMatch | CatchAllMatch;
+
+export type LiteralMatch = {
+	type: "literal-match";
+	key: VariableReference["name"];
+	value: string;
+};
+export type CatchAllMatch = {
+	type: "catchall-match";
+	key: VariableReference["name"];
 };
 
 export type Bundle = Selectable<BundleTable>;


### PR DESCRIPTION
Simplifies the match type

- key instead of name for increased generalizability and alignment with message format 2.0
- type literal-match | catchall-match to get rid of redundant match type
- gets rid of `match.value.value`

```ts
const variant = {
  matches: [
    { "key": "username", "type": "literal-match", "value": "samuel" },
    { "key": "platform", "type": "catchall-match" },
  ]
}
```