### PR TITLE
apply changes when switching the version 

### DIFF
--- a/packages/lix-sdk/src/own-entity-change-control/apply-own-entity-change.test.ts
+++ b/packages/lix-sdk/src/own-entity-change-control/apply-own-entity-change.test.ts
@@ -7,7 +7,7 @@ import type {
 } from "../database/schema.js";
 import { applyOwnEntityChanges } from "./apply-own-entity-change.js";
 import { mockJsonSnapshot } from "../snapshot/mock-json-snapshot.js";
-import { KeyValue } from "../key-value/database-schema.js";
+import { type KeyValue } from "../key-value/database-schema.js";
 
 test("it should apply insert changes correctly", async () => {
 	const lix = await openLixInMemory({});

--- a/packages/lix-sdk/src/own-entity-change-control/apply-own-entity-change.ts
+++ b/packages/lix-sdk/src/own-entity-change-control/apply-own-entity-change.ts
@@ -11,6 +11,7 @@ import {
 	primaryKeysForEntityId,
 } from "./change-controlled-tables.js";
 import { tablesByDepencies } from "../database/mutation-log/database-schema.js";
+import { withSkipOwnChangeControl } from "./with-skip-own-change-control.js";
 
 /**
  * Applies own changes to lix itself.
@@ -20,86 +21,88 @@ export async function applyOwnEntityChanges(args: {
 	changes: Change[];
 }): Promise<void> {
 	const executeInTransaction = async (trx: Lix["db"]) => {
-		// defer foreign keys to avoid constraint violations
-		// until the end of the transaction. otherwise, we would
-		// need to apply the changes in the correct order.
-		//
-		// * the pragma statement doesn't work. using tables by dependency as workaround
-		// await sql`PRAGMA defer_foreign_keys = ON;`.execute(trx);
+		await withSkipOwnChangeControl(trx, async (trx) => {
+			// defer foreign keys to avoid constraint violations
+			// until the end of the transaction. otherwise, we would
+			// need to apply the changes in the correct order.
+			//
+			// * the pragma statement doesn't work. using tables by dependency as workaround
+			// await sql`PRAGMA defer_foreign_keys = ON;`.execute(trx);
 
-		for (const table of tablesByDepencies) {
-			const changes = args.changes.filter(
-				(change) => change.schema_key === `lix_${table}_table`
-			);
+			for (const table of tablesByDepencies) {
+				const changes = args.changes.filter(
+					(change) => change.schema_key === `lix_${table}_table`
+				);
 
-			await Promise.all(
-				changes.map(async (change) => {
-					if (change.plugin_key !== "lix_own_entity") {
-						throw new Error(
-							"Expected 'lix_own_entity' as plugin key but received " +
-								change.plugin_key
+				await Promise.all(
+					changes.map(async (change) => {
+						if (change.plugin_key !== "lix_own_entity") {
+							throw new Error(
+								"Expected 'lix_own_entity' as plugin key but received " +
+									change.plugin_key
+							);
+						}
+						const snapshot = await trx
+							.selectFrom("snapshot")
+							.where("id", "=", change.snapshot_id)
+							.select("content")
+							.executeTakeFirstOrThrow();
+
+						// remove the prefix and suffix from the schema key
+						// `lix_key_value_table` -> `key_value`
+						const tableName = change.schema_key
+							.replace(/^lix_/, "")
+							.replace(/_table$/, "") as keyof typeof changeControlledTableIds;
+
+						const primaryKeys = primaryKeysForEntityId(
+							tableName,
+							change.entity_id
 						);
-					}
-					const snapshot = await trx
-						.selectFrom("snapshot")
-						.where("id", "=", change.snapshot_id)
-						.select("content")
-						.executeTakeFirstOrThrow();
 
-					// remove the prefix and suffix from the schema key
-					// `lix_key_value_table` -> `key_value`
-					const tableName = change.schema_key
-						.replace(/^lix_/, "")
-						.replace(/_table$/, "") as keyof typeof changeControlledTableIds;
+						let query:
+							| DeleteQueryBuilder<
+									LixDatabaseSchema,
+									keyof typeof changeControlledTableIds,
+									DeleteResult
+							  >
+							| InsertQueryBuilder<
+									LixDatabaseSchema,
+									keyof typeof changeControlledTableIds,
+									InsertResult
+							  >;
 
-					const primaryKeys = primaryKeysForEntityId(
-						tableName,
-						change.entity_id
-					);
-
-					let query:
-						| DeleteQueryBuilder<
-								LixDatabaseSchema,
-								keyof typeof changeControlledTableIds,
-								DeleteResult
-						  >
-						| InsertQueryBuilder<
-								LixDatabaseSchema,
-								keyof typeof changeControlledTableIds,
-								InsertResult
-						  >;
-
-					// deletion
-					if (snapshot.content === null) {
-						query = trx.deleteFrom(tableName);
-						for (const [key, value] of primaryKeys) {
-							query = query.where(key as any, "=", value);
+						// deletion
+						if (snapshot.content === null) {
+							query = trx.deleteFrom(tableName);
+							for (const [key, value] of primaryKeys) {
+								query = query.where(key as any, "=", value);
+							}
 						}
-					}
-					// upsert
-					else {
-						// take the current file data if the table is `file`
-						// (can be optimized later to adjust the query instead)
-						if (tableName === "file") {
-							const data = await trx
-								.selectFrom("file")
-								.where("id", "=", change.entity_id)
-								.select("data")
-								.executeTakeFirst();
+						// upsert
+						else {
+							// take the current file data if the table is `file`
+							// (can be optimized later to adjust the query instead)
+							if (tableName === "file") {
+								const data = await trx
+									.selectFrom("file")
+									.where("id", "=", change.entity_id)
+									.select("data")
+									.executeTakeFirst();
 
-							snapshot.content.data = data?.data ?? new Uint8Array();
+								snapshot.content.data = data?.data ?? new Uint8Array();
+							}
+
+							query = trx
+								.insertInto(tableName)
+								.values(snapshot.content)
+								.onConflict((oc) => oc.doUpdateSet(snapshot.content!));
 						}
 
-						query = trx
-							.insertInto(tableName)
-							.values(snapshot.content)
-							.onConflict((oc) => oc.doUpdateSet(snapshot.content!));
-					}
-
-					await query.execute();
-				})
-			);
-		}
+						await query.execute();
+					})
+				);
+			}
+		});
 	};
 
 	if (args.lix.db.isTransaction) {

--- a/packages/lix-sdk/src/own-entity-change-control/with-skip-own-change-control.ts
+++ b/packages/lix-sdk/src/own-entity-change-control/with-skip-own-change-control.ts
@@ -8,6 +8,7 @@ export async function withSkipOwnChangeControl<T>(
 		await trx
 			.insertInto("key_value")
 			.values({ key: "#lix_skip_own_change_control", value: "true" })
+			.onConflict((oc) => oc.doUpdateSet({ value: "true" }))
 			.execute();
 
 		// Perform the user's operation

--- a/packages/lix-sdk/src/query-filter/version-change-in-symmetric-difference.test.ts
+++ b/packages/lix-sdk/src/query-filter/version-change-in-symmetric-difference.test.ts
@@ -5,7 +5,7 @@ import { mockChange } from "../change/mock-change.js";
 import { createVersion } from "../version/create-version.js";
 import { versionChangeInSymmetricDifference } from "./version-change-in-symmetric-difference.js";
 
-test("should return the symmetric difference between two change sets", async () => {
+test("should return the symmetric difference between two versions", async () => {
 	const lix = await openLixInMemory({});
 
 	const versionA = await createVersion({ lix });

--- a/packages/lix-sdk/src/query-filter/version-change-in-symmetric-difference.ts
+++ b/packages/lix-sdk/src/query-filter/version-change-in-symmetric-difference.ts
@@ -16,7 +16,10 @@ import type { Version, LixDatabaseSchema } from "../database/schema.js";
  *     .execute();
  *   ```
  */
-export function versionChangeInSymmetricDifference(a: Version, b: Version) {
+export function versionChangeInSymmetricDifference(
+	a: Pick<Version, "id">,
+	b: Pick<Version, "id">
+) {
 	return (
 		eb: ExpressionBuilder<LixDatabaseSchema, "version_change">
 	): ExpressionWrapper<LixDatabaseSchema, "version_change", SqlBool> =>

--- a/packages/lix-sdk/src/sync/pull-from-server.ts
+++ b/packages/lix-sdk/src/sync/pull-from-server.ts
@@ -3,8 +3,6 @@ import * as LixServerApi from "@lix-js/server-api-schema";
 import { mergeTheirState, type VectorClock } from "./merge-state.js";
 import { applyChanges } from "../change/apply-changes.js";
 import type { Change } from "../database/schema.js";
-import { withSkipOwnChangeControl } from "../own-entity-change-control/with-skip-own-change-control.js";
-import { withSkipChangeQueue } from "../change-queue/with-skip-change-queue.js";
 import { CompiledQuery } from "kysely";
 
 export async function pullFromServer(args: {
@@ -95,13 +93,9 @@ export async function pullFromServer(args: {
 		if (changesToApply.length > 0) {
 			// the changes already exists hence prevent own change control
 			// from creating new changes for the applied changes
-			await withSkipOwnChangeControl(trx, async (trx) => {
-				await withSkipChangeQueue(trx, async (trx) => {
-					await applyChanges({
-						lix: { ...args.lix, db: trx },
-						changes: changesToApply,
-					});
-				});
+			await applyChanges({
+				lix: { ...args.lix, db: trx },
+				changes: changesToApply,
 			});
 		}
 	});

--- a/packages/lix-sdk/src/version/switch-version.test.ts
+++ b/packages/lix-sdk/src/version/switch-version.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "vitest";
 import { openLixInMemory } from "../lix/open-lix-in-memory.js";
 import { switchVersion } from "./switch-version.js";
 import { createVersion } from "./create-version.js";
+import { createChange } from "../change/create-change.js";
 
 test("switching versiones should update the current_version", async () => {
 	const lix = await openLixInMemory({});
@@ -17,7 +18,7 @@ test("switching versiones should update the current_version", async () => {
 			lix: { db: trx },
 			parent: currentVersion,
 		});
-		await switchVersion({ lix: { db: trx }, to: newVersion });
+		await switchVersion({ lix: { ...lix, db: trx }, to: newVersion });
 		return newVersion;
 	});
 
@@ -27,4 +28,98 @@ test("switching versiones should update the current_version", async () => {
 		.executeTakeFirstOrThrow();
 
 	expect(currentVersionAfterSwitch.id).toBe(newVersion?.id);
+});
+
+test("switching a version does not lead to duplicate changes", async () => {
+	const lix = await openLixInMemory({});
+
+	const account0 = await lix.db
+		.insertInto("account")
+		.values({ name: "account0" })
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	const currentVersion = await lix.db
+		.selectFrom("current_version")
+		.innerJoin("version", "current_version.id", "version.id")
+		.selectAll("version")
+		.executeTakeFirstOrThrow();
+
+	const change0 = await createChange({
+		lix,
+		version: currentVersion,
+		authors: [account0],
+		entityId: "entity0",
+		fileId: "file0",
+		schemaKey: "schema0",
+		snapshotContent: null,
+		pluginKey: "plugin0",
+	});
+
+	const newVersion = await createVersion({
+		lix: lix,
+		parent: currentVersion,
+	});
+
+	const changesBefore = await lix.db.selectFrom("change").selectAll().execute();
+
+	expect(changesBefore).toEqual(expect.arrayContaining([change0]));
+
+	await switchVersion({ lix, to: newVersion });
+
+	const changesAfter = await lix.db.selectFrom("change").selectAll().execute();
+
+	expect(changesAfter).toEqual(changesBefore);
+});
+
+test("switch version applies the changes of the switched to version", async () => {
+	const lix = await openLixInMemory({});
+
+	const versionA = await createVersion({ lix });
+
+	const versionB = await createVersion({ lix });
+
+	await switchVersion({ lix, to: versionA });
+
+	// version A has value foo
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "foo", value: "bar" })
+		.execute();
+
+	let keyValues = await lix.db
+		.selectFrom("key_value")
+		.where("key", "=", "foo")
+		.selectAll()
+		.execute();
+
+	expect(keyValues).toEqual([{ key: "foo", value: "bar" }]);
+
+	await switchVersion({ lix, to: versionB });
+
+	// version B should have no value foo
+	keyValues = await lix.db
+		.selectFrom("key_value")
+		.where("key", "=", "foo")
+		.selectAll()
+		.execute();
+
+	expect(keyValues).toHaveLength(0);
+
+	// version B has value foo
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "foo", value: "baz" })
+		.execute();
+
+	await switchVersion({ lix, to: versionA });
+
+	keyValues = await lix.db
+		.selectFrom("key_value")
+		.where("key", "=", "foo")
+		.selectAll()
+		.execute();
+
+	// expecting to see the value from version A again
+	expect(keyValues).toEqual([{ key: "foo", value: "bar" }]);
 });


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/185 

- applies the changes of the to be switched to version in `switchVersion()`
- fixes duplicate changes in `applyChanges()`

