### PR TITLE
fix: handle undefined document in ClientLanguageProvider for language tag retrieval

### DIFF
--- a/inlang/source-code/paraglide/paraglide-next/src/app/providers/ClientLanguageProvider.tsx
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/providers/ClientLanguageProvider.tsx
@@ -3,6 +3,7 @@ import { isAvailableLanguageTag, setLanguageTag, sourceLanguageTag } from "$para
 
 // needed for messages in module-scope code
 setLanguageTag(() => {
+    if (typeof document === "undefined") return sourceLanguageTag
 	const documentLang = document.documentElement.lang
 	return isAvailableLanguageTag(documentLang) ? documentLang : sourceLanguageTag
 })

--- a/inlang/source-code/paraglide/paraglide-next/src/app/providers/ClientLanguageProvider.tsx
+++ b/inlang/source-code/paraglide/paraglide-next/src/app/providers/ClientLanguageProvider.tsx
@@ -3,7 +3,9 @@ import { isAvailableLanguageTag, setLanguageTag, sourceLanguageTag } from "$para
 
 // needed for messages in module-scope code
 setLanguageTag(() => {
-    if (typeof document === "undefined") return sourceLanguageTag
+	// in case it's run on the server during build, 
+	// just return the source language tag
+  if (typeof document === "undefined") return sourceLanguageTag
 	const documentLang = document.documentElement.lang
 	return isAvailableLanguageTag(documentLang) ? documentLang : sourceLanguageTag
 })


### PR DESCRIPTION
As nextjs always renders on the server the first time (even with use client). We need to handle the case where the document is undefined.

Here is the error I was getting
```
 ✓ Compiled in 390ms
 ✓ Compiled / in 248ms
 GET /fr 200 in 903ms
 GET /fr 200 in 743ms
 ✓ Compiled in 100ms
 ✓ Compiled / in 117ms
 ⨯ ReferenceError: document is not defined
    at ...\.next\server\chunks\ssr\node_modules_978451._.js:16:26
    at ...\.next\server\chunks\ssr\[root of the server]__caa35e._.js:41:21   
    at ...\.next\server\chunks\ssr\node_modules_a82922._.js:15810:197        
    at ...\.next\server\chunks\ssr\node_modules_a82922._.js:15818:42
    at Header (...\.next\server\chunks\ssr\[root of the server]__246963._.js:843:145)
digest: "2480015981"
```
I already talked to @samuelstroschein about this. https://discord.com/channels/897438559458430986/1083724234142011392/1313286246067339274
