### PR TITLE
Lixdk-158-introduce-change-tags-to-filter-history-and-replace-the

### DIFF
--- a/packages/lix-sdk/docs/20-concepts/40-tag.md
+++ b/packages/lix-sdk/docs/20-concepts/40-tag.md
@@ -1,0 +1,14 @@
+# Tag
+
+## Purpose 
+
+Categorize and organize data in a way that is meaningful to the user.
+
+## Description 
+
+A tag is a label that can be applied to a change set. Tags can be used to categorize change sets, filter change sets, and search for change sets.
+
+## Examples
+
+- Tag a change set as confirmed e.g. the changes in the set should not be changed anymore.
+

--- a/packages/lix-sdk/src/database/applySchema.ts
+++ b/packages/lix-sdk/src/database/applySchema.ts
@@ -97,6 +97,16 @@ export async function applySchema(args: { sqlite: SqliteDatabase }) {
     FOREIGN KEY(change_id) REFERENCES change(id)
   ) strict;
 
+  -- tags on change sets
+  CREATE TABLE IF NOT EXISTS change_set_tag (
+    change_set_id TEXT NOT NULL,
+    tag_id TEXT NOT NULL,
+
+    UNIQUE(change_set_id, tag_id),
+    FOREIGN KEY(change_set_id) REFERENCES change_set(id),
+    FOREIGN KEY(tag_id) REFERENCES tag(id)
+  ) strict;
+
 
   -- discussions 
 
@@ -117,5 +127,13 @@ export async function applySchema(args: { sqlite: SqliteDatabase }) {
     FOREIGN KEY(discussion_id) REFERENCES discussion(id)
   ) strict;
 
+  -- tags 
+  
+  CREATE TABLE IF NOT EXISTS tag (
+    id TEXT PRIMARY KEY DEFAULT (uuid_v4()),
+    name TEXT NOT NULL UNIQUE  -- e.g., 'confirmed', 'reviewed'
+  ) strict;
+
+  INSERT OR IGNORE INTO tag (name) VALUES ('confirmed');
 `;
 }

--- a/packages/lix-sdk/src/database/initDb.test.ts
+++ b/packages/lix-sdk/src/database/initDb.test.ts
@@ -197,3 +197,21 @@ test("creating multiple discussions for one change set should be possible", asyn
 
 	expect(discussions).toHaveLength(2);
 });
+
+
+test("the confirmed tag should be created if it doesn't exist", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+	const db = initDb({ sqlite });
+
+	const tag = await db
+		.selectFrom("tag")
+		.selectAll()
+		.where("name", "=", "confirmed")
+		.executeTakeFirst();
+
+	expect(tag).toMatchObject({
+		name: "confirmed",
+	});
+});

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -9,10 +9,12 @@ export type LixDatabaseSchema = {
 	change_graph_edge: ChangeGraphEdgeTable;
 	conflict: ConflictTable;
 	snapshot: SnapshotTable;
+	tag: TagTable;
 
 	// change set
 	change_set: ChangeSetTable;
-	change_set_item: ChangeSetItem;
+	change_set_item: ChangeSetItemTable;
+	change_set_tag: ChangeSetTagTable;
 
 	// discussion
 	discussion: DiscussionTable;
@@ -155,4 +157,22 @@ type CommentTable = {
 	discussion_id: string;
 	created_at: Generated<string>;
 	body: string;
+};
+
+// ----- tags -----
+
+export type Tag = Selectable<TagTable>;
+export type NewTag = Insertable<TagTable>;
+export type TagUpdate = Updateable<TagTable>;
+type TagTable = {
+	id: Generated<string>;
+	name: string;
+};
+
+export type ChangeSetTag = Selectable<ChangeSetTagTable>;
+export type NewChangeSetTag = Insertable<ChangeSetTagTable>;
+export type ChangeSetTagUpdate = Updateable<ChangeSetTagTable>;
+type ChangeSetTagTable = {
+	change_set_id: string;
+	tag_id: string;
 };


### PR DESCRIPTION
Closes https://github.com/opral/inlang-sdk/issues/191

**Changes**

- add tag, change_set_tag tables
- tags are implemented in a generalized way e.g. we can add  `change_tag`, `file_tag`, etc. tables at a later point if needed 