### PR TITLE
rename `glob` to `detectChangesGlob`

### DIFF
--- a/packages/lix-plugin-csv/src/index.ts
+++ b/packages/lix-plugin-csv/src/index.ts
@@ -5,7 +5,7 @@ import { detectChanges } from "./detectChanges.js";
 
 export const plugin: LixPlugin = {
 	key: "lix-plugin-csv",
-	glob: "*.csv",
+	detectChangesGlob: "*.csv",
 	detectChanges,
 	detectConflicts,
 	applyChanges,

--- a/packages/lix-plugin-csv/src/utilities/mockChanges.ts
+++ b/packages/lix-plugin-csv/src/utilities/mockChanges.ts
@@ -18,7 +18,7 @@ export async function mockChanges(args: {
 	const lix =
 		args.lix ??
 		(await openLixInMemory({
-			providePlugins: [{ key: "mock", detectChanges, glob: "*" }],
+			providePlugins: [{ key: "mock", detectChanges, detectChangesGlob: "*" }],
 		}));
 	for (const update of args.fileUpdates) {
 		try {

--- a/packages/lix-plugin-csv/src/utilities/mockConflicts.ts
+++ b/packages/lix-plugin-csv/src/utilities/mockConflicts.ts
@@ -29,7 +29,7 @@ export async function mockConflicts(args: {
 }) {
 	const { lix: commonLix } = await mockChanges({
 		lix: await openLixInMemory({
-			providePlugins: [{ key: "mock", detectChanges, glob: "*" }],
+			providePlugins: [{ key: "mock", detectChanges, detectChangesGlob: "*" }],
 		}),
 		file: { path: "mock", metadata: args.metadata },
 		fileUpdates: [args.common],
@@ -40,7 +40,7 @@ export async function mockConflicts(args: {
 	const { lix: sourceLix } = await mockChanges({
 		lix: await openLixInMemory({
 			blob: commonLixBlob,
-			providePlugins: [{ key: "mock", detectChanges, glob: "*" }],
+			providePlugins: [{ key: "mock", detectChanges, detectChangesGlob: "*" }],
 		}),
 		file: { path: "mock", metadata: args.metadata },
 		fileUpdates: [args.source],
@@ -49,7 +49,7 @@ export async function mockConflicts(args: {
 	const { lix: targetLix } = await mockChanges({
 		lix: await openLixInMemory({
 			blob: commonLixBlob,
-			providePlugins: [{ key: "mock", detectChanges, glob: "*" }],
+			providePlugins: [{ key: "mock", detectChanges, detectChangesGlob: "*" }],
 		}),
 		fileUpdates: [args.target],
 		file: { path: "mock", metadata: args.metadata },

--- a/packages/lix-sdk/src/change-queue.test.ts
+++ b/packages/lix-sdk/src/change-queue.test.ts
@@ -6,7 +6,7 @@ import type { DetectedChange, LixPlugin } from "./plugin.js";
 test("should use queue and settled correctly", async () => {
 	const mockPlugin: LixPlugin = {
 		key: "mock-plugin",
-		glob: "*",
+		detectChangesGlob: "*",
 		detectChanges: async ({ before, after }) => {
 			const textBefore = before
 				? new TextDecoder().decode(before?.data)
@@ -192,7 +192,7 @@ test("should use queue and settled correctly", async () => {
 test.todo("changes should contain the author", async () => {
 	const mockPlugin: LixPlugin = {
 		key: "mock-plugin",
-		glob: "*",
+		detectChangesGlob: "*",
 		detectChanges: vi.fn().mockResolvedValue([
 			{
 				type: "mock",

--- a/packages/lix-sdk/src/discussion/create-discussion.test.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.test.ts
@@ -7,7 +7,7 @@ import { createChangeSet } from "../change-set/create-change-set.js";
 
 const mockPlugin: LixPlugin = {
 	key: "mock-plugin",
-	glob: "*",
+	detectChangesGlob: "*",
 	detectChanges: async ({ after }) => {
 		return [
 			{

--- a/packages/lix-sdk/src/file-handlers.ts
+++ b/packages/lix-sdk/src/file-handlers.ts
@@ -25,7 +25,9 @@ export async function handleFileInsert(args: {
 
 	for (const plugin of args.plugins) {
 		// glob expressions are expressed relative without leading / but path has leading /
-		if (!minimatch(normalizePath(args.after.path), "/" + plugin.glob)) {
+		if (
+			!minimatch(normalizePath(args.after.path), "/" + plugin.detectChangesGlob)
+		) {
 			break;
 		}
 
@@ -93,7 +95,9 @@ export async function handleFileChange(args: {
 
 	for (const plugin of args.plugins) {
 		// glob expressions are expressed relative without leading / but path has leading /
-		if (!minimatch(normalizePath(args.after.path), "/" + plugin.glob)) {
+		if (
+			!minimatch(normalizePath(args.after.path), "/" + plugin.detectChangesGlob)
+		) {
 			break;
 		}
 		if (plugin.detectChanges === undefined) {

--- a/packages/lix-sdk/src/merge/merge.test.ts
+++ b/packages/lix-sdk/src/merge/merge.test.ts
@@ -286,7 +286,7 @@ test("diffing should not be invoked to prevent the generation of duplicate chang
 
 	const mockPluginInTargetLix: LixPlugin = {
 		key: "mock-plugin",
-		glob: "*",
+		detectChangesGlob: "*",
 		detectChanges: vi.fn().mockResolvedValue([]),
 		detectConflicts: vi.fn().mockResolvedValue([]),
 		applyChanges: vi.fn().mockResolvedValue({ fileData: new Uint8Array() }),
@@ -635,7 +635,7 @@ test("it should naively copy changes from the sourceLix into the targetLix that 
 test("it should copy discussion and related comments and mappings", async () => {
 	const mockPlugin: LixPlugin = {
 		key: "mock-plugin",
-		glob: "*",
+		detectChangesGlob: "*",
 		detectChanges: async ({ after }) => {
 			return [
 				{

--- a/packages/lix-sdk/src/mock/mock-csv-plugin.ts
+++ b/packages/lix-sdk/src/mock/mock-csv-plugin.ts
@@ -9,7 +9,6 @@ type Cell = { rowIndex: number; columnIndex: number; text: string };
  */
 export const mockCsvPlugin: LixPlugin = {
 	key: "csv",
-	glob: "*.csv",
 	applyChanges: async ({ file, changes }) => {
 		const parsed = papaparse.parse(new TextDecoder().decode(file.data));
 		for (const change of changes) {
@@ -51,6 +50,7 @@ export const mockCsvPlugin: LixPlugin = {
 			fileData: new TextEncoder().encode(csv),
 		};
 	},
+	detectChangesGlob: "*.csv",
 	detectChanges: async ({ before, after }) => {
 		const result: DetectedChange[] = [];
 		const beforeParsed = before

--- a/packages/lix-sdk/src/open/openLix.test.ts
+++ b/packages/lix-sdk/src/open/openLix.test.ts
@@ -6,7 +6,6 @@ import type { LixPlugin } from "../plugin.js";
 test("providing plugins should be possible", async () => {
 	const mockPlugin: LixPlugin = {
 		key: "mock-plugin",
-		glob: "*",
 	};
 	const lix = await openLixInMemory({
 		blob: await newLixFile(),

--- a/packages/lix-sdk/src/plugin.ts
+++ b/packages/lix-sdk/src/plugin.ts
@@ -10,7 +10,6 @@ import type { LixReadonly } from "./types.js";
 // named lixplugin to avoid conflict with built-in plugin type
 export type LixPlugin = {
 	key: string;
-	glob?: string;
 	// TODO https://github.com/opral/lix-sdk/issues/37
 	// idea:
 	//   1. runtime reflection for lix on the change schema
@@ -20,6 +19,14 @@ export type LixPlugin = {
 	// 	message: Message,
 	// 	variant: Variant,
 	// },
+	/**
+	 * The glob pattern that should invoke `detectChanges()`.
+	 *
+	 * @example
+	 *   `**\/*.json` for all JSON files
+	 *   `**\/*.inlang` for all inlang files
+	 */
+	detectChangesGlob?: string;
 	/**
 	 * Detects changes between the `before` and `after` file update(s).
 	 *


### PR DESCRIPTION
- de-couple plugins from only dealing with files (we will likely introduce more APIs in the future)

- explicit "detect changes is invoked via the `detectChangesGlob`

Closes https://github.com/opral/lix-sdk/issues/100