### PR TITLE
Change-queue-follow-up-changes

### DIFF
--- a/packages/lix-sdk/src/branch/merge-branch.test.ts
+++ b/packages/lix-sdk/src/branch/merge-branch.test.ts
@@ -413,7 +413,6 @@ test("re-curring merges should not create a new conflict if the conflict already
 			id: "mock",
 			path: "mock",
 			data: new Uint8Array(),
-			skip_change_extraction: 1,
 		})
 		.execute();
 

--- a/packages/lix-sdk/src/change-conflict/resolve-conflict-by-selecting.test.ts
+++ b/packages/lix-sdk/src/change-conflict/resolve-conflict-by-selecting.test.ts
@@ -53,7 +53,6 @@ test("it should resolve a conflict and apply the changes", async () => {
 			id: "mock",
 			path: "mock",
 			data: new Uint8Array(),
-			skip_change_extraction: 1,
 		})
 		.execute();
 

--- a/packages/lix-sdk/src/change-queue/change-queue-settled.test.ts
+++ b/packages/lix-sdk/src/change-queue/change-queue-settled.test.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "vitest";
+import { openLixInMemory } from "../lix/open-lix-in-memory.js";
+import { changeQueueSettled } from "./change-queue-settled.js";
+
+test("should wait until the change queue is settled", async () => {
+	const lix = await openLixInMemory({});
+
+	await lix.db
+		.insertInto("change_queue")
+		.values([
+			{
+				id: 1,
+				file_id: "file1",
+				path_after: "path1",
+				data_after: new TextEncoder().encode("data1"),
+				metadata_after: null,
+			},
+			{
+				id: 2,
+				file_id: "file2",
+				path_after: "path2",
+				data_after: new TextEncoder().encode("data2"),
+				metadata_after: null,
+			},
+		])
+		.execute();
+
+	// Start a background task to remove entries from the change_queue after a delay
+	setTimeout(async () => {
+		await lix.db.deleteFrom("change_queue").where("id", "=", 1).execute();
+		await lix.db.deleteFrom("change_queue").where("id", "=", 2).execute();
+	}, 110);
+
+	await changeQueueSettled({ lix });
+
+	const remainingEntries = await lix.db
+		.selectFrom("change_queue")
+		.selectAll()
+		.execute();
+
+	expect(remainingEntries).toEqual([]);
+});
+
+test("should return immediately if the change queue is already empty", async () => {
+	const lix = await openLixInMemory({});
+
+	await lix.db.deleteFrom("change_queue").execute();
+
+	await changeQueueSettled({ lix });
+
+	const remainingEntries = await lix.db
+		.selectFrom("change_queue")
+		.selectAll()
+		.execute();
+	expect(remainingEntries).toEqual([]);
+});

--- a/packages/lix-sdk/src/change-queue/change-queue-settled.ts
+++ b/packages/lix-sdk/src/change-queue/change-queue-settled.ts
@@ -1,0 +1,31 @@
+import type { Lix } from "../lix/open-lix.js";
+
+/**
+ * Waits until the change queue is settled.
+ *
+ * @example
+ *   ```ts
+ *   await changeQueueSettled({ lix });
+ *   ```
+ */
+export async function changeQueueSettled(args: {
+	lix: Pick<Lix, "db">;
+}): Promise<void> {
+	let hasEntries = true;
+
+	while (hasEntries) {
+		const entries = await args.lix.db
+			.selectFrom("change_queue")
+			.select("id")
+			.limit(1)
+			.execute();
+
+		hasEntries = entries.length > 0;
+
+		if (hasEntries) {
+			// poll again in 50ms. This is a workaround until subscriptions
+			// or another mechanism is implemented to notify when the queue is settled
+			await new Promise((resolve) => setTimeout(resolve, 50));
+		}
+	}
+}

