### PR TITLE
minimal file path spec

### DIFF
--- a/packages/lix-sdk/src/change-conflict/resolve-conflict-by-selecting.test.ts
+++ b/packages/lix-sdk/src/change-conflict/resolve-conflict-by-selecting.test.ts
@@ -51,7 +51,7 @@ test("it should resolve a conflict and apply the changes", async () => {
 		.insertInto("file")
 		.values({
 			id: "mock",
-			path: "mock",
+			path: "/mock",
 			data: new Uint8Array(),
 		})
 		.execute();

--- a/packages/lix-sdk/src/change-queue/init-change-queue.test.ts
+++ b/packages/lix-sdk/src/change-queue/init-change-queue.test.ts
@@ -49,7 +49,7 @@ test("should use queue and settled correctly", async () => {
 	const dataInitial = enc.encode("insert text");
 	await lix.db
 		.insertInto("file")
-		.values({ id: "test", path: "test.txt", data: dataInitial })
+		.values({ id: "test", path: "/test.txt", data: dataInitial })
 		.execute();
 
 	const queue = await lix.db.selectFrom("change_queue").selectAll().execute();
@@ -58,7 +58,7 @@ test("should use queue and settled correctly", async () => {
 		expect.objectContaining({
 			id: 1,
 			file_id: "test",
-			path_after: "test.txt",
+			path_after: "/test.txt",
 			data_after: dataInitial,
 			data_before: null,
 		} satisfies Partial<ChangeQueueEntry>),
@@ -80,7 +80,7 @@ test("should use queue and settled correctly", async () => {
 		expect.objectContaining({
 			data: internalFilesAfter[0]!.data,
 			id: "test",
-			path: "test.txt",
+			path: "/test.txt",
 			metadata: null,
 		}) satisfies LixFile,
 	]);
@@ -151,7 +151,7 @@ test("should use queue and settled correctly", async () => {
 		expect.objectContaining({
 			id: 3,
 			file_id: "test",
-			path_after: "test.txt",
+			path_after: "/test.txt",
 			metadata_after: null,
 			data_before: dataUpdate1,
 			data_after: dataUpdate2,
@@ -159,7 +159,7 @@ test("should use queue and settled correctly", async () => {
 		expect.objectContaining({
 			id: 4,
 			file_id: "test",
-			path_after: "test.txt",
+			path_after: "/test.txt",
 			metadata_after: null,
 			data_before: dataUpdate2,
 			data_after: dataUpdate3,

--- a/packages/lix-sdk/src/change-queue/with-skip-change-queue.test.ts
+++ b/packages/lix-sdk/src/change-queue/with-skip-change-queue.test.ts
@@ -34,7 +34,7 @@ test("skipping the change queue should be possible", async () => {
 		.values({
 			id: "test",
 			data: new TextEncoder().encode("update0"),
-			path: "test.txt",
+			path: "/test.txt",
 		})
 		.execute();
 
@@ -102,7 +102,7 @@ test("skipping the change queue should be possible with multiple changes", async
 		.values({
 			id: "test",
 			data: new TextEncoder().encode("initial"),
-			path: "test.txt",
+			path: "/test.txt",
 		})
 		.execute();
 

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -16,7 +16,9 @@ export async function applySchema(args: {
     id TEXT PRIMARY KEY DEFAULT (uuid_v7()),
     path TEXT NOT NULL UNIQUE,
     data BLOB NOT NULL,
-    metadata TEXT
+    metadata TEXT,
+
+    CHECK (is_valid_file_path(path))
   ) WITHOUT ROWID, STRICT;
 
   -- TODO Queue - handle deletion - the current queue doesn't handle delete starting with feature parity

--- a/packages/lix-sdk/src/database/init-db.ts
+++ b/packages/lix-sdk/src/database/init-db.ts
@@ -5,6 +5,7 @@ import { SerializeJsonPlugin } from "./serialize-json-plugin.js";
 import type { LixDatabaseSchema } from "./schema.js";
 import { applySchema } from "./apply-schema.js";
 import { sha256 } from "js-sha256";
+import { validateFilePath } from "../file/validate-file-path.js";
 
 export function initDb(args: {
 	sqlite: SqliteDatabase;
@@ -32,6 +33,15 @@ function initFunctions(args: { sqlite: SqliteDatabase }) {
 		arity: 1,
 		xFunc: (_ctx: number, value) => {
 			return value ? sha256(value as string) : "no-content";
+		},
+		deterministic: true,
+	});
+
+	args.sqlite.createFunction({
+		name: "is_valid_file_path",
+		arity: 1,
+		xFunc: (_ctx: number, value) => {
+			return validateFilePath(value as string) as unknown as string;
 		},
 		deterministic: true,
 	});

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -49,6 +49,15 @@ export type NewLixFile = Insertable<LixFileTable>;
 export type LixFileUpdate = Updateable<LixFileTable>;
 type LixFileTable = {
 	id: Generated<string>;
+	/**
+	 * The path of the file.
+	 *
+	 * The path is currently defined as a subset of RFC 3986.
+	 * Any path can be tested with the `isValidFilePath()` function.
+	 *
+	 * @example
+	 *   - `/path/to/file.txt`
+	 */
 	path: string;
 	data: ArrayBuffer;
 	metadata: Record<string, any> | null;

--- a/packages/lix-sdk/src/discussion/create-discussion.test.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.test.ts
@@ -35,7 +35,7 @@ test("should be able to start a discussion on changes", async () => {
 
 	await lix.db
 		.insertInto("file")
-		.values({ id: "test", path: "test.txt", data: enc.encode("test") })
+		.values({ id: "test", path: "/test.txt", data: enc.encode("test") })
 		.execute();
 
 	await changeQueueSettled({ lix });

--- a/packages/lix-sdk/src/file/index.ts
+++ b/packages/lix-sdk/src/file/index.ts
@@ -1,0 +1,1 @@
+export { validateFilePath, isValidFilePath } from "./validate-file-path.js";

--- a/packages/lix-sdk/src/file/validate-file-path.test.ts
+++ b/packages/lix-sdk/src/file/validate-file-path.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "vitest";
+import { isValidFilePath } from "./validate-file-path.js";
+
+test("valid cases", () => {
+	const validCases = [
+		"/path/to/file",
+		"/path/to/file/with/multiple/segments",
+		"/path/to/file.with.dots",
+		"/path/to/file-with-hyphens_and_underscores",
+		"/path/with-file-extension.txt",
+	];
+
+	for (const validCase of validCases) {
+		expect(isValidFilePath(validCase)).toBe(true);
+		// testing for RFC 3986 URI
+		expect(URL.canParse(`file://${validCase}`)).toBe(true);
+	}
+});
+
+// invalid cases
+
+test("an empty path should be invalid", () => {
+	expect(isValidFilePath("")).toBe(false);
+});
+
+test("a path that contains only a slash should be invalid", () => {
+	expect(isValidFilePath("/")).toBe(false);
+});
+
+test("a path that does not start with a slash should be invalid", () => {
+	expect(isValidFilePath("path/to/file")).toBe(false);
+});
+
+test("a path that ends with a slash should be invalid", () => {
+	expect(isValidFilePath("/path/to/file/")).toBe(false);
+});
+
+test("a path that contains consecutive slashes should be invalid", () => {
+	expect(isValidFilePath("/path//to/file")).toBe(false);
+});
+
+test("a path that contains backslashes should be invalid", () => {
+	expect(isValidFilePath("/path\\to\\file")).toBe(false);
+});

--- a/packages/lix-sdk/src/file/validate-file-path.ts
+++ b/packages/lix-sdk/src/file/validate-file-path.ts
@@ -18,7 +18,7 @@ export function validateFilePath(path: string): void {
 
 	if (path[0] !== "/") {
 		throw new Error(
-			"File path must start with a slash\n\nOtherwise a path might be considered as relative.",
+			"File path must start with a slash.\n\nNot starting a file path with a slash `/` leads to ambiguity whether or not the path is a directory or a file.",
 		);
 	}
 

--- a/packages/lix-sdk/src/file/validate-file-path.ts
+++ b/packages/lix-sdk/src/file/validate-file-path.ts
@@ -1,0 +1,60 @@
+/**
+ * Idea is to have a minimal spec that can be extended over time.
+ *
+ * Every valid file path must also be a valid RFC 3986 URI.
+ */
+
+/**
+ * Validates a file path.
+ *
+ * @throws {Error} If the file path is invalid.
+ */
+export function validateFilePath(path: string): void {
+	// validate beginning
+
+	if (path.length === 0) {
+		throw new Error("File path must not be empty.");
+	}
+
+	if (path[0] !== "/") {
+		throw new Error(
+			"File path must start with a slash\n\nOtherwise a path might be considered as relative.",
+		);
+	}
+
+	// validate middle
+
+	// validate ending
+
+	if (path.endsWith("/")) {
+		throw new Error(
+			"File path must not end with a slash.\n\nEnding a file with a slash leads to ambiguity whether or not the path is a directory or a file.",
+		);
+	}
+
+	// validate general
+
+	if (path.includes("//")) {
+		throw new Error(
+			"File path must not contain consecutive slashes.\n\nConsecutive slashes lead to ambiguity whether or not the path is a directory or a file.",
+		);
+	}
+
+	if (path.includes("\\")) {
+		throw new Error(
+			"File path must not contain backslashes.\n\nThe restriction might be loosened in the future.",
+		);
+	}
+}
+
+/**
+ *
+ */
+export function isValidFilePath(path: string): boolean {
+	try {
+		validateFilePath(path);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/lix-sdk/src/index.ts
+++ b/packages/lix-sdk/src/index.ts
@@ -5,6 +5,7 @@ export * from "./change-queue/index.js";
 export * from "./change-schema/index.js";
 export * from "./database/index.js";
 export * from "./discussion/index.js";
+export * from "./file/index.js";
 export * from "./lix/index.js";
 export * from "./plugin/index.js";
 export * from "./query-filter/index.js";

--- a/packages/lix-sdk/src/lix/merge.test.ts
+++ b/packages/lix-sdk/src/lix/merge.test.ts
@@ -618,7 +618,7 @@ test("it should naively copy changes from the sourceLix into the targetLix that 
 
 	await targetLix.db
 		.insertInto("file")
-		.values({ id: "mock-file", path: "", data: new Uint8Array() })
+		.values({ id: "mock-file", path: "/mock", data: new Uint8Array() })
 		.execute();
 
 	await sourceLix.db
@@ -672,7 +672,11 @@ test("it should copy discussion and related comments and mappings", async () => 
 
 	await lix1.db
 		.insertInto("file")
-		.values({ id: "test", path: "test.txt", data: enc.encode("inserted text") })
+		.values({
+			id: "test",
+			path: "/test.txt",
+			data: enc.encode("inserted text"),
+		})
 		.execute();
 
 	await changeQueueSettled({ lix: lix1 });

--- a/packages/lix-sdk/src/lix/open-lix-in-memory.test.ts
+++ b/packages/lix-sdk/src/lix/open-lix-in-memory.test.ts
@@ -14,7 +14,7 @@ test("it should open a lix in memory from a blob", async () => {
 		.insertInto("file")
 		.values({
 			id: "1",
-			path: "a.txt",
+			path: "/a.txt",
 			data: new TextEncoder().encode("hello"),
 		})
 		.execute();
@@ -23,7 +23,7 @@ test("it should open a lix in memory from a blob", async () => {
 	expect(files).toEqual([
 		expect.objectContaining({
 			id: "1",
-			path: "a.txt",
+			path: "/a.txt",
 			data: new TextEncoder().encode("hello"),
 		}),
 	]);

--- a/packages/lix-sdk/src/plugin/apply-changes.test.ts
+++ b/packages/lix-sdk/src/plugin/apply-changes.test.ts
@@ -24,7 +24,7 @@ test("it applies the given changes", async () => {
 		.values({
 			id: "file1",
 			data: new TextEncoder().encode("initial-data"),
-			path: "mock-path",
+			path: "/mock-path",
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
@@ -66,7 +66,7 @@ test("applyChanges throws an error if plugin does not exist", async () => {
 		.values({
 			id: "file1",
 			data: new TextEncoder().encode("initial-data"),
-			path: "mock-path",
+			path: "/mock-path",
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
@@ -105,7 +105,7 @@ test("applyChanges throws an error if plugin does not support applying changes",
 		.values({
 			id: "file1",
 			data: new TextEncoder().encode("initial-data"),
-			path: "mock-path",
+			path: "/mock-path",
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();

--- a/packages/lix-sdk/src/version/merge-version.test.ts
+++ b/packages/lix-sdk/src/version/merge-version.test.ts
@@ -411,7 +411,7 @@ test("re-curring merges should not create a new conflict if the conflict already
 		.insertInto("file")
 		.values({
 			id: "mock",
-			path: "mock",
+			path: "/mock",
 			data: new Uint8Array(),
 		})
 		.execute();


### PR DESCRIPTION
Minimal file path spec that: 

- is a subset of RFC 3896
- only allowing forward slashes
- no relative paths
- no ambigious directory situations e.g. `/hello//` or `/hello/some/` is `some` a file or directory?