### PR TITLE
async calls to getLanguage to support nextjs 15

### DIFF
--- a/inlang/source-code/end-to-end-tests/paraglide-next/package.json
+++ b/inlang/source-code/end-to-end-tests/paraglide-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inlang/paraglide-next-e2e",
-	"version": "0.0.27",
+	"version": "0.0.28",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/inlang/source-code/paraglide/paraglide-next/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-next/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @inlang/paraglide-next
 
+## 0.7.0
+
+### Minor Changes
+
+- [BREAKING] Support for Next.js 15.
+
+  The `getLanguage()` function is now async on the server. Starting with latest RC of Next.js 15 (RC 2), the request APIs (including headers()) is async: nextjs.org/blog/next-15-rc2#async-request-apis-breaking-change.
+
+  PR https://github.com/opral/monorepo/pull/3188.
+
+  - stay on v0.6 for Next.js <15
+  - upgrade to v0.7 for Next.js >=15
+  - no major release to avoid releasing a 1.0 version
+
 ## 0.6.0
 
 ### Minor Changes

--- a/inlang/source-code/paraglide/paraglide-next/examples/app/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-next/examples/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @inlang/paraglide-next-example-app
 
+## 0.2.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @inlang/paraglide-next@0.7.0
+
 ## 0.2.28
 
 ### Patch Changes

