### PR TITLE
add change graph

### DIFF
--- a/packages/csv-app/package.json
+++ b/packages/csv-app/package.json
@@ -12,9 +12,11 @@
 		"generate": "node ./scripts/generateDemoData.js"
 	},
 	"dependencies": {
+		"@dagrejs/dagre": "^1.1.4",
 		"@lix-js/plugin-csv": "workspace:*",
 		"@lix-js/sdk": "workspace:*",
 		"@shoelace-style/shoelace": "^2.17.1",
+		"@xyflow/react": "^12.3.4",
 		"clsx": "^2.1.1",
 		"human-id": "^4.1.1",
 		"jotai": "^2.10.1",

--- a/packages/csv-app/src/components/ChangeGraph.tsx
+++ b/packages/csv-app/src/components/ChangeGraph.tsx
@@ -1,0 +1,123 @@
+import {
+	ReactFlow,
+	Node,
+	Edge,
+	MiniMap,
+	NodeProps,
+	Handle,
+	Position,
+	MarkerType,
+} from "@xyflow/react";
+import dagre from "@dagrejs/dagre";
+import "@xyflow/react/dist/style.css";
+import { useMemo } from "react";
+import { Change, ChangeGraphEdge, Snapshot } from "@lix-js/sdk";
+
+const nodeWidth = 172;
+const nodeHeight = 36;
+
+export const ChangeGraph = (props: {
+	changes: Array<Change & { snapshot_content: Snapshot["content"] }>;
+	edges: ChangeGraphEdge[];
+}) => {
+	const dagreGraph = useMemo(
+		() => new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({})),
+		[]
+	);
+	const { nodes, edges } = layoutElements(
+		dagreGraph,
+		props.changes,
+		props.edges
+	);
+	return (
+		<ReactFlow
+			nodes={nodes}
+			edges={edges}
+			nodesConnectable={false}
+			fitView
+			nodeTypes={{ row: Row }}
+		>
+			<MiniMap></MiniMap>
+		</ReactFlow>
+	);
+};
+
+/**
+ * Layouting is required to calculate the position of the nodes and edges.
+ */
+const layoutElements = (
+	dagreGraph: dagre.graphlib.Graph,
+	changes: Array<Change & { snapshot_content: Snapshot["content"] }>,
+	edges: ChangeGraphEdge[],
+	direction: "TB" | "LR" = "TB"
+) => {
+	dagreGraph.setGraph({ rankdir: direction });
+
+	for (const change of changes) {
+		const dimensions = calculateNodeDimensions(change.snapshot_content!.text);
+		dagreGraph.setNode(change.id, dimensions);
+	}
+	for (const edge of edges) {
+		dagreGraph.setEdge(edge.child_id, edge.parent_id);
+	}
+
+	dagre.layout(dagreGraph);
+
+	// need to map to node and edge type for the react flow component
+	const nodesMappedToFlow = changes.map((change) => {
+		const text = change.snapshot_content!.text;
+		const nodeWithPosition = dagreGraph.node(change.id);
+		return {
+			id: change.id,
+			data: { text },
+			type: "row",
+			position: {
+				x: nodeWithPosition.x - nodeWidth / 2,
+				y: nodeWithPosition.y - nodeHeight / 2,
+			},
+			style: {
+				width: nodeWithPosition.width,
+				height: nodeWithPosition.height,
+			},
+		} satisfies Node;
+	});
+
+	const edgesMappedToFlow = edges.map((edge) => {
+		return {
+			id: `${edge.parent_id}-${edge.child_id}`,
+			source: edge.child_id,
+			target: edge.parent_id,
+			markerEnd: {
+				type: MarkerType.ArrowClosed,
+			},
+		} satisfies Edge;
+	});
+
+	return { nodes: nodesMappedToFlow, edges: edgesMappedToFlow };
+};
+
+const calculateNodeDimensions = (text: string) => {
+	const nodePadding = 20;
+	const lines = text.split("\n");
+	const width = Math.max(...lines.map((line) => line.length)) * 9 + nodePadding;
+	const height = lines.length * 20 + nodePadding;
+	return { width, height };
+};
+
+function Row({ data }: NodeProps<Node<{ text: string }>>) {
+	return (
+		<div className="p-2 flex items-center border-gray-400 border justify-between rounded">
+			{data.text}
+			<Handle
+				style={{ visibility: "hidden" }}
+				type="target"
+				position={Position.Top}
+			/>
+			<Handle
+				style={{ visibility: "hidden" }}
+				type="source"
+				position={Position.Bottom}
+			/>
+		</div>
+	);
+}

