### PR TITLE
refactor: generalized discussions

### DIFF
--- a/packages/lix-sdk/src/database/applySchema.ts
+++ b/packages/lix-sdk/src/database/applySchema.ts
@@ -97,7 +97,6 @@ export async function applySchema(args: { sqlite: SqliteDatabase }) {
     FOREIGN KEY(change_id) REFERENCES change(id)
   ) strict;
 
-  -- tags on change sets
   CREATE TABLE IF NOT EXISTS change_set_tag (
     change_set_id TEXT NOT NULL,
     tag_id TEXT NOT NULL,
@@ -107,14 +106,19 @@ export async function applySchema(args: { sqlite: SqliteDatabase }) {
     FOREIGN KEY(tag_id) REFERENCES tag(id)
   ) strict;
 
+  CREATE TABLE IF NOT EXISTS change_set_discussion (
+    change_set_id TEXT NOT NULL,
+    discussion_id TEXT NOT NULL,
+
+    UNIQUE(change_set_id, discussion_id),
+    FOREIGN KEY(change_set_id) REFERENCES change_set(id),
+    FOREIGN KEY(discussion_id) REFERENCES discussion(id)
+  ) strict;
 
   -- discussions 
 
   CREATE TABLE IF NOT EXISTS discussion (
-    id TEXT PRIMARY KEY DEFAULT (uuid_v4()),
-    change_set_id TEXT NOT NULL,
-
-    FOREIGN KEY(change_set_id) REFERENCES change_set(id)
+    id TEXT PRIMARY KEY DEFAULT (uuid_v4())
   ) strict;
 
   CREATE TABLE IF NOT EXISTS comment (

--- a/packages/lix-sdk/src/database/initDb.test.ts
+++ b/packages/lix-sdk/src/database/initDb.test.ts
@@ -176,21 +176,20 @@ test("creating multiple discussions for one change set should be possible", asyn
 
 	await db
 		.insertInto("discussion")
-		.values([
-			{
-				id: "discussion-1",
-				change_set_id: changeSet.id,
-			},
-			{
-				id: "discussion-2",
-				change_set_id: changeSet.id,
-			},
-		])
+		.values([{ id: "discussion-1" }, { id: "discussion-2" }])
 		.returningAll()
 		.execute();
 
+	await db
+		.insertInto("change_set_discussion")
+		.values([
+			{ change_set_id: changeSet.id, discussion_id: "discussion-1" },
+			{ change_set_id: changeSet.id, discussion_id: "discussion-2" },
+		])
+		.execute();
+
 	const discussions = await db
-		.selectFrom("discussion")
+		.selectFrom("change_set_discussion")
 		.selectAll()
 		.where("change_set_id", "=", changeSet.id)
 		.execute();

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -15,6 +15,7 @@ export type LixDatabaseSchema = {
 	change_set: ChangeSetTable;
 	change_set_item: ChangeSetItemTable;
 	change_set_tag: ChangeSetTagTable;
+	change_set_discussion: ChangeSetDiscussionTable;
 
 	// discussion
 	discussion: DiscussionTable;
@@ -145,7 +146,6 @@ export type NewDiscussion = Insertable<DiscussionTable>;
 export type DiscussionUpdate = Updateable<DiscussionTable>;
 type DiscussionTable = {
 	id: Generated<string>;
-	change_set_id: string;
 };
 
 export type Comment = Selectable<CommentTable>;
@@ -157,6 +157,14 @@ type CommentTable = {
 	discussion_id: string;
 	created_at: Generated<string>;
 	body: string;
+};
+
+export type ChangeSetDiscussion = Selectable<ChangeSetDiscussionTable>;
+export type NewChangeSetDiscussion = Insertable<ChangeSetDiscussionTable>;
+export type ChangeSetDiscussionUpdate = Updateable<ChangeSetDiscussionTable>;
+type ChangeSetDiscussionTable = {
+	change_set_id: string;
+	discussion_id: string;
 };
 
 // ----- tags -----

--- a/packages/lix-sdk/src/discussion/create-discussion.test.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.test.ts
@@ -48,7 +48,7 @@ test("should be able to start a discussion on changes", async () => {
 	});
 
 	const discussions = await lix.db
-		.selectFrom("discussion")
+		.selectFrom("change_set_discussion")
 		.selectAll()
 		.execute();
 
@@ -57,7 +57,7 @@ test("should be able to start a discussion on changes", async () => {
 	const comments = await lix.db
 		.selectFrom("comment")
 		.selectAll()
-		.where("discussion_id", "=", discussions[0]!.id)
+		.where("discussion_id", "=", discussions[0]!.discussion_id)
 		.execute();
 
 	expect(comments).toHaveLength(1);

--- a/packages/lix-sdk/src/discussion/create-discussion.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.ts
@@ -21,11 +21,17 @@ export async function createDiscussion(args: {
 	return args.lix.db.transaction().execute(async (trx) => {
 		const discussion = await trx
 			.insertInto("discussion")
-			.values({
-				change_set_id: args.changeSet.id,
-			})
+			.defaultValues()
 			.returningAll()
 			.executeTakeFirstOrThrow();
+
+		await trx
+			.insertInto("change_set_discussion")
+			.values({
+				change_set_id: args.changeSet.id,
+				discussion_id: discussion.id,
+			})
+			.execute();
 
 		await trx
 			.insertInto("comment")


### PR DESCRIPTION
Follow up of https://github.com/opral/monorepo/pull/3189 with the insight of https://github.com/opral/monorepo/pull/3191. 

- general discussion table (as before 3189) 
- dedicated `change_set_discussion` table (like the mapping table before 3189) 

those two changes allow us to add `change_discussion` (discussing individual changes), `file_discussion` (discussing files), `*_discussion` as needed. 

