### PR TITLE
implement version switching with deleted files

### DIFF
--- a/packages/lix-file-manager/vite.config.ts
+++ b/packages/lix-file-manager/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
 		},
 	},
 	build: {
+		minify: false,
 		target: "esnext",
 	},
 });

--- a/packages/lix-sdk/src/change-queue/file-handlers.ts
+++ b/packages/lix-sdk/src/change-queue/file-handlers.ts
@@ -3,6 +3,7 @@ import type { DetectedChange } from "../plugin/lix-plugin.js";
 import type { Lix } from "../lix/open-lix.js";
 import { sql } from "kysely";
 import { createChange } from "../change/create-change.js";
+import { changeIsLeafInVersion } from "../query-filter/change-is-leaf-in-version.js";
 
 // start a new normalize path function that has the absolute minimum implementation.
 function normalizePath(path: string) {
@@ -165,14 +166,12 @@ export async function handleFileUpdate(args: {
 						data: args.changeQueueEntry.data_before,
 					}
 				: undefined,
-			after: args.changeQueueEntry.data_after
-				? {
-						id: args.changeQueueEntry.file_id,
-						path,
-						metadata: args.changeQueueEntry.metadata_after,
-						data: args.changeQueueEntry.data_after,
-					}
-				: undefined,
+			after: {
+				id: args.changeQueueEntry.file_id,
+				path,
+				metadata: args.changeQueueEntry.metadata_after,
+				data: args.changeQueueEntry.data_after!,
+			},
 		})) {
 			detectedChanges.push({
 				...change,
@@ -215,77 +214,50 @@ export async function handleFileUpdate(args: {
 	});
 }
 
+/**
+ * File deletions don't need to invoke a plugin to detect changes.
+ *
+ * Instead, we can simply query the database for all changes that are related to the file
+ * and create the corresponding deletion changes for the current version.
+ *
+ * - simpler plugin API (because deletions don't need to be accounted for)
+ * - faster file deletion (because we don't need to invoke plugins)
+ */
 export async function handleFileDelete(args: {
 	lix: Pick<Lix, "db" | "plugin" | "sqlite">;
 	changeQueueEntry: ChangeQueueEntry;
 }): Promise<void> {
-	const detectedChanges: Array<DetectedChange & { pluginKey: string }> = [];
-
-	const plugins = await args.lix.plugin.getAll();
-
-	const path = args.changeQueueEntry.path_before;
-
-	if (path === null) {
-		throw new Error("Before path is null for file deletion");
-	}
-
-	for (const plugin of plugins) {
-		if (
-			!(await glob({
-				lix: args.lix,
-				path: normalizePath(path),
-				glob: "/" + plugin.detectChangesGlob,
-			}))
-		) {
-			break;
-		}
-
-		if (plugin.detectChanges === undefined) {
-			const error = new Error(
-				"Plugin does not support detecting changes even though the glob matches."
-			);
-			console.error(error);
-			throw error;
-		}
-
-		for (const change of await plugin.detectChanges({
-			before: {
-				id: args.changeQueueEntry.file_id,
-				path,
-				metadata: args.changeQueueEntry.metadata_before,
-				data: args.changeQueueEntry.data_before!,
-			},
-			after: undefined,
-		})) {
-			detectedChanges.push({
-				...change,
-				pluginKey: plugin.key,
-			});
-		}
-	}
-
 	await args.lix.db.transaction().execute(async (trx) => {
-		const currentAuthors = await trx
-			.selectFrom("active_account")
-			.selectAll()
-			.execute();
-
 		const currentVersion = await trx
 			.selectFrom("current_version")
 			.innerJoin("version", "current_version.id", "version.id")
 			.selectAll()
 			.executeTakeFirstOrThrow();
 
+		const toBeDeletedEntities = await trx
+			.selectFrom("change")
+			.where("file_id", "=", args.changeQueueEntry.file_id)
+			.where(changeIsLeafInVersion(currentVersion))
+			.select("entity_id")
+			.select("schema_key")
+			.select("plugin_key")
+			.execute();
+
+		const currentAuthors = await trx
+			.selectFrom("active_account")
+			.selectAll()
+			.execute();
+
 		await Promise.all(
-			detectedChanges.map(async (detectedChange) => {
+			toBeDeletedEntities.map(async (change) => {
 				await createChange({
 					lix: { ...args.lix, db: trx },
 					authors: currentAuthors,
 					version: currentVersion,
-					entityId: detectedChange.entity_id,
+					entityId: change.entity_id,
 					fileId: args.changeQueueEntry.file_id,
-					pluginKey: detectedChange.pluginKey,
-					schemaKey: detectedChange.schema.key,
+					pluginKey: change.plugin_key,
+					schemaKey: change.schema_key,
 					snapshotContent: null, // Snapshot is null for deletions
 				});
 			})

--- a/packages/lix-sdk/src/change-queue/file-handlers.ts
+++ b/packages/lix-sdk/src/change-queue/file-handlers.ts
@@ -120,7 +120,7 @@ export async function handleFileInsert(args: {
 	});
 }
 
-export async function handleFileChange(args: {
+export async function handleFileUpdate(args: {
 	lix: Pick<Lix, "db" | "plugin" | "sqlite">;
 	changeQueueEntry: ChangeQueueEntry;
 }): Promise<void> {
@@ -204,6 +204,89 @@ export async function handleFileChange(args: {
 					pluginKey: detectedChange.pluginKey,
 					schemaKey: detectedChange.schema.key,
 					snapshotContent: detectedChange.snapshot,
+				});
+			})
+		);
+
+		await trx
+			.deleteFrom("change_queue")
+			.where("id", "=", args.changeQueueEntry.id)
+			.execute();
+	});
+}
+
+export async function handleFileDelete(args: {
+	lix: Pick<Lix, "db" | "plugin" | "sqlite">;
+	changeQueueEntry: ChangeQueueEntry;
+}): Promise<void> {
+	const detectedChanges: Array<DetectedChange & { pluginKey: string }> = [];
+
+	const plugins = await args.lix.plugin.getAll();
+
+	const path = args.changeQueueEntry.path_before;
+
+	if (path === null) {
+		throw new Error("Before path is null for file deletion");
+	}
+
+	for (const plugin of plugins) {
+		if (
+			!(await glob({
+				lix: args.lix,
+				path: normalizePath(path),
+				glob: "/" + plugin.detectChangesGlob,
+			}))
+		) {
+			break;
+		}
+
+		if (plugin.detectChanges === undefined) {
+			const error = new Error(
+				"Plugin does not support detecting changes even though the glob matches."
+			);
+			console.error(error);
+			throw error;
+		}
+
+		for (const change of await plugin.detectChanges({
+			before: {
+				id: args.changeQueueEntry.file_id,
+				path,
+				metadata: args.changeQueueEntry.metadata_before,
+				data: args.changeQueueEntry.data_before!,
+			},
+			after: undefined,
+		})) {
+			detectedChanges.push({
+				...change,
+				pluginKey: plugin.key,
+			});
+		}
+	}
+
+	await args.lix.db.transaction().execute(async (trx) => {
+		const currentAuthors = await trx
+			.selectFrom("active_account")
+			.selectAll()
+			.execute();
+
+		const currentVersion = await trx
+			.selectFrom("current_version")
+			.innerJoin("version", "current_version.id", "version.id")
+			.selectAll()
+			.executeTakeFirstOrThrow();
+
+		await Promise.all(
+			detectedChanges.map(async (detectedChange) => {
+				await createChange({
+					lix: { ...args.lix, db: trx },
+					authors: currentAuthors,
+					version: currentVersion,
+					entityId: detectedChange.entity_id,
+					fileId: args.changeQueueEntry.file_id,
+					pluginKey: detectedChange.pluginKey,
+					schemaKey: detectedChange.schema.key,
+					snapshotContent: null, // Snapshot is null for deletions
 				});
 			})
 		);

--- a/packages/lix-sdk/src/change-queue/init-change-queue.test.ts
+++ b/packages/lix-sdk/src/change-queue/init-change-queue.test.ts
@@ -339,3 +339,97 @@ test.todo("changes should contain the author", async () => {
 
 	// expect(changes3.at(-1)?.author).toBe("some-other-id");
 });
+
+
+test("should handle file deletions correctly", async () => {
+	const mockPlugin: LixPlugin = {
+		key: "mock-plugin",
+		detectChangesGlob: "*",
+		detectChanges: async ({ before, after }) => {
+			if (!before || after) {
+				return [];
+			}
+
+			return [
+				{
+					schema: {
+						key: "text",
+						type: "json",
+					},
+					entity_id: "test",
+					snapshot: undefined,
+				},
+			];
+		},
+	};
+
+	const lix = await openLixInMemory({
+		blob: await newLixFile(),
+		providePlugins: [mockPlugin],
+	});
+
+	const enc = new TextEncoder();
+	const dataInitial = enc.encode("file to be deleted");
+
+	// Insert initial file
+	await lix.db
+		.insertInto("file")
+		.values({ id: "delete-test", path: "/delete.txt", data: dataInitial })
+		.execute();
+
+	// Queue deletion
+	await changeQueueSettled({ lix });
+
+	await lix.db.deleteFrom("file").where("id", "=", "delete-test").execute();
+
+	// Ensure the queue reflects the deletion entry
+	const queue = await lix.db.selectFrom("change_queue").selectAll().execute();
+
+	expect(queue).toEqual([
+		expect.objectContaining({
+			file_id: "delete-test",
+			path_before: "/delete.txt",
+			data_before: dataInitial,
+			path_after: null,
+			data_after: null,
+		} satisfies Partial<ChangeQueueEntry>),
+	]);
+
+	// Run the change queue settlement process
+	await changeQueueSettled({ lix });
+
+	// Verify the change queue is empty
+	expect(
+		(await lix.db.selectFrom("change_queue").selectAll().execute()).length
+	).toBe(0);
+
+	// Verify the changes reflect the deletion
+	const changes = await lix.db
+		.selectFrom("change")
+		.innerJoin("snapshot", "snapshot.id", "change.snapshot_id")
+		.innerJoin("change_author", "change_author.change_id", "change.id")
+		.selectAll("change")
+		.select("change_author.account_id")
+		.select("snapshot.content")
+		.execute();
+
+	expect(changes).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				entity_id: "test",
+				file_id: "delete-test",
+				plugin_key: "mock-plugin",
+				schema_key: "text",
+				content: null, // Content is null for deletions
+			}),
+		])
+	);
+
+	// Verify the file no longer exists in the database
+	const internalFilesAfter = await lix.db
+		.selectFrom("file")
+		.selectAll()
+		.execute();
+
+	expect(internalFilesAfter).toEqual([]);
+});

--- a/packages/lix-sdk/src/change-queue/init-change-queue.ts
+++ b/packages/lix-sdk/src/change-queue/init-change-queue.ts
@@ -1,5 +1,9 @@
 import type { SqliteDatabase } from "sqlite-wasm-kysely";
-import { handleFileChange, handleFileInsert } from "./file-handlers.js";
+import {
+	handleFileUpdate,
+	handleFileInsert,
+	handleFileDelete,
+} from "./file-handlers.js";
 import type { Lix } from "../lix/open-lix.js";
 
 export async function initChangeQueue(args: {
@@ -53,7 +57,7 @@ export async function initChangeQueue(args: {
 
 			if (entry) {
 				if (entry.data_before && entry.data_after) {
-					await handleFileChange({
+					await handleFileUpdate({
 						changeQueueEntry: entry,
 						lix: args.lix,
 					});
@@ -63,23 +67,10 @@ export async function initChangeQueue(args: {
 						lix: args.lix,
 					});
 				} else if (entry.data_before && !entry.data_after) {
-					// TODO Queue - handle deletion - the current queue doesn't handle delete starting with feature parity
-					// await handleFileDelete({
-					// 	queueEntry: entry,
-					// before: {
-					// 	id: entry.file_id,
-					// 	path: entry.path,
-					// 	metadata: null,
-					// 	// TODO Queue - handle deletion - until than this we have to bang here
-					// 	data: entry.data_before,
-					// 	skip_change_extraction: null
-					// },
-					// 	plugins,
-					// 	lix: {
-					// 		db,
-					// 		plugin,
-					// 	},
-					// });
+					await handleFileDelete({
+						changeQueueEntry: entry,
+						lix: args.lix,
+					});
 				}
 			}
 

--- a/packages/lix-sdk/src/change-queue/init-change-queue.ts
+++ b/packages/lix-sdk/src/change-queue/init-change-queue.ts
@@ -66,7 +66,7 @@ export async function initChangeQueue(args: {
 						changeQueueEntry: entry,
 						lix: args.lix,
 					});
-				} else if (entry.data_before && !entry.data_after) {
+				} else {
 					await handleFileDelete({
 						changeQueueEntry: entry,
 						lix: args.lix,

--- a/packages/lix-sdk/src/change/apply-changes.ts
+++ b/packages/lix-sdk/src/change/apply-changes.ts
@@ -66,7 +66,13 @@ export async function applyChanges(args: {
 				.selectFrom("file")
 				.where("id", "=", fileId)
 				.selectAll()
-				.executeTakeFirstOrThrow();
+				.executeTakeFirst();
+
+			// lix own change control deleted the file
+			// no plugin needs to apply changes
+			if (file === undefined) {
+				continue;
+			}
 
 			for (const [pluginKey, changes] of Object.entries(groupByPlugin)) {
 				if (changes === undefined) {

--- a/packages/lix-sdk/src/change/apply-changes.ts
+++ b/packages/lix-sdk/src/change/apply-changes.ts
@@ -1,4 +1,3 @@
-import { CompiledQuery } from "kysely";
 import { withSkipChangeQueue } from "../change-queue/with-skip-change-queue.js";
 import type { Change } from "../database/schema.js";
 import type { Lix } from "../lix/open-lix.js";

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -28,15 +28,6 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
     CHECK (is_valid_file_path(path))
   ) STRICT;
 
-  -- TODO Queue - handle deletion - the current queue doesn't handle delete starting with feature parity
-    -- CREATE TRIGGER IF NOT EXISTS file_delete BEFORE DELETE ON file
-    -- WHEN NEW.skip_change_extraction IS NULL
-    -- BEGIN
-    --     INSERT INTO change_queue(file_id, path, data_before, data_after, metadata)
-    --     VALUES (OLD.id, OLD.path, OLD.data, NULL, OLD.metadata);
-    --   SELECT triggerChangeQueue();
-    -- END;
-
   CREATE TABLE IF NOT EXISTS change_queue (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     file_id TEXT NOT NULL,
@@ -73,6 +64,17 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
       NEW.path, NEW.data, NEW.metadata
     );
 
+    SELECT triggerChangeQueue();
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS file_delete BEFORE DELETE ON file
+  BEGIN
+    INSERT INTO change_queue(
+      file_id, path_before, data_before, metadata_before
+    )
+    VALUES (
+      OLD.id, OLD.path, OLD.data, OLD.metadata
+    );
     SELECT triggerChangeQueue();
   END;
 

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -69,12 +69,8 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
 
   CREATE TRIGGER IF NOT EXISTS file_delete BEFORE DELETE ON file
   BEGIN
-    INSERT INTO change_queue(
-      file_id, path_before, data_before, metadata_before
-    )
-    VALUES (
-      OLD.id, OLD.path, OLD.data, OLD.metadata
-    );
+    INSERT INTO change_queue(file_id)
+    VALUES (OLD.id);
     SELECT triggerChangeQueue();
   END;
 

--- a/packages/lix-sdk/src/plugin/lix-plugin.ts
+++ b/packages/lix-sdk/src/plugin/lix-plugin.ts
@@ -28,11 +28,16 @@ export type LixPlugin = {
 	/**
 	 * Detects changes between the `before` and `after` file update(s).
 	 *
-	 * The function is invoked by lix based on the plugin's `glob` pattern.
+	 * `Before` is `undefined` if the file did not exist before (
+	 * the file was created).
+	 *
+	 * `After` is always defined. Either the file was updated, or
+	 * deleted. If the file is deleted, lix own change control
+	 * will handle the deletion. Hence, `after` is always be defined.
 	 */
 	detectChanges?: (args: {
 		before?: LixFile;
-		after?: LixFile;
+		after: LixFile;
 	}) => Promise<Array<DetectedChange>>;
 	/**
 	 * UI components that are used to render the diff view.

--- a/packages/lix-sdk/src/query-filter/version-change-in-difference.test.ts
+++ b/packages/lix-sdk/src/query-filter/version-change-in-difference.test.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "vitest";
+import { openLixInMemory } from "../lix/open-lix-in-memory.js";
+import type { VersionChange } from "../database/schema.js";
+import { mockChange } from "../change/mock-change.js";
+import { createVersion } from "../version/create-version.js";
+import { versionChangeInDifference } from "./version-change-in-difference.js";
+
+test("should return the difference between two versions", async () => {
+	const lix = await openLixInMemory({});
+
+	const versionA = await createVersion({ lix });
+	const versionB = await createVersion({ lix });
+
+	await lix.db
+		.insertInto("change")
+		.values([
+			mockChange({ id: "change1" }),
+			mockChange({ id: "change2" }),
+			mockChange({ id: "change3" }),
+			mockChange({ id: "change4" }),
+		])
+		.returningAll()
+		.execute();
+
+	const changesA: VersionChange[] = [
+		{ version_id: versionA.id, change_id: "change1" },
+		{ version_id: versionA.id, change_id: "change2" },
+	];
+
+	const changesB: VersionChange[] = [
+		{ version_id: versionB.id, change_id: "change2" },
+		{ version_id: versionB.id, change_id: "change3" },
+	];
+
+	await lix.db
+		.insertInto("version_change")
+		.values([...changesA, ...changesB])
+		.execute();
+
+	const result = await lix.db
+		.selectFrom("version_change")
+		.where(versionChangeInDifference(versionA, versionB))
+		.selectAll()
+		.execute();
+
+	expect(result).toEqual([
+		// change1 is in A but not in B
+		{ version_id: versionA.id, change_id: "change1" },
+	] satisfies VersionChange[]);
+});
+
+test("should return an empty array if there are no differences", async () => {
+	const lix = await openLixInMemory({});
+
+	const versionA = await createVersion({ lix });
+	const versionB = await createVersion({ lix });
+
+	await lix.db
+		.insertInto("change")
+		.values([mockChange({ id: "change1" }), mockChange({ id: "change2" })])
+		.returningAll()
+		.execute();
+
+	const changes: VersionChange[] = [
+		{ version_id: versionA.id, change_id: "change1" },
+		{ version_id: versionA.id, change_id: "change2" },
+		{ version_id: versionB.id, change_id: "change1" },
+		{ version_id: versionB.id, change_id: "change2" },
+	];
+
+	await lix.db.insertInto("version_change").values(changes).execute();
+
+	const result = await lix.db
+		.selectFrom("version_change")
+		.where(versionChangeInDifference(versionA, versionB))
+		.selectAll()
+		.execute();
+
+	expect(result).toEqual([]);
+});
+
+test("should handle empty versions", async () => {
+	const lix = await openLixInMemory({});
+
+	const versionA = await createVersion({ lix });
+	const versionB = await createVersion({ lix });
+
+	const result = await lix.db
+		.selectFrom("version_change")
+		.where(versionChangeInDifference(versionA, versionB))
+		.selectAll()
+		.execute();
+
+	// Verify the results
+	expect(result).toEqual([]);
+});

--- a/packages/lix-sdk/src/query-filter/version-change-in-difference.ts
+++ b/packages/lix-sdk/src/query-filter/version-change-in-difference.ts
@@ -1,0 +1,37 @@
+import type { ExpressionBuilder, ExpressionWrapper, SqlBool } from "kysely";
+import type { Version, LixDatabaseSchema } from "../database/schema.js";
+
+/**
+ * Returns the difference between two versions for the version_change table.
+ *
+ * The difference is the set of changes that exist in version `a` but not in version `b`.
+ * Modeled after https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/difference
+ *
+ * @example
+ *   ```ts
+ *   await lix.db.selectFrom("version_change")
+ *     .where(versionChangeInDifference(a: versionA, b: versionB))
+ *     .selectAll()
+ *     .execute();
+ *   ```
+ */
+export function versionChangeInDifference(
+	a: Pick<Version, "id">,
+	b: Pick<Version, "id">
+) {
+	return (
+		eb: ExpressionBuilder<LixDatabaseSchema, "version_change">
+	): ExpressionWrapper<LixDatabaseSchema, "version_change", SqlBool> =>
+		eb("version_change.change_id", "in", (subquery) =>
+			subquery
+				.selectFrom("version_change as A")
+				.leftJoin("version_change as B", (join) =>
+					join
+						.onRef("A.change_id", "=", "B.change_id")
+						.on("B.version_id", "=", b.id)
+				)
+				.where("A.version_id", "=", a.id)
+				.where("B.change_id", "is", null)
+				.select("A.change_id")
+		);
+}

--- a/packages/lix-sdk/src/version/switch-version.test.ts
+++ b/packages/lix-sdk/src/version/switch-version.test.ts
@@ -1,8 +1,10 @@
-import { test, expect } from "vitest";
+import { test, expect, vi } from "vitest";
 import { openLixInMemory } from "../lix/open-lix-in-memory.js";
 import { switchVersion } from "./switch-version.js";
 import { createVersion } from "./create-version.js";
 import { createChange } from "../change/create-change.js";
+import type { LixPlugin } from "../plugin/lix-plugin.js";
+import { changeQueueSettled } from "../change-queue/change-queue-settled.js";
 
 test("switching versiones should update the current_version", async () => {
 	const lix = await openLixInMemory({});
@@ -122,4 +124,90 @@ test("switch version applies the changes of the switched to version", async () =
 
 	// expecting to see the value from version A again
 	expect(keyValues).toEqual([{ key: "foo", value: "bar" }]);
+});
+
+// https://github.com/opral/lix-sdk/issues/209
+test("a deleted file in one version does not impact a version which did not delete the file", async () => {
+	const mockTxtPlugin: LixPlugin = {
+		key: "mock_txt_plugin",
+		detectChangesGlob: "*.txt",
+		// @ts-expect-error - mocked
+		detectChanges: vi.fn(async ({ after }) => {
+			return [
+				{
+					entity_id: "txt_file",
+					snapshot: after
+						? {
+								text: new TextDecoder().decode(after?.data),
+							}
+						: null,
+					schema: {
+						type: "json",
+						key: "txt",
+					},
+				},
+			];
+		}),
+
+		applyChanges: vi.fn(async ({ lix, changes }) => {
+			const snapshot = await lix.db
+				.selectFrom("snapshot")
+				.where("id", "=", changes.at(-1)!.snapshot_id)
+				.selectAll()
+				.executeTakeFirstOrThrow();
+
+			return {
+				fileData: new TextEncoder().encode(snapshot.content!.text),
+			};
+		}),
+	};
+
+	const lix = await openLixInMemory({ providePlugins: [mockTxtPlugin] });
+
+	const sourceVersion = await createVersion({ lix });
+
+	await switchVersion({ lix, to: sourceVersion });
+
+	await lix.db
+		.insertInto("file")
+		.values({
+			id: "file0",
+			data: new TextEncoder().encode("hello world"),
+			path: "/file.txt",
+		})
+		.execute();
+
+	await changeQueueSettled({ lix });
+
+	expect(mockTxtPlugin.detectChanges).toHaveBeenCalledTimes(1);
+
+	const targetVersion = await createVersion({ lix, parent: sourceVersion });
+
+	await switchVersion({ lix, to: targetVersion });
+
+	// there is no difference in both versions
+	expect(mockTxtPlugin.applyChanges).toHaveBeenCalledTimes(0);
+
+	// deleting the file in the target version
+	await lix.db.deleteFrom("file").where("id", "=", "file0").execute();
+
+	await changeQueueSettled({ lix });
+
+	expect(mockTxtPlugin.detectChanges).toHaveBeenCalledTimes(2);
+
+	// switching back to the source version
+	await switchVersion({ lix, to: sourceVersion });
+
+	// the plugin re-applies the changes
+	expect(mockTxtPlugin.applyChanges).toHaveBeenCalledTimes(1);
+
+	// the file should still be there
+
+	const file = await lix.db
+		.selectFrom("file")
+		.where("id", "=", "file0")
+		.selectAll()
+		.executeTakeFirstOrThrow();
+
+	expect(file.data).toEqual(new TextEncoder().encode("hello world"));
 });

--- a/packages/lix-sdk/src/version/switch-version.ts
+++ b/packages/lix-sdk/src/version/switch-version.ts
@@ -1,7 +1,7 @@
 import { applyChanges } from "../change/apply-changes.js";
 import type { Change, Version } from "../database/schema.js";
 import type { Lix } from "../lix/open-lix.js";
-import { versionChangeInDifference } from "../query-filter/version-change-in-difference.js";
+import { versionChangeInSymmetricDifference } from "../query-filter/version-change-in-symmetric-difference.js";
 
 /**
  * Switches the current Version to the given Version.
@@ -28,61 +28,71 @@ export async function switchVersion(args: {
 	to: Pick<Version, "id">;
 }): Promise<void> {
 	const executeInTransaction = async (trx: Lix["db"]) => {
-		const currentVersion = await trx
+		const sourceVersion = await trx
 			.selectFrom("current_version")
 			.selectAll()
 			.executeTakeFirstOrThrow();
 
 		await trx.updateTable("current_version").set({ id: args.to.id }).execute();
 
-		const versionChangesDifference = await trx
+		// need symmetric difference to detect inserts and deletions
+		// that should occur when switching the version
+		const versionChangesSymmetricDifference = await trx
 			.selectFrom("version_change")
 			.innerJoin("change", "version_change.change_id", "change.id")
-			.where(versionChangeInDifference(currentVersion, args.to))
+			.where(versionChangeInSymmetricDifference(sourceVersion, args.to))
 			.selectAll("change")
 			.execute();
 
-		const toBeAppliedChanges: Change[] = [];
+		// because we use the symmetric difference, entity
+		// changes need to be de-duplicated. in the future,
+		// we could improve the symmetric difference query
+		const toBeAppliedChanges: Map<string, Change> = new Map();
 
-		await Promise.all(
-			versionChangesDifference.map(async (change) => {
-				const existingEntityChange = await trx
-					.selectFrom("version_change")
-					.innerJoin("change", "change.id", "version_change.change_id")
-					.where("version_id", "=", args.to.id)
-					.where("change.entity_id", "=", change.entity_id)
-					.where("change.file_id", "=", change.file_id)
-					.where("change.schema_key", "=", change.schema_key)
-					.selectAll("change")
-					.executeTakeFirst();
+		for (const change of versionChangesSymmetricDifference) {
+			const existingEntityChange = await trx
+				.selectFrom("version_change")
+				.innerJoin("change", "change.id", "version_change.change_id")
+				.where("version_id", "=", args.to.id)
+				.where("change.entity_id", "=", change.entity_id)
+				.where("change.file_id", "=", change.file_id)
+				.where("change.schema_key", "=", change.schema_key)
+				.selectAll("change")
+				.executeTakeFirst();
 
-				if (existingEntityChange) {
-					return toBeAppliedChanges.push(existingEntityChange);
+			if (existingEntityChange) {
+				toBeAppliedChanges.set(
+					`${change.file_id},${change.entity_id},${change.schema_key}`,
+					existingEntityChange
+				);
+				continue;
+			}
+			// need to remove the entity when switching the version
+			else {
+				if (
+					change.plugin_key === "lix_own_entity" &&
+					(change.schema_key === "lix_account_table" ||
+						change.schema_key === "lix_version_table")
+				) {
+					// deleting accounts and versions when switching is
+					// not desired. a version should be able to jump to a
+					// different version and the accounts are not affected
+					continue;
 				}
-				// need to remove the entity when switching the version
-				else {
-					if (
-						change.plugin_key === "lix_own_entity" &&
-						(change.schema_key === "lix_account_table" ||
-							change.schema_key === "lix_version_table")
-					) {
-						// deleting accounts and versions when switching is
-						// not desired. a version should be able to jump to a
-						// different version and the accounts are not affected
-						return;
-					}
-					// the entity does not exist in the switched to version
-					return toBeAppliedChanges.push({
+				// the entity does not exist in the switched to version
+				toBeAppliedChanges.set(
+					`${change.file_id},${change.entity_id},${change.schema_key}`,
+					{
 						...change,
 						snapshot_id: "no-content",
-					});
-				}
-			})
-		);
+					}
+				);
+			}
+		}
 
-		await applyChanges({
+		return await applyChanges({
 			lix: { ...args.lix, db: trx },
-			changes: toBeAppliedChanges,
+			changes: toBeAppliedChanges.values().toArray(),
 		});
 	};
 


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/209. 

- handles file deletion logic in file queue
- plugins don't need to handle deletions anymore
- fixes apply changes handling file deletions



https://github.com/user-attachments/assets/e1e6b90a-f769-4662-b0b0-eb864c21fbfc

