### PR TITLE
own change control for version changes

### DIFF
--- a/packages/lix-sdk/src/change/create-change.test.ts
+++ b/packages/lix-sdk/src/change/create-change.test.ts
@@ -257,3 +257,40 @@ test("should throw an error if authors array is empty", async () => {
 		})
 	).rejects.toThrow("At least one author is required");
 });
+
+test("option to create a change without updating the version changes", async () => {
+	const lix = await openLixInMemory({});
+
+	const version0 = await createVersion({ lix, name: "version0" });
+
+	const author = await createAccount({
+		lix,
+		name: "author",
+	});
+
+	const change = await createChange(
+		{
+			lix,
+			version: version0,
+			authors: [author],
+			entityId: "entity1",
+			fileId: "file1",
+			pluginKey: "plugin1",
+			schemaKey: "schema1",
+			snapshotContent: { text: "snapshot-content" },
+		},
+		{
+			updateVersionChanges: false,
+		}
+	);
+
+	const versionChanges = await lix.db
+		.selectFrom("version_change")
+		.where("version_change.version_id", "=", version0.id)
+		.selectAll()
+		.execute();
+
+	expect(
+		versionChanges.find((vc) => vc.change_id === change.id)
+	).toBeUndefined();
+});

--- a/packages/lix-sdk/src/change/create-change.ts
+++ b/packages/lix-sdk/src/change/create-change.ts
@@ -12,16 +12,31 @@ import { updateChangesInVersion } from "../version/update-changes-in-version.js"
  * Use this function to directly create a change from a lix app
  * with bypassing of file-based change detection.
  */
-export async function createChange(args: {
-	lix: Pick<Lix, "db" | "sqlite">;
-	authors: Array<Pick<Account, "id">>;
-	version: Pick<Version, "id">;
-	entityId: Change["entity_id"];
-	fileId: Change["file_id"];
-	pluginKey: Change["plugin_key"];
-	schemaKey: Change["schema_key"];
-	snapshotContent: Snapshot["content"];
-}): Promise<Change> {
+export async function createChange(
+	args: {
+		lix: Pick<Lix, "db" | "sqlite">;
+		authors: Array<Pick<Account, "id">>;
+		version: Pick<Version, "id">;
+		entityId: Change["entity_id"];
+		fileId: Change["file_id"];
+		pluginKey: Change["plugin_key"];
+		schemaKey: Change["schema_key"];
+		snapshotContent: Snapshot["content"];
+	},
+	options?: {
+		/**
+		 * When true, the version changes will be updated.
+		 *
+		 * Defaults to true.
+		 */
+		updateVersionChanges?: boolean;
+	}
+): Promise<Change> {
+	const optionsWithDefaults = {
+		updateVersionChanges: true,
+		...options,
+	};
+
 	if (args.authors.length === 0) {
 		throw new Error("At least one author is required");
 	}
@@ -96,11 +111,13 @@ export async function createChange(args: {
 	}
 
 	// update the version with the new change
-	updateChangesInVersion({
-		lix: { ...args.lix },
-		changes: [change],
-		version: args.version,
-	});
+	if (optionsWithDefaults.updateVersionChanges) {
+		updateChangesInVersion({
+			lix: { ...args.lix },
+			changes: [change],
+			version: args.version,
+		});
+	}
 
 	return change;
 }

--- a/packages/lix-sdk/src/database/mutation-log/database-schema.ts
+++ b/packages/lix-sdk/src/database/mutation-log/database-schema.ts
@@ -49,7 +49,7 @@ export const tableIdColumns: Record<string, Array<string>> = {
 	change_edge: ["parent_id", "child_id"],
 	change_conflict_resolution: ["change_conflict_id", "resolved_change_id"],
 	version_change_conflict: ["version_id", "change_conflict_id"],
-	version_change: ["version_id", "change_id"],
+	// version_change: ["version_id", "change_id"],
 };
 
 export function applyMutationLogDatabaseSchema(sqlite: SqliteDatabase): void {

--- a/packages/lix-sdk/src/own-entity-change-control/change-controlled-tables.ts
+++ b/packages/lix-sdk/src/own-entity-change-control/change-controlled-tables.ts
@@ -10,6 +10,7 @@ export const changeControlledTableIds = {
 	file: ["id"],
 	key_value: ["key"],
 	version: ["id"],
+	version_change: ["version_id", "change_id"],
 } as const;
 
 //

--- a/packages/lix-sdk/src/own-entity-change-control/database-triggers.ts
+++ b/packages/lix-sdk/src/own-entity-change-control/database-triggers.ts
@@ -159,14 +159,19 @@ function handleLixOwnEntityChange(
 
 	const entityId = entityIdForRow(tableName, ...values);
 
-	createChange({
-		lix,
-		authors: authors,
-		version: currentVersion,
-		entityId,
-		fileId: "null",
-		pluginKey: "lix_own_entity",
-		schemaKey: `lix_${tableName}_table`,
-		snapshotContent,
-	});
+	createChange(
+		{
+			lix,
+			authors: authors,
+			version: currentVersion,
+			entityId,
+			fileId: "null",
+			pluginKey: "lix_own_entity",
+			schemaKey: `lix_${tableName}_table`,
+			snapshotContent,
+		},
+		{
+			updateVersionChanges: tableName === "version_change" ? false : true,
+		}
+	);
 }

--- a/packages/lix-sdk/src/sync/pull-from-server.test.ts
+++ b/packages/lix-sdk/src/sync/pull-from-server.test.ts
@@ -328,7 +328,7 @@ test.skip("rows changed on the server more recently should be updated on the cli
 // 	]);
 // });
 
-test("non-conflicting changes from another client should for the same version should be applied", async () => {
+test("non-conflicting changes from the server should for the same version should be applied", async () => {
 	const lix = await openLixInMemory({});
 
 	const currentVersion = await lix.db


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/192. Also opens the door for simplified sync'ing because the mutation log is not required anymore. 


https://github.com/user-attachments/assets/e8389a62-bea9-434c-84ab-0cac554e7664



