### PR TITLE
add id's to lix

### DIFF
--- a/packages/lix-sdk/src/database/init-db.ts
+++ b/packages/lix-sdk/src/database/init-db.ts
@@ -1,6 +1,6 @@
 import { Kysely } from "kysely";
 import { createDialect, type SqliteDatabase } from "sqlite-wasm-kysely";
-import { v7 as uuid_v7 } from "uuid";
+import { v7 as uuid_v7, v4 as uuid_v4 } from "uuid";
 import type { LixDatabaseSchema } from "./schema.js";
 import { applySchema } from "./apply-schema.js";
 import { validateFilePath } from "../file/validate-file-path.js";
@@ -35,6 +35,12 @@ function initFunctions(args: { sqlite: SqliteDatabase }) {
 		name: "uuid_v7",
 		arity: 0,
 		xFunc: () => uuid_v7(),
+	});
+
+	args.sqlite.createFunction({
+		name: "uuid_v4",
+		arity: 0,
+		xFunc: () => uuid_v4(),
 	});
 
 	args.sqlite.createFunction({

--- a/packages/lix-sdk/src/key-value/database-schema.ts
+++ b/packages/lix-sdk/src/key-value/database-schema.ts
@@ -9,6 +9,9 @@ export function applyKeyValueDatabaseSchema(
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
   ) STRICT;
+
+  INSERT OR IGNORE INTO key_value (key, value)
+  VALUES ('lix-id', uuid_v4());
 `;
 }
 
@@ -38,8 +41,7 @@ export type KeyValueTable = {
 	value: string;
 };
 
-
-type PredefinedKeys = `lix-${string}`;
+type PredefinedKeys = "lix-id";
 // The string & {} ensures TypeScript recognizes KeyValueKeys
 // as a superset of string, preventing conflicts when using other string values.
 type KeyType = string & {};


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/148. 

Adds ids to lix. 

```ts

const id = await lix.db
		.selectFrom("key_value")
		.where("key", "=", "lix-id")
		.selectAll()
		.executeTakeFirstOrThrow();

id.value
```