--- a/inlang/source-code/paraglide/paraglide-next/examples/app/package.json
+++ b/inlang/source-code/paraglide/paraglide-next/examples/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inlang/paraglide-next-example-app",
-	"version": "0.2.28",
+	"version": "0.2.29",
 	"private": true,
 	"scripts": {
 		"_dev": "next dev",

--- a/inlang/source-code/paraglide/paraglide-next/examples/pages/CHANGELOG.md
+++ b/inlang/source-code/paraglide/paraglide-next/examples/pages/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @inlang/paraglide-next-example-pages
 
+## 0.2.31
+
+### Patch Changes
+
+- Updated dependencies
+  - @inlang/paraglide-next@0.7.0
+
 ## 0.2.30
 
 ### Patch Changes

--- a/inlang/source-code/paraglide/paraglide-next/examples/pages/package.json
+++ b/inlang/source-code/paraglide/paraglide-next/examples/pages/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inlang/paraglide-next-example-pages",
-	"version": "0.2.30",
+	"version": "0.2.31",
 	"private": true,
 	"sideEffects": false,
 	"scripts": {

--- a/inlang/source-code/paraglide/paraglide-next/package.json
+++ b/inlang/source-code/paraglide/paraglide-next/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@inlang/paraglide-next",
 	"description": "The easiest way to do i18n in NextJS",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/inlang/source-code/paraglide/paraglide-next/src/app/getLanguage.server.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/getLanguage.server.ts
@@ -9,9 +9,9 @@ import { PARAGLIDE_LANGUAGE_HEADER_NAME } from "./constants"
  * THIS WILL BECOME OBSOLETE ONCE WE FIGURE OUT HOW TO SET THE LANGUAGE BEFORE ANY NEXT CODE RUNS
  * Once that's the case we will be able to just use `languageTag()` instead
  */
-export function getLanguage<T extends string>(): T {
+export async function getLanguage<T extends string>(): Promise<T> {
 	try {
-		const langHeader = headers().get(PARAGLIDE_LANGUAGE_HEADER_NAME)
+		const langHeader = await headers().get(PARAGLIDE_LANGUAGE_HEADER_NAME)
 		const lang = isAvailableLanguageTag(langHeader) ? langHeader : sourceLanguageTag
 		return lang as T
 	} catch (e) {

--- a/inlang/source-code/paraglide/paraglide-next/src/app/initializeLanguage.server.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/initializeLanguage.server.ts
@@ -12,14 +12,14 @@ import { getLanguage } from "./getLanguage.server"
  * import { initializeLanguage } from "@inlang/paraglide-next"
  * import { languageTag } from "@/paraglide/runtime"
  *
- * initializeLanguage() //call it at the top of the file
+ * await initializeLanguage() //call it at the top of the file
  *
  * export function someAction() {
  *   languageTag() // "de"
  * }
  * ```
  */
-export function initializeLanguage() {
+export async function initializeLanguage() {
 	//for some reason we can't pass the function as a reference directly
-	setLanguageTag(() => getLanguage())
+	setLanguageTag(await getLanguage())
 }

--- a/inlang/source-code/paraglide/paraglide-next/src/app/legacy/createI18n.server.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/legacy/createI18n.server.ts
@@ -25,8 +25,8 @@ import { PrefixStrategy } from "../routing-strategy/strats/prefixStrategy"
  * @deprecated
  * Use `createMiddleware` and `createNavigation` instead
  */
-export function createI18n<T extends string = string>(userConfig: I18nUserConfig<T> = {}) {
-	setLanguageTag(getLanguage)
+export async function createI18n<T extends string = string>(userConfig: I18nUserConfig<T> = {}) {
+	setLanguageTag(await getLanguage())
 
 	const config: ResolvedI18nConfig<T> = {
 		exclude: createExclude(userConfig.exclude ?? []),
@@ -45,8 +45,8 @@ export function createI18n<T extends string = string>(userConfig: I18nUserConfig
 
 	return {
 		/** @deprecated - Use getLocalisedHref instead */
-		localizePath: (canonicalPath: `/${string}`, lang: T) => {
-			return strategy.getLocalisedUrl(canonicalPath, lang, getLanguage() !== lang).pathname
+		localizePath: async (canonicalPath: `/${string}`, lang: T) => {
+			return strategy.getLocalisedUrl(canonicalPath, lang, (await getLanguage()) !== lang).pathname
 		},
 		getLocalisedUrl: strategy.getLocalisedUrl,
 		middleware,

--- a/inlang/source-code/paraglide/paraglide-next/src/app/providers/LanguageProvider.tsx
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/providers/LanguageProvider.tsx
@@ -4,11 +4,15 @@ import { ClientLanguageProvider } from "./ClientLanguageProvider"
 import { getLanguage } from "../getLanguage.server"
 
 // avoid flash of wrong language on startup
-setLanguageTag(getLanguage)
+;(async () => {
+	setLanguageTag(await getLanguage())
+})()
 
 //If we can reliably call setLanguageTag() from middleware.tsx, we can probably get rid of this component
-export default function LanguageProvider(props: { children: React.ReactNode }): React.ReactElement {
-	setLanguageTag(getLanguage)
+export default async function LanguageProvider(props: {
+	children: React.ReactNode
+}): Promise<React.ReactElement> {
+	setLanguageTag(await getLanguage())
 
 	//we make the client side language provider a sibling of the children
 	//That way the entire app isn't turned into a client component


### PR DESCRIPTION
Relates to issue: https://github.com/opral/inlang-paraglide-js/issues/245

Starting with latest RC of Next.js 15 (RC 2), the request APIs (including `headers()`) is async: [nextjs.org/blog/next-15-rc2#async-request-apis-breaking-change](https://nextjs.org/blog/next-15-rc2#async-request-apis-breaking-change).

This change breaks the `getLanguage()` function from `@inlang/paraglide-next`, (on the server):

[opral/monorepo@a0aaf62/inlang/source-code/paraglide/paraglide-next/src/app/getLanguage.server.ts#L14](https://github.com/opral/monorepo/blob/a0aaf620811b580e478a3d4add22e4c5475cbcc3/inlang/source-code/paraglide/paraglide-next/src/app/getLanguage.server.ts#L14)

This PR updates the `getLanguage()` function (every function that uses it) to be async.


**Note**: I was not actually able to test this locally in-repo, as I don't have Doppler access and couldn't get the local env running fully. However I did run unit tests and build, both of which appeared to be passing.