### PR TITLE
Update deployment.md to show correct cloudflare compatibility flags

### DIFF
--- a/inlang/source-code/paraglide/paraglide-sveltekit/docs/deployment.md
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/docs/deployment.md
@@ -21,10 +21,10 @@ export const handle = i18n.handle({
 
 ## Deployment on Cloudflare
 
-`Paraglide-SvelteKit` makes use of `AsyncLocalStorage`. `AsyncLocalStorage` is supported on Cloudflare, but you need to enable the `nodejs_compat` feature flag in `wrangler.toml`.
+`Paraglide-SvelteKit` makes use of `AsyncLocalStorage`. `AsyncLocalStorage` is supported on Cloudflare, but you need to enable the `nodejs_als` feature flag in `wrangler.toml`.
 
 ```toml
-compatibility_flags = [ "nodejs_compat" ]
+compatibility_flags = [ "nodejs_als" ]
 ```
 
 ## Issues on Vercel


### PR DESCRIPTION
As per cloudflare's documentation: https://developers.cloudflare.com/workers/configuration/compatibility-flags/

`nodejs_compat` is being removed in favour of `nodejs_compat_v2`. However using `nodejs_als` will enable `AsyncLocalStorage` only.

We could potentially leave a link to their documentation so user's can easily check the current compatibility flags.