--- a/packages/lix-sdk/src/change-queue/change-queue.test.ts
+++ b/packages/lix-sdk/src/change-queue/change-queue.test.ts
@@ -77,13 +77,12 @@ test("should use queue and settled correctly", async () => {
 		.execute();
 
 	expect(internalFilesAfter).toEqual([
-		{
+		expect.objectContaining({
 			data: internalFilesAfter[0]!.data,
 			id: "test",
 			path: "test.txt",
 			metadata: null,
-			$skip_change_queue: null,
-		} satisfies LixFile,
+		}) satisfies LixFile,
 	]);
 
 	const changes = await lix.db

--- a/packages/lix-sdk/src/change-queue/change-queue.test.ts
+++ b/packages/lix-sdk/src/change-queue/change-queue.test.ts
@@ -2,6 +2,8 @@ import { expect, test, vi } from "vitest";
 import { openLixInMemory } from "../lix/open-lix-in-memory.js";
 import { newLixFile } from "../lix/new-lix.js";
 import type { DetectedChange, LixPlugin } from "../plugin/lix-plugin.js";
+import type { ChangeQueueEntry } from "../database/schema.js";
+import { changeQueueSettled } from "./change-queue-settled.js";
 
 test("should use queue and settled correctly", async () => {
 	const mockPlugin: LixPlugin = {
@@ -51,17 +53,18 @@ test("should use queue and settled correctly", async () => {
 		.execute();
 
 	const queue = await lix.db.selectFrom("change_queue").selectAll().execute();
+
 	expect(queue).toEqual([
-		{
+		expect.objectContaining({
 			id: 1,
 			file_id: "test",
-			metadata: null,
-			path: "test.txt",
+			path_after: "test.txt",
 			data_after: dataInitial,
 			data_before: null,
-		},
+		} satisfies Partial<ChangeQueueEntry>),
 	]);
-	await lix.settled();
+
+	await changeQueueSettled({ lix });
 
 	expect(
 		(await lix.db.selectFrom("change_queue").selectAll().execute()).length,
@@ -109,55 +112,62 @@ test("should use queue and settled correctly", async () => {
 		.where("id", "=", "test")
 		.execute();
 
-	const beforeQueueTick = await lix.db
-		.selectFrom("change_queue")
-		.selectAll()
-		.execute();
+	// const beforeQueueTick = await lix.db
+	// 	.selectFrom("change_queue")
+	// 	.selectAll()
+	// 	.execute();
 
-	expect(beforeQueueTick.length).toBe(1);
+	// expect(beforeQueueTick.length).toBe(1);
 
-	const afterQueueTick = await lix.db
-		.selectFrom("change_queue")
-		.selectAll()
-		.execute();
-	expect(afterQueueTick.length).toBe(0);
+	// const afterQueueTick = await lix.db
+	// 	.selectFrom("change_queue")
+	// 	.selectAll()
+	// 	.execute();
 
-	const dataUpdate1Again = dataUpdate1;
-	// re apply same change
-	await lix.db
-		.updateTable("file")
-		.set({ data: dataUpdate1Again })
-		.where("id", "=", "test")
-		.execute();
+	// expect(afterQueueTick.length).toBe(0);
 
-	const dataUpdate2 = enc.encode("seond text update");
+	// update2 is equal to update1
+	const dataUpdate2 = dataUpdate1;
+
+	// insert same file again
 	await lix.db
 		.updateTable("file")
 		.set({ data: dataUpdate2 })
 		.where("id", "=", "test")
 		.execute();
 
+	const dataUpdate3 = enc.encode("second text update");
+
+	await lix.db
+		.updateTable("file")
+		.set({ data: dataUpdate3 })
+		.where("id", "=", "test")
+		.execute();
+
 	const queue2 = await lix.db.selectFrom("change_queue").selectAll().execute();
+
 	expect(queue2).toEqual([
-		{
+		// change update 1 is the same as change update 2
+		// hence, only 2 change queue entries are expected
+		expect.objectContaining({
 			id: 3,
 			file_id: "test",
-			path: "test.txt",
-			metadata: null,
+			path_after: "test.txt",
+			metadata_after: null,
 			data_before: dataUpdate1,
-			data_after: dataUpdate1Again,
-		},
-		{
+			data_after: dataUpdate2,
+		} satisfies Partial<ChangeQueueEntry>),
+		expect.objectContaining({
 			id: 4,
 			file_id: "test",
-			path: "test.txt",
-			metadata: null,
-			data_before: dataUpdate1Again,
-			data_after: dataUpdate2,
-		},
+			path_after: "test.txt",
+			metadata_after: null,
+			data_before: dataUpdate2,
+			data_after: dataUpdate3,
+		} satisfies Partial<ChangeQueueEntry>),
 	]);
 
-	await lix.settled();
+	await changeQueueSettled({ lix });
 
 	expect(
 		(await lix.db.selectFrom("change_queue").selectAll().execute()).length,
@@ -206,7 +216,7 @@ test("should use queue and settled correctly", async () => {
 			plugin_key: "mock-plugin",
 			schema_key: "text",
 			content: {
-				text: "seond text update",
+				text: "second text update",
 			},
 		}),
 	]);
@@ -270,7 +280,7 @@ test.todo("changes should contain the author", async () => {
 		})
 		.execute();
 
-	await lix.settled();
+	await changeQueueSettled({ lix });
 
 	// const changes1 = await lix.db.selectFrom("change").selectAll().execute();
 
@@ -286,7 +296,7 @@ test.todo("changes should contain the author", async () => {
 		.where("id", "=", "mock")
 		.execute();
 
-	await lix.settled();
+	await changeQueueSettled({ lix });
 
 	// const changes2 = await lix.db.selectFrom("change").selectAll().execute();
 
@@ -300,7 +310,7 @@ test.todo("changes should contain the author", async () => {
 		.where("id", "=", "mock")
 		.execute();
 
-	await lix.settled();
+	await changeQueueSettled({ lix });
 
 	// const changes3 = await lix.db.selectFrom("change").selectAll().execute();
 

--- a/packages/lix-sdk/src/change-queue/change-queue.test.ts
+++ b/packages/lix-sdk/src/change-queue/change-queue.test.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from "vitest";
 import { openLixInMemory } from "../lix/open-lix-in-memory.js";
 import { newLixFile } from "../lix/new-lix.js";
 import type { DetectedChange, LixPlugin } from "../plugin/lix-plugin.js";
-import type { ChangeQueueEntry } from "../database/schema.js";
+import type { ChangeQueueEntry, LixFile } from "../database/schema.js";
 import { changeQueueSettled } from "./change-queue-settled.js";
 
 test("should use queue and settled correctly", async () => {
@@ -78,12 +78,12 @@ test("should use queue and settled correctly", async () => {
 
 	expect(internalFilesAfter).toEqual([
 		{
-			data: internalFilesAfter[0]?.data,
+			data: internalFilesAfter[0]!.data,
 			id: "test",
 			path: "test.txt",
 			metadata: null,
-			skip_change_extraction: null,
-		},
+			$skip_change_queue: null,
+		} satisfies LixFile,
 	]);
 
 	const changes = await lix.db

--- a/packages/lix-sdk/src/change-queue/change-queue.ts
+++ b/packages/lix-sdk/src/change-queue/change-queue.ts
@@ -1,0 +1,119 @@
+import type { SqliteDatabase } from "sqlite-wasm-kysely";
+import { handleFileChange, handleFileInsert } from "./file-handlers.js";
+import type { Lix } from "../lix/open-lix.js";
+
+export async function initChangeQueue(args: {
+	lix: Pick<Lix, "db" | "plugin">;
+	rawDatabase: SqliteDatabase;
+}): Promise<void> {
+	args.rawDatabase.createFunction({
+		name: "triggerWorker",
+		arity: 0,
+		// @ts-expect-error - dynamic function
+		xFunc: () => {
+			// TODO: abort current running queue?
+			queueWorker();
+		},
+	});
+
+	const closed = false;
+
+	let pending: Promise<void> | undefined;
+
+	let resolve: () => void;
+	// run number counts the worker runs in a current batch and is used to prevent race conditions where a trigger is missed because a previous run is just about to reset the hasMoreEntriesSince flag
+	let runNumber = 1;
+	// If a queue trigger happens during an existing queue run we might miss updates and use hasMoreEntriesSince to make sure there is always a final immediate queue worker execution
+	let hasMoreEntriesSince: number | undefined = undefined;
+
+	async function queueWorker(trail = false) {
+		if (closed) {
+			return;
+		}
+
+		try {
+			if (pending && !trail) {
+				hasMoreEntriesSince = runNumber;
+				return;
+			}
+			runNumber++;
+
+			if (!pending) {
+				pending = new Promise((res) => {
+					resolve = res;
+				});
+			}
+
+			const entry = await args.lix.db
+				.selectFrom("change_queue")
+				.selectAll()
+				.orderBy("id asc")
+				.limit(1)
+				.executeTakeFirst();
+
+			if (entry) {
+				if (entry.data_before && entry.data_after) {
+					await handleFileChange({
+						changeQueueEntry: entry,
+						lix: args.lix,
+					});
+				} else if (!entry.data_before && entry.data_after) {
+					await handleFileInsert({
+						changeQueueEntry: entry,
+						lix: args.lix,
+					});
+				} else if (entry.data_before && !entry.data_after) {
+					// TODO Queue - handle deletion - the current queue doesn't handle delete starting with feature parity
+					// await handleFileDelete({
+					// 	queueEntry: entry,
+					// before: {
+					// 	id: entry.file_id,
+					// 	path: entry.path,
+					// 	metadata: null,
+					// 	// TODO Queue - handle deletion - until than this we have to bang here
+					// 	data: entry.data_before,
+					// 	skip_change_extraction: null
+					// },
+					// 	plugins,
+					// 	lix: {
+					// 		db,
+					// 		plugin,
+					// 	},
+					// });
+				}
+			}
+
+			// console.log("getrting { numEntries }");
+
+			const { numEntries } = await args.lix.db
+				.selectFrom("change_queue")
+				.select((eb) => eb.fn.count<number>("id").as("numEntries"))
+				.executeTakeFirstOrThrow();
+
+			// console.log({ numEntries });
+
+			if (
+				!hasMoreEntriesSince ||
+				(numEntries === 0 && hasMoreEntriesSince < runNumber)
+			) {
+				resolve!(); // TODO: fix type
+				hasMoreEntriesSince = undefined;
+				pending = undefined;
+				// console.log("resolving");
+			}
+
+			// TODO: handle endless tries on failing quee entries
+			// we either execute the queue immediately if we know there is more work or fall back to polling
+			setTimeout(() => queueWorker(true), hasMoreEntriesSince ? 0 : 1000);
+		} catch (e) {
+			// https://linear.app/opral/issue/LIXDK-102/re-visit-simplifying-the-change-queue-implementation
+
+			console.error(
+				"change queue failed (will remain so until rework of change queue): ",
+				e,
+			);
+		}
+	}
+	// start a worker in case there are entries
+	return queueWorker();
+}

--- a/packages/lix-sdk/src/change-queue/file-handlers.ts
+++ b/packages/lix-sdk/src/change-queue/file-handlers.ts
@@ -58,7 +58,7 @@ export async function handleFileInsert(args: {
 				path,
 				metadata: args.changeQueueEntry.metadata_after,
 				data: args.changeQueueEntry.data_after,
-				skip_change_extraction: null,
+				$skip_change_queue: null,
 			},
 		})) {
 			detectedChanges.push({
@@ -144,7 +144,7 @@ export async function handleFileChange(args: {
 						path: path,
 						metadata: args.changeQueueEntry.metadata_before,
 						data: args.changeQueueEntry.data_before,
-						skip_change_extraction: null,
+						$skip_change_queue: null,
 					}
 				: undefined,
 			after: args.changeQueueEntry.data_after
@@ -153,7 +153,7 @@ export async function handleFileChange(args: {
 						path,
 						metadata: args.changeQueueEntry.metadata_after,
 						data: args.changeQueueEntry.data_after,
-						skip_change_extraction: null,
+						$skip_change_queue: null,
 					}
 				: undefined,
 		})) {

--- a/packages/lix-sdk/src/change-queue/file-handlers.ts
+++ b/packages/lix-sdk/src/change-queue/file-handlers.ts
@@ -58,7 +58,6 @@ export async function handleFileInsert(args: {
 				path,
 				metadata: args.changeQueueEntry.metadata_after,
 				data: args.changeQueueEntry.data_after,
-				$skip_change_queue: null,
 			},
 		})) {
 			detectedChanges.push({
@@ -144,7 +143,6 @@ export async function handleFileChange(args: {
 						path: path,
 						metadata: args.changeQueueEntry.metadata_before,
 						data: args.changeQueueEntry.data_before,
-						$skip_change_queue: null,
 					}
 				: undefined,
 			after: args.changeQueueEntry.data_after
@@ -153,7 +151,6 @@ export async function handleFileChange(args: {
 						path,
 						metadata: args.changeQueueEntry.metadata_after,
 						data: args.changeQueueEntry.data_after,
-						$skip_change_queue: null,
 					}
 				: undefined,
 		})) {

--- a/packages/lix-sdk/src/change-queue/index.ts
+++ b/packages/lix-sdk/src/change-queue/index.ts
@@ -1,0 +1,1 @@
+export { changeQueueSettled } from "./change-queue-settled.js";

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -8,13 +8,25 @@ export async function applySchema(args: {
 }): Promise<unknown> {
 	return args.sqlite.exec`
 
+  -- file
+
   CREATE TABLE IF NOT EXISTS file (
     id TEXT PRIMARY KEY DEFAULT (uuid_v4()),
     path TEXT NOT NULL UNIQUE,
     data BLOB NOT NULL,
-    metadata TEXT,  -- Added metadata field
-    skip_change_extraction INTEGER -- New column with default value
+    metadata TEXT,
+
+    '$skip_change_queue' INTEGER
   ) strict;
+
+  -- TODO Queue - handle deletion - the current queue doesn't handle delete starting with feature parity
+    -- CREATE TRIGGER IF NOT EXISTS file_delete BEFORE DELETE ON file
+    -- WHEN NEW.skip_change_extraction IS NULL
+    -- BEGIN
+    --     INSERT INTO change_queue(file_id, path, data_before, data_after, metadata)
+    --     VALUES (OLD.id, OLD.path, OLD.data, NULL, OLD.metadata);
+    --   SELECT triggerWorker();
+    -- END;
 
   CREATE TABLE IF NOT EXISTS change_queue (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -26,6 +38,35 @@ export async function applySchema(args: {
     metadata_before TEXT,
     metadata_after TEXT
   ) strict;
+
+  CREATE TRIGGER IF NOT EXISTS file_insert BEFORE INSERT ON file
+  WHEN NEW.'$skip_change_queue' IS NULL
+  BEGIN
+    INSERT INTO change_queue(
+      file_id, path_after, data_after, metadata_after
+    )
+    VALUES (NEW.id, NEW.path, NEW.data, NEW.metadata);
+
+    SELECT triggerWorker();
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS file_update BEFORE UPDATE ON file
+  WHEN NEW.'$skip_change_queue' IS NULL
+  BEGIN
+    INSERT INTO change_queue(
+      file_id, 
+      path_before, data_before, metadata_before, 
+      path_after, data_after, metadata_after
+    )
+
+    VALUES (
+      NEW.id, 
+      OLD.path, OLD.data, OLD.metadata,
+      NEW.path, NEW.data, NEW.metadata
+    );
+
+    SELECT triggerWorker();
+  END;
 
   CREATE TABLE IF NOT EXISTS change (
     id TEXT PRIMARY KEY DEFAULT (uuid_v4()),
@@ -79,41 +120,6 @@ export async function applySchema(args: {
     FOREIGN KEY(change_conflict_id) REFERENCES change_conflict(id),
     FOREIGN KEY(resolved_change_id) REFERENCES change(id)
   ) strict;
-
-  CREATE TRIGGER IF NOT EXISTS file_insert BEFORE INSERT ON file
-  WHEN NEW.skip_change_extraction IS NULL
-  BEGIN
-    INSERT INTO change_queue(
-      file_id, path_after, data_after, metadata_after
-    )
-    VALUES (NEW.id, NEW.path, NEW.data, NEW.metadata);
-    SELECT triggerWorker();
-  END;
-
-  CREATE TRIGGER IF NOT EXISTS file_update BEFORE UPDATE ON file
-  WHEN NEW.skip_change_extraction IS NULL
-  BEGIN
-    INSERT INTO change_queue(
-      file_id, 
-      path_before, data_before, metadata_before, 
-      path_after, data_after, metadata_after
-    )
-    VALUES (
-      NEW.id, 
-      OLD.path, OLD.data, OLD.metadata,
-      NEW.path, NEW.data, NEW.metadata
-    );
-    SELECT triggerWorker();
-  END;
-
--- TODO Queue - handle deletion - the current queue doesn't handle delete starting with feature parity
-  -- CREATE TRIGGER IF NOT EXISTS file_delete BEFORE DELETE ON file
-  -- WHEN NEW.skip_change_extraction IS NULL
-  -- BEGIN
-  --     INSERT INTO change_queue(file_id, path, data_before, data_after, metadata)
-  --     VALUES (OLD.id, OLD.path, OLD.data, NULL, OLD.metadata);
-  --   SELECT triggerWorker();
-  -- END;
 
   -- change sets
 

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -18,11 +18,13 @@ export async function applySchema(args: {
 
   CREATE TABLE IF NOT EXISTS change_queue (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    file_id TEXT,
-    path TEXT NOT NULL,
+    file_id TEXT NOT NULL,
     data_before BLOB,
     data_after BLOB,
-    metadata TEXT  -- Added metadata field
+    path_before TEXT,
+    path_after TEXT,
+    metadata_before TEXT,
+    metadata_after TEXT
   ) strict;
 
   CREATE TABLE IF NOT EXISTS change (
@@ -81,16 +83,26 @@ export async function applySchema(args: {
   CREATE TRIGGER IF NOT EXISTS file_insert BEFORE INSERT ON file
   WHEN NEW.skip_change_extraction IS NULL
   BEGIN
-    INSERT INTO change_queue(file_id, path, data_before, data_after, metadata)
-      VALUES (NEW.id, NEW.path, NULL, NEW.data, NEW.metadata);
+    INSERT INTO change_queue(
+      file_id, path_after, data_after, metadata_after
+    )
+    VALUES (NEW.id, NEW.path, NEW.data, NEW.metadata);
     SELECT triggerWorker();
   END;
 
   CREATE TRIGGER IF NOT EXISTS file_update BEFORE UPDATE ON file
   WHEN NEW.skip_change_extraction IS NULL
   BEGIN
-    INSERT INTO change_queue(file_id, path, data_before, data_after, metadata)
-      VALUES (OLD.id, OLD.path, OLD.data, NEW.data, OLD.metadata);
+    INSERT INTO change_queue(
+      file_id, 
+      path_before, data_before, metadata_before, 
+      path_after, data_after, metadata_after
+    )
+    VALUES (
+      NEW.id, 
+      OLD.path, OLD.data, OLD.metadata,
+      NEW.path, NEW.data, NEW.metadata
+    );
     SELECT triggerWorker();
   END;
 

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -24,7 +24,7 @@ test("file ids should default to uuid", async () => {
 		.values({
 			path: "/mock",
 			data: new Uint8Array(),
-			skip_change_extraction: 1,
+			$skip_change_queue: 1,
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
@@ -146,7 +146,7 @@ test("files should be able to have metadata", async () => {
 			metadata: {
 				primary_key: "email",
 			},
-			skip_change_extraction: 1,
+			$skip_change_queue: 1,
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
@@ -160,7 +160,7 @@ test("files should be able to have metadata", async () => {
 			metadata: {
 				primary_key: "something-else",
 			},
-			skip_change_extraction: 1,
+			$skip_change_queue: 1,
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -24,7 +24,7 @@ test("file ids should default to uuid", async () => {
 		.values({
 			path: "/mock",
 			data: new Uint8Array(),
-			$skip_change_queue: 1,
+			$skip_change_queue: true,
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
@@ -146,7 +146,7 @@ test("files should be able to have metadata", async () => {
 			metadata: {
 				primary_key: "email",
 			},
-			$skip_change_queue: 1,
+			$skip_change_queue: true,
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
@@ -160,7 +160,7 @@ test("files should be able to have metadata", async () => {
 			metadata: {
 				primary_key: "something-else",
 			},
-			$skip_change_queue: 1,
+			$skip_change_queue: true,
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -52,7 +52,7 @@ type LixFileTable = {
 	path: string;
 	data: ArrayBuffer;
 	metadata: Record<string, any> | null;
-	skip_change_extraction?: number | null;
+	$skip_change_queue: number | null;
 };
 
 export type Change = Selectable<ChangeTable>;

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -34,11 +34,13 @@ export type NewChangeQueueEntry = Insertable<ChangeQueueTable>;
 export type ChangeQueueEntryUpdate = Updateable<ChangeQueueTable>;
 type ChangeQueueTable = {
 	id: Generated<number>;
-	path: string;
 	file_id: string;
-	metadata: Record<string, any> | null;
+	path_before: string | null;
+	path_after: string | null;
 	data_before: ArrayBuffer | null;
 	data_after: ArrayBuffer | null;
+	metadata_before: Record<string, any> | null;
+	metadata_after: Record<string, any> | null;
 };
 
 // named lix file to avoid conflict with built-in file type

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -2,7 +2,7 @@
 import type { Generated, Insertable, Selectable, Updateable } from "kysely";
 
 export type LixDatabaseSchema = {
-	file: LixFileTable;
+	file: LixFileTableWithQueryFlags;
 	change_queue: ChangeQueueTable;
 	change_edge: ChangeEdgeTable;
 	snapshot: SnapshotTable;
@@ -52,7 +52,9 @@ type LixFileTable = {
 	path: string;
 	data: ArrayBuffer;
 	metadata: Record<string, any> | null;
-	$skip_change_queue: number | null;
+};
+type LixFileTableWithQueryFlags = LixFileTable & {
+	$skip_change_queue?: boolean;
 };
 
 export type Change = Selectable<ChangeTable>;

--- a/packages/lix-sdk/src/discussion/create-discussion.test.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.test.ts
@@ -4,6 +4,7 @@ import { newLixFile } from "../lix/new-lix.js";
 import type { DetectedChange, LixPlugin } from "../plugin/lix-plugin.js";
 import { createDiscussion } from "./create-discussion.js";
 import { createChangeSet } from "../change-set/create-change-set.js";
+import { changeQueueSettled } from "../change-queue/change-queue-settled.js";
 
 const mockPlugin: LixPlugin = {
 	key: "mock-plugin",
@@ -37,7 +38,7 @@ test("should be able to start a discussion on changes", async () => {
 		.values({ id: "test", path: "test.txt", data: enc.encode("test") })
 		.execute();
 
-	await lix.settled();
+	await changeQueueSettled({ lix });
 
 	const changes = await lix.db
 		.selectFrom("change")

--- a/packages/lix-sdk/src/index.ts
+++ b/packages/lix-sdk/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./branch/index.js";
 export * from "./change-set/index.js";
 export * from "./change-conflict/index.js";
+export * from "./change-queue/index.js";
 export * from "./change-schema/index.js";
 export * from "./database/index.js";
 export * from "./discussion/index.js";

--- a/packages/lix-sdk/src/lix/merge.test.ts
+++ b/packages/lix-sdk/src/lix/merge.test.ts
@@ -13,6 +13,7 @@ import { mockJsonSnapshot } from "../snapshot/mock-json-snapshot.js";
 import { createChangeSet } from "../change-set/create-change-set.js";
 import { createDiscussion } from "../discussion/create-discussion.js";
 import { createComment } from "../discussion/create-comment.js";
+import { changeQueueSettled } from "../change-queue/change-queue-settled.js";
 
 test("it should copy changes from the sourceLix into the targetLix that do not exist in targetLix yet", async () => {
 	const mockSnapshots = [
@@ -435,7 +436,7 @@ test.todo("it should apply changes that are not conflicting", async () => {
 		})
 		.execute();
 
-	await targetLix.settled();
+	await changeQueueSettled({ lix: targetLix });
 
 	await merge({ sourceLix, targetLix });
 	const changes = await targetLix.db
@@ -673,7 +674,7 @@ test("it should copy discussion and related comments and mappings", async () => 
 		.values({ id: "test", path: "test.txt", data: enc.encode("inserted text") })
 		.execute();
 
-	await lix1.settled();
+	await changeQueueSettled({ lix: lix1 });
 
 	// The files have to be there before we merge
 	const lix2 = await openLixInMemory({

--- a/packages/lix-sdk/src/lix/merge.ts
+++ b/packages/lix-sdk/src/lix/merge.ts
@@ -79,7 +79,7 @@ export async function merge(args: {
 			};
 			await args.targetLix.db
 				.insertInto("file")
-				.values({ ...fileToInsert, skip_change_extraction: 1 })
+				.values({ ...fileToInsert, $skip_change_queue: 1 })
 				.executeTakeFirst();
 		}
 
@@ -176,7 +176,7 @@ export async function merge(args: {
 			await trx
 				.updateTable("file")
 				.set("data", fileData)
-				.set("skip_change_extraction", 1)
+				.set("$skip_change_queue", 1)
 				.where("id", "=", fileId)
 				.execute();
 		}

--- a/packages/lix-sdk/src/lix/merge.ts
+++ b/packages/lix-sdk/src/lix/merge.ts
@@ -79,7 +79,7 @@ export async function merge(args: {
 			};
 			await args.targetLix.db
 				.insertInto("file")
-				.values({ ...fileToInsert, $skip_change_queue: 1 })
+				.values({ ...fileToInsert, $skip_change_queue: true })
 				.executeTakeFirst();
 		}
 
@@ -176,7 +176,7 @@ export async function merge(args: {
 			await trx
 				.updateTable("file")
 				.set("data", fileData)
-				.set("$skip_change_queue", 1)
+				.set("$skip_change_queue", true)
 				.where("id", "=", fileId)
 				.execute();
 		}

--- a/packages/lix-sdk/src/lix/open-lix.ts
+++ b/packages/lix-sdk/src/lix/open-lix.ts
@@ -1,15 +1,12 @@
 import type { LixPlugin } from "../plugin/lix-plugin.js";
-import {
-	handleFileChange,
-	handleFileInsert,
-} from "../change-queue/file-handlers.js";
 import { loadPlugins } from "../plugin/load-plugin.js";
 import { contentFromDatabase, type SqliteDatabase } from "sqlite-wasm-kysely";
 import { initDb } from "../database/init-db.js";
+import { initChangeQueue } from "../change-queue/change-queue.js";
+import { changeQueueSettled } from "../change-queue/change-queue-settled.js";
 
 export type Lix = {
 	db: ReturnType<typeof initDb>;
-	settled: () => Promise<void>;
 	toBlob: () => Promise<Blob>;
 	plugin: {
 		getAll: () => Promise<LixPlugin[]>;
@@ -38,8 +35,6 @@ export async function openLix(args: {
 }): Promise<Lix> {
 	const db = initDb({ sqlite: args.database });
 
-	let closed = false;
-
 	const plugins = await loadPlugins(db);
 	if (args.providePlugins && args.providePlugins.length > 0) {
 		plugins.push(...args.providePlugins);
@@ -49,175 +44,23 @@ export async function openLix(args: {
 		getAll: async () => plugins,
 	};
 
-	args.database.createFunction({
-		name: "triggerWorker",
-		arity: 0,
-		// @ts-expect-error - dynamic function
-		xFunc: () => {
-			// TODO: abort current running queue?
-			queueWorker();
-		},
+	initChangeQueue({
+		lix: { db, plugin },
+		rawDatabase: args.database,
 	});
-
-	let pending: Promise<void> | undefined;
-	let resolve: () => void;
-	// run number counts the worker runs in a current batch and is used to prevent race conditions where a trigger is missed because a previous run is just about to reset the hasMoreEntriesSince flag
-	let runNumber = 1;
-	// If a queue trigger happens during an existing queue run we might miss updates and use hasMoreEntriesSince to make sure there is always a final immediate queue worker execution
-	let hasMoreEntriesSince: number | undefined = undefined;
-	async function queueWorker(trail = false) {
-		if (closed) {
-			return;
-		}
-		try {
-			if (pending && !trail) {
-				hasMoreEntriesSince = runNumber;
-				// console.log({ hasMoreEntriesSince });
-				return;
-			}
-			runNumber++;
-
-			if (!pending) {
-				pending = new Promise((res) => {
-					resolve = res;
-				});
-			}
-
-			const entry = await db
-				.selectFrom("change_queue")
-				.selectAll()
-				.orderBy("id asc")
-				.limit(1)
-				.executeTakeFirst();
-
-			if (entry) {
-				if (entry.data_before && entry.data_after) {
-					await handleFileChange({
-						queueEntry: entry,
-						before: {
-							id: entry.file_id,
-							path: entry.path,
-							metadata: null,
-							data: entry.data_before,
-							skip_change_extraction: null,
-						},
-						after: {
-							id: entry.file_id,
-							path: entry.path,
-							metadata: null,
-							data: entry.data_after,
-							skip_change_extraction: null,
-						},
-						plugins,
-						lix: {
-							db,
-							plugin,
-						},
-					});
-				} else if (!entry.data_before && entry.data_after) {
-					await handleFileInsert({
-						queueEntry: entry,
-						after: {
-							id: entry.file_id,
-							path: entry.path,
-							metadata: null,
-							// TODO Queue - handle deletion - until than this we have to bang here
-							data: entry.data_after,
-							skip_change_extraction: null,
-						},
-						plugins,
-						lix: {
-							db,
-							plugin,
-						},
-					});
-				} else if (entry.data_before && !entry.data_after) {
-					// TODO Queue - handle deletion - the current queue doesn't handle delete starting with feature parity
-					// await handleFileDelete({
-					// 	queueEntry: entry,
-					// before: {
-					// 	id: entry.file_id,
-					// 	path: entry.path,
-					// 	metadata: null,
-					// 	// TODO Queue - handle deletion - until than this we have to bang here
-					// 	data: entry.data_before,
-					// 	skip_change_extraction: null
-					// },
-					// 	plugins,
-					// 	lix: {
-					// 		db,
-					// 		plugin,
-					// 	},
-					// });
-				}
-			}
-
-			// console.log("getrting { numEntries }");
-
-			const { numEntries } = await db
-				.selectFrom("change_queue")
-				.select((eb) => eb.fn.count<number>("id").as("numEntries"))
-				.executeTakeFirstOrThrow();
-
-			// console.log({ numEntries });
-
-			if (
-				!hasMoreEntriesSince ||
-				(numEntries === 0 && hasMoreEntriesSince < runNumber)
-			) {
-				resolve!(); // TODO: fix type
-				pending = undefined;
-				hasMoreEntriesSince = undefined;
-				// console.log("resolving");
-			}
-
-			// TODO: handle endless tries on failing quee entries
-			// we either execute the queue immediately if we know there is more work or fall back to polling
-			setTimeout(() => queueWorker(true), hasMoreEntriesSince ? 0 : 1000);
-		} catch (e) {
-			// https://linear.app/opral/issue/LIXDK-102/re-visit-simplifying-the-change-queue-implementation
-
-			console.error(
-				"change queue failed (will remain so until rework of change queue): ",
-				e,
-			);
-		}
-	}
-
-	queueWorker();
-
-	async function settled() {
-		await pending;
-	}
 
 	return {
 		db,
-		settled,
 		toBlob: async () => {
-			await settled();
+			await changeQueueSettled({ lix: { db } });
 			return new Blob([contentFromDatabase(args.database)]);
 		},
 		plugin,
 		close: async () => {
 			closed = true;
-			await settled();
+			await changeQueueSettled({ lix: { db } });
 			args.database.close();
 			await db.destroy();
 		},
 	};
 }
-
-// // TODO register on behalf of apps or leave it up to every app?
-// //      - if every apps registers, components can be lazy loaded
-// async function registerDiffComponents(plugins: LixPlugin[]) {
-// 	for (const plugin of plugins) {
-// 		for (const type in plugin.diffComponent) {
-// 			const component = plugin.diffComponent[type]?.()
-// 			const name = "lix-plugin-" + plugin.key + "-diff-" + type
-// 			if (customElements.get(name) === undefined) {
-// 				// @ts-ignore
-// 				customElements.define(name, component)
-// 			}
-// 		}
-// 	}
-// }

--- a/packages/lix-sdk/src/plugin/apply-changes.test.ts
+++ b/packages/lix-sdk/src/plugin/apply-changes.test.ts
@@ -25,7 +25,6 @@ test("it applies the given changes", async () => {
 			id: "file1",
 			data: new TextEncoder().encode("initial-data"),
 			path: "mock-path",
-			skip_change_extraction: 1,
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();

--- a/packages/lix-sdk/src/plugin/apply-changes.ts
+++ b/packages/lix-sdk/src/plugin/apply-changes.ts
@@ -69,7 +69,7 @@ export async function applyChanges(args: {
 					// which is not duplicate tolerant
 					// yet. see https://linear.app/opral/issue/LIXDK-114/make-diff-and-change-generation-fault-tolerant
 					.updateTable("file")
-					.set({ data: fileData, $skip_change_queue: 1 })
+					.set({ data: fileData, $skip_change_queue: true })
 					.where("id", "=", fileId)
 					.execute();
 			}

--- a/packages/lix-sdk/src/plugin/apply-changes.ts
+++ b/packages/lix-sdk/src/plugin/apply-changes.ts
@@ -69,7 +69,7 @@ export async function applyChanges(args: {
 					// which is not duplicate tolerant
 					// yet. see https://linear.app/opral/issue/LIXDK-114/make-diff-and-change-generation-fault-tolerant
 					.updateTable("file")
-					.set({ data: fileData, skip_change_extraction: 1 })
+					.set({ data: fileData, $skip_change_queue: 1 })
 					.where("id", "=", fileId)
 					.execute();
 			}


### PR DESCRIPTION
**Context**

Follow up of https://github.com/opral/monorepo/pull/3212

**improvements**

- [x] pass before and after metadata state to detectChanges (in case the metadata changed)
- [x] rename flag to $skip_change_queue to convey special meaning with `$` 
- [x] LixFile type does not have the flag. apps won't get a type error.
- https://github.com/opral/lix-sdk/issues/52