--- a/packages/csv-app/src/components/ChangeSet.tsx
+++ b/packages/csv-app/src/components/ChangeSet.tsx
@@ -15,7 +15,7 @@ import {
 	activeFileAtom,
 	parsedCsvAtom,
 	uniqueColumnIndexAtom,
-} from "../routes/editor/state.ts";
+} from "../state-active-file.ts";
 
 const getChanges = async (
 	lix: Lix,

--- a/packages/csv-app/src/components/TableEditor.tsx
+++ b/packages/csv-app/src/components/TableEditor.tsx
@@ -14,7 +14,7 @@ import {
 	activeRowChangesAtom,
 	parsedCsvAtom,
 	uniqueColumnAtom,
-} from "../routes/editor/state.ts";
+} from "../state-active-file.ts";
 import CellGraph from "./CellGraph.tsx";
 import { debounce } from "lodash-es";
 import { saveLixToOpfs } from "../helper/saveLixToOpfs.ts";

--- a/packages/csv-app/src/layouts/OpenFileLayout.tsx
+++ b/packages/csv-app/src/layouts/OpenFileLayout.tsx
@@ -18,7 +18,7 @@ import {
 	parsedCsvAtom,
 	unconfirmedChangesAtom,
 	uniqueColumnAtom,
-} from "../routes/editor/state.ts";
+} from "../state-active-file.ts";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { currentBranchAtom, existingBranchesAtom, lixAtom } from "../state.ts";
 import { saveLixToOpfs } from "../helper/saveLixToOpfs.ts";
