### PR TITLE
add key value table

### DIFF
--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -1,5 +1,6 @@
 import type { SqliteDatabase } from "sqlite-wasm-kysely";
 import { applyAccountDatabaseSchema } from "../account/database-schema.js";
+import { applyKeyValueDatabaseSchema } from "../key-value/database-schema.js";
 
 /**
  * Applies the database schema to the given sqlite database.
@@ -8,6 +9,7 @@ export async function applySchema(args: {
 	sqlite: SqliteDatabase;
 }): Promise<unknown> {
 	applyAccountDatabaseSchema(args.sqlite);
+	applyKeyValueDatabaseSchema(args.sqlite);
 
 	return args.sqlite.exec`
 

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -3,6 +3,7 @@ import type {
 	AccountTable,
 	ActiveAccountTable,
 } from "../account/database-schema.js";
+import type { KeyValueTable } from "../key-value/database-schema.js";
 
 export type LixDatabaseSchema = {
 	// account
@@ -27,6 +28,9 @@ export type LixDatabaseSchema = {
 	change_set_element: ChangeSetElementTable;
 	change_set_label: ChangeSetLabelTable;
 	change_set_label_author: ChangeSetLabelAuthorTable;
+
+	// key value
+	key_value: KeyValueTable;
 
 	// discussion
 	discussion: DiscussionTable;

--- a/packages/lix-sdk/src/key-value/database-schema.test.ts
+++ b/packages/lix-sdk/src/key-value/database-schema.test.ts
@@ -1,0 +1,134 @@
+import { Kysely, sql } from "kysely";
+import { createDialect, createInMemoryDatabase } from "sqlite-wasm-kysely";
+import { expect, test } from "vitest";
+import {
+	applyKeyValueDatabaseSchema,
+	type KeyValueTable,
+} from "./database-schema.js";
+
+test("string values are accepted", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+
+	applyKeyValueDatabaseSchema(sqlite);
+
+	const db = new Kysely<{
+		key_value: KeyValueTable;
+	}>({
+		dialect: createDialect({
+			database: sqlite,
+		}),
+	});
+
+	const result = await db
+		.insertInto("key_value")
+		.values({
+			key: "foo",
+			value: "bar",
+		})
+		.returningAll()
+		.execute();
+
+	expect(result).toMatchObject([
+		{
+			key: "foo",
+			value: "bar",
+		},
+	]);
+});
+
+test("duplicate keys lead to an error", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+
+	applyKeyValueDatabaseSchema(sqlite);
+
+	const db = new Kysely<{
+		key_value: KeyValueTable;
+	}>({
+		dialect: createDialect({
+			database: sqlite,
+		}),
+	});
+
+	await db
+		.insertInto("key_value")
+		.values({
+			key: "foo",
+			value: "bar",
+		})
+		.returningAll()
+		.execute();
+
+	expect(
+		db
+			.insertInto("key_value")
+			.values({
+				key: "foo",
+				value: "bar",
+			})
+			.returningAll()
+			.execute(),
+	).rejects.toThrowErrorMatchingInlineSnapshot(
+		`[SQLite3Error: SQLITE_CONSTRAINT_PRIMARYKEY: sqlite3 result code 1555: UNIQUE constraint failed: key_value.key]`,
+	);
+});
+
+test("using json as value should work", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+
+	applyKeyValueDatabaseSchema(sqlite);
+
+	const db = new Kysely<{
+		key_value: KeyValueTable;
+	}>({
+		dialect: createDialect({
+			database: sqlite,
+		}),
+	});
+
+	await db
+		.insertInto("key_value")
+		.values([
+			{
+				key: "foo",
+				value: JSON.stringify({
+					bar: "baz",
+					age: 42,
+					location: "Berlin",
+				}),
+			},
+		])
+		.returningAll()
+		.execute();
+
+	const onlyOneProperty = await db
+		.selectFrom("key_value")
+		.where("key", "=", "foo")
+		.select(sql`json_extract(value, '$.bar')`.as("bar"))
+		.executeTakeFirstOrThrow();
+
+	// The JSON parsing plugin needs improvements.
+	// not important for now
+	// const parsedAsJson = await db
+	// 	.selectFrom("key_value")
+	// 	.where("key", "=", "foo")
+	// 	.select(sql`json(value)`.as("value"))
+	// 	.executeTakeFirstOrThrow();
+
+	// expect(parsedAsJson).toMatchObject({
+	// 	value: {
+	// 		bar: "baz",
+	// 		age: 42,
+	// 		location: "Berlin",
+	// 	},
+	// });
+
+	expect(onlyOneProperty).toMatchObject({
+		bar: "baz",
+	});
+});

--- a/packages/lix-sdk/src/key-value/database-schema.ts
+++ b/packages/lix-sdk/src/key-value/database-schema.ts
@@ -16,6 +16,31 @@ export type KeyValue = Selectable<KeyValueTable>;
 export type NewKeyValue = Insertable<KeyValueTable>;
 export type KeyValueUpdate = Updateable<KeyValueTable>;
 export type KeyValueTable = {
-	key: string;
+	/**
+	 * The key of the key-value pair.
+	 *
+	 * Lix prefixes its keys with "lix-" to avoid conflicts with user-defined keys.
+	 *
+	 * @example
+	 *   "namespace-cool-key"
+	 */
+	key: KeyValueKeys;
+	/**
+	 * The value of the key-value pair.
+	 *
+	 * Must be a string. A JSON is a string too ;)
+	 *
+	 * @example
+	 *   "some value"
+	 *   "{ "foo": "bar" }"
+	 *
+	 */
 	value: string;
 };
+
+
+type PredefinedKeys = `lix-${string}`;
+// The string & {} ensures TypeScript recognizes KeyValueKeys
+// as a superset of string, preventing conflicts when using other string values.
+type KeyType = string & {};
+type KeyValueKeys = PredefinedKeys | KeyType;

--- a/packages/lix-sdk/src/key-value/database-schema.ts
+++ b/packages/lix-sdk/src/key-value/database-schema.ts
@@ -1,0 +1,21 @@
+import type { Insertable, Selectable, Updateable } from "kysely";
+import type { SqliteDatabase } from "sqlite-wasm-kysely";
+
+export function applyKeyValueDatabaseSchema(
+	sqlite: SqliteDatabase,
+): SqliteDatabase {
+	return sqlite.exec`
+  CREATE TABLE IF NOT EXISTS key_value (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  ) STRICT;
+`;
+}
+
+export type KeyValue = Selectable<KeyValueTable>;
+export type NewKeyValue = Insertable<KeyValueTable>;
+export type KeyValueUpdate = Updateable<KeyValueTable>;
+export type KeyValueTable = {
+	key: string;
+	value: string;
+};


### PR DESCRIPTION
Adds a key value table that can be used to persist variables like the lix-id (https://github.com/opral/lix-sdk/issues/148). 

Closes https://github.com/opral/lix-sdk/issues/149

```ts
const value = await db
		.selectFrom("key_value")
		.where("key", "=", "lix-id")
                .select('value')
		.executeTakeFirstOrThrow();


```