### PR TITLE
add `executeSync()`

### DIFF
--- a/packages/lix-sdk/src/database/execute-sync.test.ts
+++ b/packages/lix-sdk/src/database/execute-sync.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "vitest";
+import { openLixInMemory } from "../lix/open-lix-in-memory.js";
+import { executeSync } from "./execute-sync.js";
+import type { Lix } from "../lix/open-lix.js";
+import { mockChange } from "../change/mock-change.js";
+import type { LixFile } from "./schema.js";
+import { sql } from "kysely";
+
+test("executeSync yields the same result as async execute for an insert", async () => {
+	const lix1 = await openLixInMemory({});
+	const lix2 = await openLixInMemory({});
+
+	const query = (lix: Lix) =>
+		lix.db
+			.insertInto("key_value")
+			.values({ key: "foo", value: "bar" })
+			.returningAll();
+
+	const result = executeSync({ lix: lix1, query: query(lix1) });
+	const result2 = await query(lix2).execute();
+
+	expect(result).toEqual(result2);
+});
+
+test("handles joins", async () => {
+	const lix = await openLixInMemory({});
+
+	const mockFile0: LixFile = {
+		id: "file-0",
+		path: "/file-0",
+		data: new ArrayBuffer(0),
+		metadata: {},
+	};
+	const mockChange0 = mockChange({ id: "change-0", file_id: "file-0" });
+
+	await lix.db.insertInto("change").values(mockChange0).execute();
+	await lix.db.insertInto("file").values(mockFile0).execute();
+
+	const query = lix.db
+		.selectFrom("file")
+		.innerJoin("change", "change.file_id", "file.id")
+		.where("file.id", "=", "file-0")
+		.selectAll("change")
+		.select("file.path as file_path");
+
+	const result = executeSync({ lix, query });
+	const result2 = await query.execute();
+
+	expect(result).toEqual(result2);
+});
+
+test("does not transform the query or results (json parsing)", async () => {
+	const lix1 = await openLixInMemory({});
+	const lix2 = await openLixInMemory({});
+
+	const mockFile0: LixFile = {
+		id: "file-0",
+		path: "/file-0",
+		data: new ArrayBuffer(0),
+		metadata: {
+			foo: "bar",
+		},
+	};
+
+	const insertQuery = (lix: Lix) =>
+		lix.db.insertInto("file").values(mockFile0).returningAll();
+
+	const result1 = await insertQuery(lix1).execute();
+	const result2 = executeSync({ lix: lix2, query: insertQuery(lix2) });
+
+	expect(result1).not.toEqual(result2);
+
+	const withManualJson = executeSync({
+		lix: lix2,
+		query: lix2.db
+			.selectFrom("file")
+			.selectAll()
+			.select(sql`json(metadata)`.as("metadata")),
+	});
+
+	for (const row of withManualJson) {
+		row.metadata = JSON.parse(row.metadata as string);
+	}
+
+	expect(result1).toEqual(withManualJson);
+});
+
+// important for function like `createQuery` which are used in triggers and need to be sync
+// but are also used by users where the API is async
+test("using executeSync with a 'fake async' function should work", async () => {
+	const lix = await openLixInMemory({});
+
+	async function fakeAyncQuery(lix: Lix): Promise<any> {
+		const query = lix.db
+			.insertInto("key_value")
+			.values({ key: "foo", value: "bar" })
+			.returningAll();
+		return executeSync({ lix, query }) as any;
+	}
+
+	const result = await fakeAyncQuery(lix);
+
+	expect(result).toEqual([{ key: "foo", value: "bar" }]);
+});

--- a/packages/lix-sdk/src/database/execute-sync.ts
+++ b/packages/lix-sdk/src/database/execute-sync.ts
@@ -1,0 +1,36 @@
+import type { Lix } from "../lix/open-lix.js";
+
+/**
+ * Execute a query synchronously.
+ *
+ * WARNING: This function is not recommended for general use.
+ * Only if you need sync queries, like in a trigger for exmaple,
+ * you should use this function. The function is not transforming
+ * the query or the result as the db API does. You get raw SQL.
+ *
+ * @example
+ *   const query = lix.db.selectFrom("key_value").selectAll();
+ *   const result = executeSync({ lix, query }) as KeyValue[];
+ */
+export function executeSync(args: { lix: Lix; query: any }): Array<any> {
+	const compiledQuery = args.query.compile();
+
+	const columnNames: string[] = [];
+
+	const result = args.lix.sqlite.exec({
+		sql: compiledQuery.sql,
+		bind: compiledQuery.parameters as any[],
+		returnValue: "resultRows",
+		columnNames,
+	});
+
+	return result.map((row) => {
+		const obj: any = {};
+
+		columnNames.forEach((columnName, index) => {
+			obj[columnName] = row[index];
+		});
+
+		return obj;
+	});
+}

--- a/packages/lix-sdk/src/database/index.ts
+++ b/packages/lix-sdk/src/database/index.ts
@@ -1,3 +1,4 @@
 export * from "./schema.js";
 export { jsonObjectFrom, jsonArrayFrom } from "kysely/helpers/sqlite";
 export { sql } from "kysely";
+export { executeSync } from "./execute-sync.js";

--- a/packages/lix-sdk/src/lix/open-lix.ts
+++ b/packages/lix-sdk/src/lix/open-lix.ts
@@ -9,6 +9,17 @@ import type { LixDatabaseSchema } from "../database/schema.js";
 import { initSyncProcess } from "../sync/init-sync-process.js";
 
 export type Lix = {
+	/**
+	 * The raw SQLite instance.
+	 *
+	 * Required for advanced use cases that can't be
+	 * expressed with the db API.
+	 *
+	 * Use with caution, automatic transformation of
+	 * results like parsing json (similar to the db API)
+	 * is not guaranteed.
+	 */
+	sqlite: SqliteDatabase;
 	db: Kysely<LixDatabaseSchema>;
 	toBlob: () => Promise<Blob>;
 	plugin: {
@@ -68,6 +79,7 @@ export async function openLix(args: {
 
 	return {
 		db,
+		sqlite: args.database,
 		toBlob: async () => {
 			await changeQueueSettled({ lix: { db } });
 			return new Blob([contentFromDatabase(args.database)]);


### PR DESCRIPTION
required for triggers. closes https://github.com/opral/lix-sdk/issues/170

went with a functional approach over monkey patching kysely or an upstream pr. benefits include: 

1. it works
2. no monkey patching maintenance in the long run
3. its really simple (easy to maintain)


https://github.com/user-attachments/assets/ffa93fd8-0a70-401c-9553-8088bb0b27a7