@@ -98,7 +98,7 @@ export default function Layout(props: { children: React.ReactNode }) {
 					<div className="px-3 flex gap-1">
 						<NavItem to={`/editor?f=${activeFile.id}`} name="Edit" />
 						<NavItem
-							to={`/graph?f=${activeFile.id}`}
+							to={`/changes?f=${activeFile.id}`}
 							counter={
 								unconfirmedChanges.length !== 0
 									? unconfirmedChanges.length
@@ -106,6 +106,7 @@ export default function Layout(props: { children: React.ReactNode }) {
 							}
 							name="Changes"
 						/>
+						<NavItem to={`/graph?f=${activeFile.id}`} name="Graph" />
 					</div>
 				</div>
 

--- a/packages/csv-app/src/routes.tsx
+++ b/packages/csv-app/src/routes.tsx
@@ -1,8 +1,9 @@
 import { RouteObject } from "react-router-dom";
 import EditorPage from "./routes/editor/Page.tsx";
 import IndexPage from "./routes/index/Page.tsx";
-import GraphPage from "./routes/graph/Page.tsx";
+import ChangesPage from "./routes/changes/Page.tsx";
 import RootLayout from "./layouts/RootLayout.tsx";
+import GraphPage from "./routes/graph/Page.tsx";
 
 export const routes: RouteObject[] = [
 	{
@@ -18,6 +19,15 @@ export const routes: RouteObject[] = [
 		element: (
 			<RootLayout>
 				<EditorPage />
+			</RootLayout>
+		),
+	},
+	{
+		path: "/changes",
+		element: (
+			// @ts-expect-error - type mismatch?
+			<RootLayout>
+				<ChangesPage />,
 			</RootLayout>
 		),
 	},

--- a/packages/csv-app/src/routes/changes/Page.tsx
+++ b/packages/csv-app/src/routes/changes/Page.tsx
@@ -1,0 +1,51 @@
+import OpenFileLayout from "../../layouts/OpenFileLayout.tsx";
+import ChangeSet from "../../components/ChangeSet.tsx";
+import { atom, useAtom } from "jotai";
+import { lixAtom, withPollingAtom } from "../../state.ts";
+import { activeFileAtom } from "../../state-active-file.ts";
+
+const changeSetsAtom = atom(async (get) => {
+	get(withPollingAtom);
+	const lix = await get(lixAtom);
+	const activeFile = await get(activeFileAtom);
+	return await lix.db
+		.selectFrom("change_set")
+		.innerJoin(
+			"change_set_element",
+			"change_set_element.change_set_id",
+			"change_set.id"
+		)
+		.leftJoin("change", "change.id", "change_set_element.change_id")
+		.leftJoin("discussion", "discussion.change_set_id", "change_set.id")
+		// Join with the `comment` table, filtering for first-level comments
+		.leftJoin("comment", "comment.discussion_id", "discussion.id")
+		.where("comment.parent_id", "is", null) // Filter to get only the first comment
+		.where("change.file_id", "=", activeFile.id)
+		.groupBy("change_set.id")
+		.orderBy("change.created_at", "desc")
+		.select("change_set.id")
+		.select("discussion.id as discussion_id")
+		.select("comment.content as first_comment_content") // Get the first comment's content
+		.execute();
+});
+
+export default function Page() {
+	const [changeSets] = useAtom(changeSetsAtom);
+	return (
+		<>
+			<OpenFileLayout>
+				<div className="px-3 pb-6 pt-3 md:pt-5">
+					<div className="mx-auto max-w-7xl bg-white border border-zinc-200 rounded-lg divide-y divide-zinc-200 overflow-hidden">
+						{changeSets.map((changeSet) => (
+							<ChangeSet
+								key={changeSet.id}
+								id={changeSet.id}
+								firstComment={changeSet.first_comment_content}
+							/>
+						))}
+					</div>
+				</div>
+			</OpenFileLayout>
+		</>
+	);
+}

--- a/packages/csv-app/src/routes/graph/Page.tsx
+++ b/packages/csv-app/src/routes/graph/Page.tsx
@@ -1,48 +1,16 @@
+import { useAtom } from "jotai";
+import { ChangeGraph } from "../../components/ChangeGraph.tsx";
+import { allChangesAtom, allEdgesAtom } from "../../state-active-file.ts";
 import OpenFileLayout from "../../layouts/OpenFileLayout.tsx";
-import ChangeSet from "../../components/ChangeSet.tsx";
-import { atom, useAtom } from "jotai";
-import { lixAtom, withPollingAtom } from "../../state.ts";
-import { activeFileAtom } from "../editor/state.ts";
-
-const changeSetsAtom = atom(async (get) => {
-	get(withPollingAtom);
-	const lix = await get(lixAtom);
-	const activeFile = await get(activeFileAtom);
-	return await lix.db
-		.selectFrom("change_set")
-		.innerJoin(
-			"change_set_element",
-			"change_set_element.change_set_id",
-			"change_set.id"
-		)
-		.leftJoin("change", "change.id", "change_set_element.change_id")
-		.leftJoin("discussion", "discussion.change_set_id", "change_set.id")
-		// Join with the `comment` table, filtering for first-level comments
-		.leftJoin("comment", "comment.discussion_id", "discussion.id")
-		.where("comment.parent_id", "is", null) // Filter to get only the first comment
-		.where("change.file_id", "=", activeFile.id)
-		.groupBy("change_set.id")
-		.orderBy("change.created_at", "desc")
-		.select("change_set.id")
-		.select("discussion.id as discussion_id")
-		.select("comment.content as first_comment_content") // Get the first comment's content
-		.execute();
-});
 
 export default function Page() {
-	const [changeSets] = useAtom(changeSetsAtom);
+	const [allChanges] = useAtom(allChangesAtom);
+	const [allEdges] = useAtom(allEdgesAtom);
+
 	return (
 		<OpenFileLayout>
-			<div className="px-3 pb-6 pt-3 md:pt-5">
-				<div className="mx-auto max-w-7xl bg-white border border-zinc-200 rounded-lg divide-y divide-zinc-200 overflow-hidden">
-					{changeSets.map((changeSet) => (
-						<ChangeSet
-							key={changeSet.id}
-							id={changeSet.id}
-							firstComment={changeSet.first_comment_content}
-						/>
-					))}
-				</div>
+			<div className="h-screen">
+				<ChangeGraph changes={allChanges} edges={allEdges}></ChangeGraph>
 			</div>
 		</OpenFileLayout>
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1418,7 +1418,7 @@ importers:
         version: 10.4.5
       next:
         specifier: ^13.0.0 || ^14.0.0 || ^15.0.0
-        version: 14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-941e1b4a-20240729(react@18.3.1))(react@18.3.1)
+        version: 14.2.15(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-941e1b4a-20240729(react@18.3.1))(react@18.3.1)
       qs:
         specifier: ^6.12.1
         version: 6.13.0
@@ -3321,6 +3321,9 @@ importers:
 
   packages/csv-app:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: ^1.1.4
+        version: 1.1.4
       '@lix-js/plugin-csv':
         specifier: workspace:*
         version: link:../lix-plugin-csv
@@ -3330,6 +3333,9 @@ importers:
       '@shoelace-style/shoelace':
         specifier: ^2.17.1
         version: 2.17.1(@types/react@18.3.11)
+      '@xyflow/react':
+        specifier: ^12.3.4
+        version: 12.3.4(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -4395,6 +4401,13 @@ packages:
   '@ctrl/tinycolor@4.1.0':
     resolution: {integrity: sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==}
     engines: {node: '>=14'}
+
+  '@dagrejs/dagre@1.1.4':
+    resolution: {integrity: sha512-QUTc54Cg/wvmlEUxB+uvoPVKFazM1H18kVHBQNmK2NbrDR5ihOCR6CXLnDSZzMcSQKJtabPUWridBOlJM3WkDg==}
+
+  '@dagrejs/graphlib@2.2.4':
+    resolution: {integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==}
+    engines: {node: '>17.0.0'}
 
   '@deno/shim-deno-test@0.5.0':
     resolution: {integrity: sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==}
@@ -7898,6 +7911,24 @@ packages:
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -8978,6 +9009,15 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  '@xyflow/react@12.3.4':
+    resolution: {integrity: sha512-KjFkj84S+wK8aJF/PORxSkOAeotTTPz++hus+Y95NFMIJGVyl8jjVaaz5B1zyV0prk6ZkbMp6q0vqMjJdZT25Q==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.45':
+    resolution: {integrity: sha512-szP1LjDD4jlRYYhxvgZqOCTMToUVNqjQkrlhb0fhv1sXomU1+yMDdhpQT+FjE4d+rKx08fS10sOuZUl2ycXaDw==}
+
   '@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15':
     resolution: {integrity: sha512-kYzDJO5CA9sy+on/s2aIW0411AklfCi8Ck/4QDivOqsMKpStZA2SsR+X27VTggGwpStWaLrjJcDcdDMowtG8MA==}
     engines: {node: '>=14.15.0'}
@@ -9800,6 +9840,9 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
@@ -10198,6 +10241,44 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   daemonize-process@1.0.9:
     resolution: {integrity: sha512-YoB+AmcgHIBDVeyfVWSCV90FNk799zX8Uvn7RJTDCD8Y0EMNbSfIKLG961VgchJme2GHmqpXUuV8Rxe2j2L+bw==}
@@ -16815,6 +16896,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.2.2:
+    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   userhome@1.0.0:
     resolution: {integrity: sha512-ayFKY3H+Pwfy4W98yPdtH1VqH4psDeyW8lYYFzfecR9d6hqLpqhecktvYR3SEEXt7vG0S1JEpciI3g94pMErig==}
     engines: {node: '>= 0.8.0'}
@@ -17850,6 +17936,21 @@ packages:
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  zustand@4.5.5:
+    resolution: {integrity: sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -19162,6 +19263,12 @@ snapshots:
   '@ctrl/tinycolor@3.6.1': {}
 
   '@ctrl/tinycolor@4.1.0': {}
+
+  '@dagrejs/dagre@1.1.4':
+    dependencies:
+      '@dagrejs/graphlib': 2.2.4
+
+  '@dagrejs/graphlib@2.2.4': {}
 
   '@deno/shim-deno-test@0.5.0': {}
 
@@ -23625,6 +23732,27 @@ snapshots:
     dependencies:
       '@types/node': 20.16.13
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
@@ -24630,7 +24758,7 @@ snapshots:
       msw: 2.4.11(typescript@5.6.3)
       sirv: 2.0.4
       tinyrainbow: 1.2.0
-      vitest: 0.33.0(@vitest/browser@2.1.3)(jsdom@25.0.1)(lightningcss@1.27.0)(playwright@1.48.1)(safaridriver@0.1.2)(terser@5.36.0)(webdriverio@9.2.1)
+      vitest: 0.33.0(@vitest/browser@2.1.3)(jsdom@22.1.0)(lightningcss@1.27.0)(playwright@1.48.1)(safaridriver@0.1.2)(terser@5.36.0)(webdriverio@9.2.1)
       ws: 8.18.0
     optionalDependencies:
       playwright: 1.48.1
@@ -25684,6 +25812,27 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  '@xyflow/react@12.3.4(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@xyflow/system': 0.0.45
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.5(@types/react@18.3.11)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.45':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   '@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15(esbuild@0.18.20)':
     dependencies:
       esbuild: 0.18.20
@@ -26730,6 +26879,8 @@ snapshots:
     dependencies:
       consola: 3.2.3
 
+  classcat@5.0.5: {}
+
   classnames@2.5.1: {}
 
   clean-git-ref@2.0.1: {}
@@ -27133,6 +27284,42 @@ snapshots:
     optional: true
 
   csstype@3.1.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   daemonize-process@1.0.9: {}
 
@@ -27847,7 +28034,7 @@ snapshots:
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.41.0))(eslint@8.41.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.41.0))(eslint@8.41.0))(eslint@8.41.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.41.0)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.41.0)
       eslint-plugin-react: 7.37.1(eslint@8.41.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.41.0)
@@ -27893,7 +28080,7 @@ snapshots:
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.41.0))(eslint@8.41.0))(eslint@8.41.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.41.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -27911,7 +28098,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(eslint@8.41.0))(eslint@8.41.0))(eslint@8.41.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.41.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -31887,7 +32074,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.25.8)(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.2-canary.4
       '@next/swc-darwin-x64': 14.1.2-canary.4
@@ -31913,7 +32100,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.25.8)(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.3
       '@next/swc-darwin-x64': 14.1.3
@@ -31924,32 +32111,6 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.1.3
       '@next/swc-win32-ia32-msvc': 14.1.3
       '@next/swc-win32-x64-msvc': 14.1.3
-      '@opentelemetry/api': 1.9.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
-  next@14.2.15(@babel/core@7.25.8)(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-941e1b4a-20240729(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 14.2.15
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001651
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 19.0.0-rc-941e1b4a-20240729(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.25.8)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.15
-      '@next/swc-darwin-x64': 14.2.15
-      '@next/swc-linux-arm64-gnu': 14.2.15
-      '@next/swc-linux-arm64-musl': 14.2.15
-      '@next/swc-linux-x64-gnu': 14.2.15
-      '@next/swc-linux-x64-musl': 14.2.15
-      '@next/swc-win32-arm64-msvc': 14.2.15
-      '@next/swc-win32-ia32-msvc': 14.2.15
-      '@next/swc-win32-x64-msvc': 14.2.15
       '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -31991,7 +32152,33 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.25.8)(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.15
+      '@next/swc-darwin-x64': 14.2.15
+      '@next/swc-linux-arm64-gnu': 14.2.15
+      '@next/swc-linux-arm64-musl': 14.2.15
+      '@next/swc-linux-x64-gnu': 14.2.15
+      '@next/swc-linux-x64-musl': 14.2.15
+      '@next/swc-win32-arm64-msvc': 14.2.15
+      '@next/swc-win32-ia32-msvc': 14.2.15
+      '@next/swc-win32-x64-msvc': 14.2.15
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@14.2.15(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-941e1b4a-20240729(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 14.2.15
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001651
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 19.0.0-rc-941e1b4a-20240729(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.15
       '@next/swc-darwin-x64': 14.2.15
@@ -34908,17 +35095,15 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.1(@babel/core@7.25.8)(react@18.3.1):
-    dependencies:
-      client-only: 0.0.1
-      react: 18.3.1
-    optionalDependencies:
-      '@babel/core': 7.25.8
-
   styled-jsx@5.1.1(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
+
+  styled-jsx@5.1.1(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
 
   sucrase@3.35.0:
     dependencies:
@@ -36268,6 +36453,10 @@ snapshots:
       tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.11
+
+  use-sync-external-store@1.2.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   userhome@1.0.0: {}
 
@@ -38009,5 +38198,12 @@ snapshots:
       zod: 3.23.8
 
   zod@3.23.8: {}
+
+  zustand@4.5.5(@types/react@18.3.11)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.2.2(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      react: 18.3.1
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Adds a change graph tab to the csv app. will act as "ah that's why this is the current change" when evaluating branches

- evaluated mermaid but mapping edges to text and then coordinate rendering is messy
- evaluated gitgraph.js but the styling was not adjustable (and default rendered extremely large)
- picked react flow because adjustable and ... it works

![CleanShot 2024-11-05 at 16 45 33@2x](https://github.com/user-attachments/assets/80ffacd8-ed9d-40d5-82ae-6702860761c2)
