### PR TITLE
apply changes on merging a version

### DIFF
--- a/packages/lix-sdk/src/own-entity-change-control/apply-own-entity-change.ts
+++ b/packages/lix-sdk/src/own-entity-change-control/apply-own-entity-change.ts
@@ -1,4 +1,5 @@
 import {
+	CompiledQuery,
 	type DeleteQueryBuilder,
 	type DeleteResult,
 	type InsertQueryBuilder,
@@ -10,7 +11,6 @@ import {
 	changeControlledTableIds,
 	primaryKeysForEntityId,
 } from "./change-controlled-tables.js";
-import { tablesByDepencies } from "../database/mutation-log/database-schema.js";
 import { withSkipOwnChangeControl } from "./with-skip-own-change-control.js";
 
 /**
@@ -25,83 +25,77 @@ export async function applyOwnEntityChanges(args: {
 			// defer foreign keys to avoid constraint violations
 			// until the end of the transaction. otherwise, we would
 			// need to apply the changes in the correct order.
-			//
-			// * the pragma statement doesn't work. using tables by dependency as workaround
-			// await sql`PRAGMA defer_foreign_keys = ON;`.execute(trx);
+			await trx.executeQuery(
+				CompiledQuery.raw("PRAGMA defer_foreign_keys = ON;")
+			);
 
-			for (const table of tablesByDepencies) {
-				const changes = args.changes.filter(
-					(change) => change.schema_key === `lix_${table}_table`
-				);
-
-				await Promise.all(
-					changes.map(async (change) => {
-						if (change.plugin_key !== "lix_own_entity") {
-							throw new Error(
-								"Expected 'lix_own_entity' as plugin key but received " +
-									change.plugin_key
-							);
-						}
-						const snapshot = await trx
-							.selectFrom("snapshot")
-							.where("id", "=", change.snapshot_id)
-							.select("content")
-							.executeTakeFirstOrThrow();
-
-						// remove the prefix and suffix from the schema key
-						// `lix_key_value_table` -> `key_value`
-						const tableName = change.schema_key
-							.replace(/^lix_/, "")
-							.replace(/_table$/, "") as keyof typeof changeControlledTableIds;
-
-						const primaryKeys = primaryKeysForEntityId(
-							tableName,
-							change.entity_id
+			await Promise.all(
+				args.changes.map(async (change) => {
+					if (change.plugin_key !== "lix_own_entity") {
+						throw new Error(
+							"Expected 'lix_own_entity' as plugin key but received " +
+								change.plugin_key
 						);
+					}
+					const snapshot = await trx
+						.selectFrom("snapshot")
+						.where("id", "=", change.snapshot_id)
+						.select("content")
+						.executeTakeFirstOrThrow();
 
-						let query:
-							| DeleteQueryBuilder<
-									LixDatabaseSchema,
-									keyof typeof changeControlledTableIds,
-									DeleteResult
-							  >
-							| InsertQueryBuilder<
-									LixDatabaseSchema,
-									keyof typeof changeControlledTableIds,
-									InsertResult
-							  >;
+					// remove the prefix and suffix from the schema key
+					// `lix_key_value_table` -> `key_value`
+					const tableName = change.schema_key
+						.replace(/^lix_/, "")
+						.replace(/_table$/, "") as keyof typeof changeControlledTableIds;
 
-						// deletion
-						if (snapshot.content === null) {
-							query = trx.deleteFrom(tableName);
-							for (const [key, value] of primaryKeys) {
-								query = query.where(key as any, "=", value);
-							}
+					const primaryKeys = primaryKeysForEntityId(
+						tableName,
+						change.entity_id
+					);
+
+					let query:
+						| DeleteQueryBuilder<
+								LixDatabaseSchema,
+								keyof typeof changeControlledTableIds,
+								DeleteResult
+						  >
+						| InsertQueryBuilder<
+								LixDatabaseSchema,
+								keyof typeof changeControlledTableIds,
+								InsertResult
+						  >;
+
+					// deletion
+					if (snapshot.content === null) {
+						query = trx.deleteFrom(tableName);
+						for (const [key, value] of primaryKeys) {
+							query = query.where(key as any, "=", value);
 						}
-						// upsert
-						else {
-							// take the current file data if the table is `file`
-							// (can be optimized later to adjust the query instead)
-							if (tableName === "file") {
-								const data = await trx
-									.selectFrom("file")
-									.where("id", "=", change.entity_id)
-									.select("data")
-									.executeTakeFirst();
+					}
+					// upsert
+					else {
+						// take the current file data if the table is `file`
+						// (can be optimized later to adjust the query instead)
+						if (tableName === "file") {
+							const data = await trx
+								.selectFrom("file")
+								.where("id", "=", change.entity_id)
+								.select("data")
+								.executeTakeFirst();
 
-								snapshot.content.data = data?.data ?? new Uint8Array();
-							}
-
-							query = trx
-								.insertInto(tableName)
-								.values(snapshot.content)
-								.onConflict((oc) => oc.doUpdateSet(snapshot.content!));
+							snapshot.content.data = data?.data ?? new Uint8Array();
 						}
 
-						await query.execute();
-					})
-				);
-			}
+						query = trx
+							.insertInto(tableName)
+							.values(snapshot.content)
+							.onConflict((oc) => oc.doUpdateSet(snapshot.content!));
+					}
+
+					await query.execute();
+				})
+			);
 		});
 	};
 

--- a/packages/lix-sdk/src/plugin/lix-plugin.test-d.ts
+++ b/packages/lix-sdk/src/plugin/lix-plugin.test-d.ts
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { assertType, test } from "vitest";
-import type { DetectedChange } from "./lix-plugin.js";
+import type { DetectedChange, LixPlugin } from "./lix-plugin.js";
 import type { ExperimentalChangeSchema } from "../change-schema/types.js";
 
 test("json schema type of a detected change", () => {
@@ -32,3 +33,13 @@ test("json schema type of a detected change", () => {
 
 	assertType(change);
 });
+
+// test("file.data is potentially undefined", () => {
+// 	const plugin: LixPlugin = {
+// 		key: "plugin1",
+// 		applyChanges: async ({ file }) => {
+// 			assertType<ArrayBuffer | undefined>(file.data);
+// 			return { fileData: new Uint8Array() };
+// 		},
+// 	};
+// });

--- a/packages/lix-sdk/src/plugin/lix-plugin.ts
+++ b/packages/lix-sdk/src/plugin/lix-plugin.ts
@@ -52,11 +52,18 @@ export type LixPlugin = {
 	}) => Promise<DetectedConflict[]>;
 	applyChanges?: (args: {
 		lix: LixReadonly;
-		// todo a file can be-non existent
-		// maybe it's better to remove the file from this api
-		// and let the plugin handle the file selection and
-		// , if needed, file creation
+		// maybe make lix file data optional (see comment below)
 		file: LixFile;
+		/**
+		 * The file to which the changes should be applied.
+		 *
+		 * The `file.data` might be undefined if the file does not
+		 * exist at the time of applying the changes. This can
+		 * happen when merging a version that created a new file
+		 * that did not exist in the target version. Or, a file
+		 * has been deleted and should be restored at a later point.
+		 */
+		// file: Omit<LixFile, "data"> & { data?: LixFile["data"] };
 		changes: Array<Change>;
 	}) => Promise<{
 		fileData: LixFile["data"];

--- a/packages/lix-sdk/src/version/merge-version.ts
+++ b/packages/lix-sdk/src/version/merge-version.ts
@@ -1,5 +1,6 @@
 import { createChangeConflict } from "../change-conflict/create-change-conflict.js";
 import { detectChangeConflicts } from "../change-conflict/detect-change-conflicts.js";
+import { applyChanges } from "../change/apply-changes.js";
 import type { Version } from "../database/schema.js";
 import type { Lix } from "../lix/open-lix.js";
 import { versionChangeInSymmetricDifference } from "../query-filter/version-change-in-symmetric-difference.js";
@@ -80,6 +81,11 @@ export async function mergeVersion(args: {
 				conflictingChangeIds: detectedConflict.conflictingChangeIds,
 			});
 		}
+
+		await applyChanges({
+			lix: { ...args.lix, db: trx },
+			changes: symmetricDifference,
+		});
 	};
 
 	if (args.lix.db.isTransaction) {


### PR DESCRIPTION
Merging a version led to no appliance of changes. Odd behavior which @felixhaeberle identified in https://github.com/opral/lix-sdk/issues/205. 

- applies changes after merging a version now
- improves foreign key defer