### PR TITLE
remove assumption that file.data is always defined

### DIFF
--- a/packages/lix-plugin-csv/src/detectChanges.ts
+++ b/packages/lix-plugin-csv/src/detectChanges.ts
@@ -34,11 +34,17 @@ export const detectChanges: NonNullable<LixPlugin["detectChanges"]> = async ({
 	const afterParsed = parseCsv(after?.data, uniqueColumnAfter);
 
 	const headerChanged = checkHeaderChange(
+		beforeParsed.delimeter,
+		afterParsed.delimeter,
 		beforeParsed.header,
 		afterParsed.header,
 	);
 
-	if (headerChanged) {
+	if (
+		headerChanged ||
+		// in case the unique column has been set, the change needs to be detected
+		before?.metadata?.unique_column !== after?.metadata?.unique_column
+	) {
 		detectedChanges.push({
 			schema: HeaderSchemaV1,
 			entity_id: "header",
@@ -62,8 +68,6 @@ export const detectChanges: NonNullable<LixPlugin["detectChanges"]> = async ({
 
 		const rowLineNumberBefore = beforeParsed.lineNumbers[rowId];
 		const rowLineNumberAfter = afterParsed.lineNumbers[rowId];
-
-		
 
 		if (rowLineNumberBefore !== rowLineNumberAfter) {
 			detectedChanges.push({
@@ -120,8 +124,13 @@ export const detectChanges: NonNullable<LixPlugin["detectChanges"]> = async ({
 	return detectedChanges;
 };
 
-function checkHeaderChange(before?: string[], after?: string[]) {
-	const beforeHeaderRow = before?.join(",");
-	const afterHeaderRow = after?.join(",");
+function checkHeaderChange(
+	beforeDelimeter: string,
+	afterDelimeter: string,
+	before?: string[],
+	after?: string[],
+) {
+	const beforeHeaderRow = before?.join(beforeDelimeter);
+	const afterHeaderRow = after?.join(afterDelimeter);
 	return beforeHeaderRow !== afterHeaderRow;
 }

--- a/packages/lix-plugin-csv/src/utilities/parseCsv.ts
+++ b/packages/lix-plugin-csv/src/utilities/parseCsv.ts
@@ -23,6 +23,7 @@ export function parseCsv(
 	index: Map<string, Record<string, string>>;
 	lineNumbers: Record<string, number>;
 	header: string[];
+	delimeter: string;
 } {
 	const parsed = data
 		? papaparse.parse(new TextDecoder().decode(data), {
@@ -47,7 +48,12 @@ export function parseCsv(
 		}
 	}
 
-	return { index, header: parsed?.meta.fields ?? [], lineNumbers };
+	return {
+		index,
+		header: parsed?.meta.fields ?? [],
+		lineNumbers,
+		delimeter: parsed?.meta.delimiter ?? ",",
+	};
 }
 
 /**

--- a/packages/lix-sdk/src/change-queue/file-handlers.ts
+++ b/packages/lix-sdk/src/change-queue/file-handlers.ts
@@ -72,6 +72,7 @@ export async function handleFileInsert(args: {
 		}
 
 		for (const change of await plugin.detectChanges({
+			lix: args.lix,
 			before: undefined,
 			after: {
 				id: args.changeQueueEntry.file_id,
@@ -158,6 +159,7 @@ export async function handleFileUpdate(args: {
 			throw error;
 		}
 		for (const change of await plugin.detectChanges({
+			lix: args.lix,
 			before: args.changeQueueEntry.data_before
 				? {
 						id: args.changeQueueEntry.file_id,

--- a/packages/lix-sdk/src/change/apply-changes.ts
+++ b/packages/lix-sdk/src/change/apply-changes.ts
@@ -72,6 +72,9 @@ export async function applyChanges(args: {
 			// no plugin needs to apply changes
 			if (file === undefined) {
 				continue;
+			} else if (file.data.byteLength === 0) {
+				// @ts-expect-error - the plugin will handle undefined file.data
+				delete file.data
 			}
 
 			for (const [pluginKey, changes] of Object.entries(groupByPlugin)) {

--- a/packages/lix-sdk/src/own-entity-change-control/apply-own-entity-change.ts
+++ b/packages/lix-sdk/src/own-entity-change-control/apply-own-entity-change.ts
@@ -84,7 +84,10 @@ export async function applyOwnEntityChanges(args: {
 								.select("data")
 								.executeTakeFirst();
 
-							snapshot.content.data = data?.data ?? new Uint8Array();
+							snapshot.content.data =
+								data?.data ??
+								// empty uint8array will trigger applyChanges() to pass an empty file to the plugin
+								new Uint8Array();
 						}
 
 						query = trx

--- a/packages/lix-sdk/src/plugin/lix-plugin.test-d.ts
+++ b/packages/lix-sdk/src/plugin/lix-plugin.test-d.ts
@@ -34,12 +34,12 @@ test("json schema type of a detected change", () => {
 	assertType(change);
 });
 
-// test("file.data is potentially undefined", () => {
-// 	const plugin: LixPlugin = {
-// 		key: "plugin1",
-// 		applyChanges: async ({ file }) => {
-// 			assertType<ArrayBuffer | undefined>(file.data);
-// 			return { fileData: new Uint8Array() };
-// 		},
-// 	};
-// });
+test("file.data is potentially undefined", () => {
+	const plugin: LixPlugin = {
+		key: "plugin1",
+		applyChanges: async ({ file }) => {
+			assertType<ArrayBuffer | undefined>(file.data);
+			return { fileData: new Uint8Array() };
+		},
+	};
+});

--- a/packages/lix-sdk/src/plugin/lix-plugin.ts
+++ b/packages/lix-sdk/src/plugin/lix-plugin.ts
@@ -8,15 +8,6 @@ import type { Lix } from "../lix/open-lix.js";
 // named lixplugin to avoid conflict with built-in plugin type
 export type LixPlugin = {
 	key: string;
-	// TODO https://github.com/opral/lix-sdk/issues/37
-	// idea:
-	//   1. runtime reflection for lix on the change schema
-	//   2. lix can validate the changes based on the schema
-	// schema: {
-	// 	bundle: Bundle,
-	// 	message: Message,
-	// 	variant: Variant,
-	// },
 	/**
 	 * The glob pattern that should invoke `detectChanges()`.
 	 *
@@ -36,6 +27,7 @@ export type LixPlugin = {
 	 * will handle the deletion. Hence, `after` is always be defined.
 	 */
 	detectChanges?: (args: {
+		lix: LixReadonly;
 		before?: LixFile;
 		after: LixFile;
 	}) => Promise<Array<DetectedChange>>;
@@ -57,8 +49,6 @@ export type LixPlugin = {
 	}) => Promise<DetectedConflict[]>;
 	applyChanges?: (args: {
 		lix: LixReadonly;
-		// maybe make lix file data optional (see comment below)
-		file: LixFile;
 		/**
 		 * The file to which the changes should be applied.
 		 *
@@ -68,7 +58,7 @@ export type LixPlugin = {
 		 * that did not exist in the target version. Or, a file
 		 * has been deleted and should be restored at a later point.
 		 */
-		// file: Omit<LixFile, "data"> & { data?: LixFile["data"] };
+		file: Omit<LixFile, "data"> & { data?: LixFile["data"] };
 		changes: Array<Change>;
 	}) => Promise<{
 		fileData: LixFile["data"];

--- a/packages/lix-sdk/src/version/switch-version.ts
+++ b/packages/lix-sdk/src/version/switch-version.ts
@@ -1,3 +1,4 @@
+import { withSkipChangeQueue } from "../change-queue/with-skip-change-queue.js";
 import { applyChanges } from "../change/apply-changes.js";
 import type { Change, Version } from "../database/schema.js";
 import type { Lix } from "../lix/open-lix.js";
@@ -28,71 +29,76 @@ export async function switchVersion(args: {
 	to: Pick<Version, "id">;
 }): Promise<void> {
 	const executeInTransaction = async (trx: Lix["db"]) => {
-		const sourceVersion = await trx
-			.selectFrom("current_version")
-			.selectAll()
-			.executeTakeFirstOrThrow();
+		await withSkipChangeQueue(trx, async (trx) => {
+			const sourceVersion = await trx
+				.selectFrom("current_version")
+				.selectAll()
+				.executeTakeFirstOrThrow();
 
-		await trx.updateTable("current_version").set({ id: args.to.id }).execute();
+			await trx
+				.updateTable("current_version")
+				.set({ id: args.to.id })
+				.execute();
 
-		// need symmetric difference to detect inserts and deletions
-		// that should occur when switching the version
-		const versionChangesSymmetricDifference = await trx
-			.selectFrom("version_change")
-			.innerJoin("change", "version_change.change_id", "change.id")
-			.where(versionChangeInSymmetricDifference(sourceVersion, args.to))
-			.selectAll("change")
-			.execute();
-
-		// because we use the symmetric difference, entity
-		// changes need to be de-duplicated. in the future,
-		// we could improve the symmetric difference query
-		const toBeAppliedChanges: Map<string, Change> = new Map();
-
-		for (const change of versionChangesSymmetricDifference) {
-			const existingEntityChange = await trx
+			// need symmetric difference to detect inserts and deletions
+			// that should occur when switching the version
+			const versionChangesSymmetricDifference = await trx
 				.selectFrom("version_change")
-				.innerJoin("change", "change.id", "version_change.change_id")
-				.where("version_id", "=", args.to.id)
-				.where("change.entity_id", "=", change.entity_id)
-				.where("change.file_id", "=", change.file_id)
-				.where("change.schema_key", "=", change.schema_key)
+				.innerJoin("change", "version_change.change_id", "change.id")
+				.where(versionChangeInSymmetricDifference(sourceVersion, args.to))
 				.selectAll("change")
-				.executeTakeFirst();
+				.execute();
 
-			if (existingEntityChange) {
-				toBeAppliedChanges.set(
-					`${change.file_id},${change.entity_id},${change.schema_key}`,
-					existingEntityChange
-				);
-				continue;
-			}
-			// need to remove the entity when switching the version
-			else {
-				if (
-					change.plugin_key === "lix_own_entity" &&
-					(change.schema_key === "lix_account_table" ||
-						change.schema_key === "lix_version_table")
-				) {
-					// deleting accounts and versions when switching is
-					// not desired. a version should be able to jump to a
-					// different version and the accounts are not affected
+			// because we use the symmetric difference, entity
+			// changes need to be de-duplicated. in the future,
+			// we could improve the symmetric difference query
+			const toBeAppliedChanges: Map<string, Change> = new Map();
+
+			for (const change of versionChangesSymmetricDifference) {
+				const existingEntityChange = await trx
+					.selectFrom("version_change")
+					.innerJoin("change", "change.id", "version_change.change_id")
+					.where("version_id", "=", args.to.id)
+					.where("change.entity_id", "=", change.entity_id)
+					.where("change.file_id", "=", change.file_id)
+					.where("change.schema_key", "=", change.schema_key)
+					.selectAll("change")
+					.executeTakeFirst();
+
+				if (existingEntityChange) {
+					toBeAppliedChanges.set(
+						`${change.file_id},${change.entity_id},${change.schema_key}`,
+						existingEntityChange
+					);
 					continue;
 				}
-				// the entity does not exist in the switched to version
-				toBeAppliedChanges.set(
-					`${change.file_id},${change.entity_id},${change.schema_key}`,
-					{
-						...change,
-						snapshot_id: "no-content",
+				// need to remove the entity when switching the version
+				else {
+					if (
+						change.plugin_key === "lix_own_entity" &&
+						(change.schema_key === "lix_account_table" ||
+							change.schema_key === "lix_version_table")
+					) {
+						// deleting accounts and versions when switching is
+						// not desired. a version should be able to jump to a
+						// different version and the accounts are not affected
+						continue;
 					}
-				);
+					// the entity does not exist in the switched to version
+					toBeAppliedChanges.set(
+						`${change.file_id},${change.entity_id},${change.schema_key}`,
+						{
+							...change,
+							snapshot_id: "no-content",
+						}
+					);
+				}
 			}
-		}
 
-		return await applyChanges({
-			lix: { ...args.lix, db: trx },
-			changes: toBeAppliedChanges.values().toArray(),
+			return await applyChanges({
+				lix: { ...args.lix, db: trx },
+				changes: toBeAppliedChanges.values().toArray(),
+			});
 		});
 	};
 


### PR DESCRIPTION
closes https://github.com/opral/lix-sdk/issues/181

- enables re-construction of files and switching between versions where one file doesn't exist
- fixes change queue triggering in version switching
- updates csv plugin to create a new csv file when file.data is undefined