### PR TITLE
introduce support for rollup virtual modules used by other vite-plugins

### DIFF
--- a/.changeset/swift-eels-crash.md
+++ b/.changeset/swift-eels-crash.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-unplugin": patch
+---
+
+Support for NULL character prefixed virtual modules

--- a/inlang/source-code/paraglide/paraglide-unplugin/src/index.ts
+++ b/inlang/source-code/paraglide/paraglide-unplugin/src/index.ts
@@ -160,6 +160,10 @@ export const paraglide = createUnplugin((config: UserConfig) => {
 			vite: {
 				apply: "build",
 				resolveId(id, importer) {
+					// if the id contains a null char ignore it since it should be a rollup virtual module
+                    // this helps support other vite plugins (like sentry) that make heavy use of these types of file-namings
+                    if (id.includes("\0"))
+                        return undefined;
 					// resolve relative imports inside the output directory
 					// the importer is alwazs normalized
 					if (importer?.startsWith(normalizedOutdir)) {

--- a/inlang/source-code/paraglide/paraglide-unplugin/src/index.ts
+++ b/inlang/source-code/paraglide/paraglide-unplugin/src/index.ts
@@ -161,9 +161,8 @@ export const paraglide = createUnplugin((config: UserConfig) => {
 				apply: "build",
 				resolveId(id, importer) {
 					// if the id contains a null char ignore it since it should be a rollup virtual module
-                    // this helps support other vite plugins (like sentry) that make heavy use of these types of file-namings
-                    if (id.includes("\0"))
-                        return undefined;
+					// this helps support other vite plugins (like sentry) that make heavy use of these types of file-namings
+					if (id.includes("\0")) return undefined
 					// resolve relative imports inside the output directory
 					// the importer is alwazs normalized
 					if (importer?.startsWith(normalizedOutdir)) {


### PR DESCRIPTION
The paraglide vite plugin resolves all files during the build process. If any filename contains a NULL character (like some vite/rollup virtual modules do) the paraglide-process doesn't check if the paths contains NULL characters.

> If your plugin uses 'virtual modules' (e.g. for helper functions), prefix the module ID with \0. This prevents other plugins from trying to process it. (https://rollupjs.org/plugin-development/#conventions)

Paraglide doesn't use virtual modules, but if other plugins use them paraglide inevitably will touch them. This PR will instruct the paraglide vite plugin to ignore any file, if the filename contains a NULL character.

resolves https://github.com/opral/inlang-paraglide-js/issues/192