### PR TITLE
paraglide-sveltekit: update invalidation key in docs

### DIFF
--- a/inlang/source-code/paraglide/paraglide-sveltekit/docs/localised-routing.md
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/docs/localised-routing.md
@@ -178,16 +178,16 @@ Use this to create a language switcher.
 
 ## Re-Loading Language-Dependent data
 
-If you have a `load` function that returns data that depends on the language you can tell it to re-run on language changes by calling `depends("paraglide_lang")`.
+If you have a `load` function that returns data that depends on the language you can tell it to re-run on language changes by calling `depends("paraglide:lang")`.
 
 ```ts
 // src/routes/+page.server.js
 export async function load({ depends }) {
-  // Paraglide-SvelteKit automatically calls `invalidate("paraglide_lang")` whenever the langauge changes
+  // Paraglide-SvelteKit automatically calls `invalidate("paraglide:lang")` whenever the langauge changes
   // This tells SvelteKit to re-run this function whenever that happens
-  depends("paraglide_lang") 
+  depends("paraglide:lang") 
   return await myLanguageSpecificData();
 }
 ```
 
-Paraglide-SvelteKit automatically calls `invalidate("paraglide_lang")` when the language changes.
+Paraglide-SvelteKit automatically calls `invalidate("paraglide:lang")` when the language changes.


### PR DESCRIPTION
Invalidation key changes have been updated (again) in #3184, but docs still contain the old key. This commit updates docs to reflect the actual key value.

Reference: 559bc443e962b21497b7e0ee32931ad45719396d opral/inlang-paraglide-js#243