### PR TITLE
fix opral/inlang-paraglide-js#234: update LANG_COOKIE_NAME to follow rfc6265 standard

### DIFF
--- a/.changeset/new-news-count.md
+++ b/.changeset/new-news-count.md
@@ -1,0 +1,18 @@
+---
+"@inlang/paraglide-sveltekit": patch
+---
+
+Fixes https://github.com/opral/inlang-paraglide-js/issues/234. 
+
+Paraglide SvelteKit used the cookie name `paraglide:lang` which is
+not compliant with rfc6265 standards for cookie names. SvelteKit
+recently introduced strict cookie parsing which caused 
+`paraglide:lang` to be rejected. 
+
+The cookie name has been updated to `paraglide_lang` to be compliant.
+
+```diff
+-paraglide:lang
++paraglide_lang
+```
+

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/constants.js
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/constants.js
@@ -2,7 +2,7 @@
 export const NO_TRANSLATE_ATTRIBUTE = "data-no-translate"
 
 /** The key with which `invalidate` is called when the language changes */
-export const LANGUAGE_CHANGE_INVALIDATION_KEY = "paraglide:lang"
+export const LANGUAGE_CHANGE_INVALIDATION_KEY = "paraglide_lang"
 
 /** The name of the cookie in which the language is stored */
 export const LANG_COOKIE_NAME = "paraglide_lang"

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/constants.js
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/constants.js
@@ -5,4 +5,4 @@ export const NO_TRANSLATE_ATTRIBUTE = "data-no-translate"
 export const LANGUAGE_CHANGE_INVALIDATION_KEY = "paraglide:lang"
 
 /** The name of the cookie in which the language is stored */
-export const LANG_COOKIE_NAME = "paraglide:lang"
+export const LANG_COOKIE_NAME = "paraglide_lang"


### PR DESCRIPTION
As discussed in the issue, the cookie named "paraglide:lang" doesn't follow the rfc6265 standard.

And the latest version of SvelteKit [(2.6.2)](https://github.com/sveltejs/kit/blob/main/packages/kit/CHANGELOG.md#262) upgraded to the latest cookie package, which enforces that the cookies follows this standard.

This is very minor change, tested locally. It's also my first PR to an open source project, apologies if I'm not following all the good practices.