### PR TITLE
query against server

### DIFF
--- a/packages/lix-sdk/examples/server-protocol-handler-hono/src/main.ts
+++ b/packages/lix-sdk/examples/server-protocol-handler-hono/src/main.ts
@@ -8,8 +8,6 @@ const lspHandler = await createLspHandler({
 	storage: createLspHandlerMemoryStorage(),
 });
 
-app.get("/", (c) => c.text("Hono!"));
-
 // @ts-expect-error - Hono provides a subset of the Request object
 app.use("/lsp/*", (c) => lspHandler(c.req));
 

--- a/packages/lix-sdk/src/experimental/sync/kysely-sync-plugin.test.ts
+++ b/packages/lix-sdk/src/experimental/sync/kysely-sync-plugin.test.ts
@@ -1,0 +1,64 @@
+import { Kysely, sql } from "kysely";
+import { createDialect, createInMemoryDatabase } from "sqlite-wasm-kysely";
+import { expect, test, vi } from "vitest";
+import { SyncPlugin } from "./kysely-sync-plugin.js";
+import type { paths } from "@lix-js/server-protocol";
+
+test("select queries execute against the server", async () => {
+	const database = await createInMemoryDatabase({ readOnly: false });
+
+	const db = new Kysely<any>({
+		dialect: createDialect({
+			database,
+		}),
+		plugins: [SyncPlugin()],
+	});
+
+	// mock the fetch function and simulate a lsp response
+	global.fetch = vi.fn(
+		async () =>
+			new Response(
+				JSON.stringify({
+					// server has two rows
+					rows: [{ id: 1 }, { id: 2 }],
+					num_affected_rows: 2,
+				} satisfies paths["/lsp/lix/{id}/query"]["post"]["responses"]["200"]["content"]["application/json"]),
+				{ status: 200 },
+			),
+	);
+
+	await sql`CREATE TABLE mock_table (id INTEGER PRIMARY KEY);`.execute(db);
+	// client has only 1 row
+	await sql`INSERT INTO mock_table (id) VALUES (1);`.execute(db);
+
+	const result = await db.selectFrom("mock_table").selectAll().execute();
+
+	expect(global.fetch).toHaveBeenCalledOnce();
+	expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+});
+
+test("if the remote query failed, the local query should be returned as fallback", async () => {
+	const database = await createInMemoryDatabase({ readOnly: false });
+
+	const db = new Kysely<any>({
+		dialect: createDialect({
+			database,
+		}),
+		plugins: [SyncPlugin()],
+	});
+
+	// mock the fetch function and simulate a lsp response
+	global.fetch = vi.fn(async () => {
+		throw new Error("Failed to execute query against server.");
+	});
+
+	await sql`CREATE TABLE mock_table (id INTEGER PRIMARY KEY);`.execute(db);
+	// client has 1 row
+	await sql`INSERT INTO mock_table (id) VALUES (1);`.execute(db);
+
+	const result = await db.selectFrom("mock_table").selectAll().execute();
+
+	expect(global.fetch).toHaveBeenCalledOnce();
+	// fallback to local query
+	expect(result).toEqual([{ id: 1 }]);
+});

--- a/packages/lix-sdk/src/experimental/sync/kysely-sync-plugin.ts
+++ b/packages/lix-sdk/src/experimental/sync/kysely-sync-plugin.ts
@@ -1,0 +1,58 @@
+import {
+	SelectQueryNode,
+	CompiledQuery,
+	type KyselyPlugin,
+	type PluginTransformQueryArgs,
+} from "kysely";
+
+type QueryId = PluginTransformQueryArgs["queryId"];
+
+export function SyncPlugin(): KyselyPlugin {
+	const selectQueries = new WeakMap<QueryId, SelectQueryNode>();
+
+	return {
+		async transformResult({ queryId, result }) {
+			if (selectQueries.has(queryId) === false) {
+				return result;
+			}
+			let remoteResult;
+			try {
+				remoteResult = await executeRemoteQuery(
+					"http://localhost:3000",
+					CompiledQuery.raw(`SELECT * FROM change;`),
+				);
+			} catch {
+				return result;
+			}
+			return remoteResult;
+		},
+		transformQuery({ queryId, node }) {
+			if (node.kind === "SelectQueryNode") {
+				selectQueries.set(queryId, node);
+			}
+			return node;
+		},
+	};
+}
+
+async function executeRemoteQuery(
+	serverUrl: string,
+	compiledQuery: CompiledQuery,
+) {
+	const { sql, parameters } = compiledQuery;
+
+	const response = await fetch(`${serverUrl}/lsp/lix/{mock-lix-id}/query`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ sql, parameters }),
+	});
+
+	if (!response.ok) {
+		console.error("Error executing remote query:", await response.text());
+		throw new Error("Failed to execute query against server.");
+	}
+
+	return response.json();
+}


### PR DESCRIPTION
adds a sync plugin that executes select queries against the server. 

todos:

- [ ] no hardcoded variables
- [ ] compile query on client (need to pass db)

part of https://github.com/opral/lix-sdk/issues/147



