### PR TITLE
Allow for next.config.ts in paraglide cli init command

### DIFF
--- a/.changeset/curly-ladybugs-happen.md
+++ b/.changeset/curly-ladybugs-happen.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-next": patch
+---
+
+allow for next.config.ts in paraglide cli init command https://github.com/opral/monorepo/pull/3199

--- a/inlang/source-code/paraglide/paraglide-next/src/cli/flows/scan-next-project/index.ts
+++ b/inlang/source-code/paraglide/paraglide-next/src/cli/flows/scan-next-project/index.ts
@@ -99,13 +99,13 @@ export const scanNextJSProject: CliStep<
 }
 
 /**
- * Attempts to find the next.config.js or next.config.mjs file in the current working directory.
+ * Attempts to find the next.config.js, next.config.mjs or next.config.ts file in the current working directory.
  */
 async function findNextConfig(
 	fs: NodeishFilesystem,
 	cwd: string
 ): Promise<NextConfigFile | undefined> {
-	const possibleNextConfigPaths = ["./next.config.js", "./next.config.mjs"].map(
+	const possibleNextConfigPaths = ["./next.config.js", "./next.config.mjs", "./next.config.ts"].map(
 		(possibleRelativePath) => path.resolve(cwd, possibleRelativePath)
 	)
 
@@ -113,7 +113,7 @@ async function findNextConfig(
 		if (await fileExists(fs, possibleNextConfigPath)) {
 			return {
 				path: possibleNextConfigPath,
-				type: possibleNextConfigPath.endsWith(".mjs") ? "esm" : "cjs",
+				type: possibleNextConfigPath.endsWith(".js") ? "cjs" : "esm",
 			}
 		}
 	}


### PR DESCRIPTION
Really silly PR but I think its important taking into account that NextJS 15 init will now by default create `next.config.ts` files.

`inlang/source-code/paraglide/paraglide-next/src/cli/flows/addPluginToNextConfig.ts` doesn't need to be modified as it relies purely on regex to modify the NextJs config.

Couldn't test as I can't seem to get a build going on my Ubuntu machine.

Apologies in advance for possibly missing any procedures in my contribution but I couldn't find any guides or references to do so for this repo.