### PR TITLE
update paraglide sveltekit to svelte 5 runes

### DIFF
--- a/.changeset/nasty-donkeys-occur.md
+++ b/.changeset/nasty-donkeys-occur.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-sveltekit": minor
+---
+
+Updates internal components to Svelte 5 rune syntax. Closes https://github.com/opral/inlang-paraglide-js/issues/262 and fixes https://github.com/opral/inlang-paraglide-js/issues/272.

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/package.json
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/package.json
@@ -19,14 +19,14 @@
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "workspace:*",
-		"@sveltejs/adapter-node": "^5.0.1",
+		"@sveltejs/adapter-node": "^5.2.10",
 		"@sveltejs/adapter-static": "^3.0.0",
-		"@sveltejs/kit": "^2.5.17",
-		"@sveltejs/vite-plugin-svelte": "^3.0.2",
+		"@sveltejs/kit": "^2.12.1",
+		"@sveltejs/vite-plugin-svelte": "^4.0.3",
 		"rollup-plugin-visualizer": "^5.12.0",
-		"svelte": "^5.0.0",
+		"svelte": "^5.14.1",
 		"svelte-check": "^3.6.9",
-		"vite": "^5.2.6"
+		"vite": "^5.4.11"
 	},
 	"files": [
 		"*",

--- a/inlang/source-code/paraglide/paraglide-sveltekit/example/vite.config.ts
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/example/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
 		paraglide({
 			project: "./project.inlang",
 			outdir: "./src/lib/paraglide",
-			experimentalUseVirtualModules: true,
 		}),
 		sveltekit(),
 		visualizer({

--- a/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/AlternateLinks.svelte
+++ b/inlang/source-code/paraglide/paraglide-sveltekit/src/runtime/AlternateLinks.svelte
@@ -5,11 +5,13 @@
 	import { base as maybe_relative_base } from "$app/paths"
 	import { parseRoute, serializeRoute } from "./utils/route.js"
 
-	const absoluteBase = normaliseBase(maybe_relative_base, new URL($page.url)) || "/"
+	const absoluteBase = $derived(normaliseBase(maybe_relative_base, new URL($page.url)) || "/")
 
-	export let availableLanguageTags: readonly T[]
-	export let strategy: RoutingStrategy<T>
-	export let currentLang: T
+	const { availableLanguageTags, strategy, currentLang } = $props<{
+		availableLanguageTags?: readonly T[]
+		strategy:  RoutingStrategy<T>
+		currentLang: T
+	}>()
 
 	const getAlternateLinks = (canonicalPath: string, strategy: RoutingStrategy<T>) => {
 		const links: string[] = []
@@ -22,9 +24,9 @@
 		return links
 	}
 
-	$: localisedPath = parseRoute($page.url.pathname, absoluteBase)[0]
-	$: canonicalPath = strategy.getCanonicalPath(localisedPath, currentLang)
-	$: alternateLinks = getAlternateLinks(canonicalPath, strategy)
+	const localisedPath = $derived(parseRoute($page.url.pathname, absoluteBase)[0])
+	const canonicalPath = $derived(strategy.getCanonicalPath(localisedPath, currentLang))
+	const alternateLinks = $derived(getAlternateLinks(canonicalPath, strategy))
 </script>
 
 <!-- If there is more than one language, add alternate links -->

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 3.59.2
       svelte-check:
         specifier: ^3.6.9
-        version: 3.7.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)))(postcss@8.4.39)(svelte@3.59.2)
+        version: 3.7.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)))(postcss@8.4.49)(svelte@3.59.2)
       typescript:
         specifier: ^5.0.4
         version: 5.3.3
@@ -367,7 +367,7 @@ importers:
         version: 7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/web-components-vite':
         specifier: ^7.6.16
-        version: 7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
+        version: 7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
       '@types/chroma-js':
         specifier: ^2.4.4
         version: 2.4.4
@@ -1143,7 +1143,7 @@ importers:
         version: 7.6.19(lit@3.1.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/web-components-vite':
         specifier: ^7.6.16
-        version: 7.6.19(lit@3.1.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
+        version: 7.6.19(lit@3.1.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
       '@types/chroma-js':
         specifier: ^2.4.4
         version: 2.4.4
@@ -1400,7 +1400,7 @@ importers:
         version: 3.1.6
       '@astrojs/svelte':
         specifier: ^5.6.0
-        version: 5.7.0(astro@4.12.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)(typescript@5.5.3))(svelte@4.2.18)(typescript@5.5.3)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+        version: 5.7.0(astro@4.12.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)(typescript@5.5.3))(svelte@4.2.18)(typescript@5.5.3)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
       astro:
         specifier: ^4.11.3
         version: 4.12.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)(typescript@5.5.3)
@@ -1578,7 +1578,7 @@ importers:
         version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.3.4(@types/node@20.12.7)(lightningcss@1.25.1)(terser@5.31.6))
+        version: 4.2.1(vite@5.4.11(@types/node@20.12.7)(lightningcss@1.25.1)(terser@5.31.6))
       jsdom:
         specifier: 22.1.0
         version: 22.1.0
@@ -1735,7 +1735,7 @@ importers:
         version: 0.13.6(solid-js@1.8.17)
       '@solidjs/start':
         specifier: ^1.0.2
-        version: 1.0.2(rollup@4.20.0)(solid-js@1.8.17)(vinxi@0.3.12(@azure/identity@4.2.0)(@types/node@20.14.10)(ioredis@5.4.1)(lightningcss@1.25.1)(terser@5.31.6)(webpack-sources@3.2.3))(vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))
+        version: 1.0.2(rollup@4.20.0)(solid-js@1.8.17)(vinxi@0.3.12(@azure/identity@4.2.0)(@types/node@20.14.10)(ioredis@5.4.1)(lightningcss@1.25.1)(terser@5.31.6)(webpack-sources@3.2.3))(vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))
       solid-js:
         specifier: ^1.8.17
         version: 1.8.17
@@ -1836,29 +1836,29 @@ importers:
         specifier: workspace:*
         version: link:../../paraglide-js
       '@sveltejs/adapter-node':
-        specifier: ^5.0.1
-        version: 5.1.1(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))
+        specifier: ^5.2.10
+        version: 5.2.10(@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.0
-        version: 3.0.1(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))
+        version: 3.0.1(@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))
       '@sveltejs/kit':
-        specifier: ^2.5.17
-        version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+        specifier: ^2.12.1
+        version: 2.12.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^3.0.2
-        version: 3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+        specifier: ^4.0.3
+        version: 4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
       rollup-plugin-visualizer:
         specifier: ^5.12.0
-        version: 5.12.0(rollup@4.17.2)
+        version: 5.12.0(rollup@4.20.0)
       svelte:
-        specifier: ^5.0.0
-        version: 5.10.1
+        specifier: ^5.14.1
+        version: 5.14.1
       svelte-check:
         specifier: ^3.6.9
-        version: 3.7.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)))(postcss@8.4.39)(svelte@5.10.1)
+        version: 3.7.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)))(postcss@8.4.49)(svelte@5.14.1)
       vite:
-        specifier: ^5.2.6
-        version: 5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+        specifier: ^5.4.11
+        version: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
 
   inlang/source-code/paraglide/paraglide-unplugin:
     dependencies:
@@ -2612,7 +2612,7 @@ importers:
         version: 7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/web-components-vite':
         specifier: ^7.6.16
-        version: 7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
+        version: 7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
       '@types/chroma-js':
         specifier: ^2.4.4
         version: 2.4.4
@@ -6833,8 +6833,8 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/plugin-commonjs@26.0.1':
-    resolution: {integrity: sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==}
+  '@rollup/plugin-commonjs@28.0.2':
+    resolution: {integrity: sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
     peerDependencies:
       rollup: ^2.68.0||^3.0.0||^4.0.0
@@ -6862,6 +6862,15 @@ packages:
 
   '@rollup/plugin-node-resolve@15.2.3':
     resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-node-resolve@15.3.1':
+    resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
@@ -6940,11 +6949,6 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.17.2':
-    resolution: {integrity: sha512-NM0jFxY8bB8QLkoKxIQeObCaDlJKewVlIEkuyYKm5An1tdVZ966w2+MPQ2l8LBZLjR+SgyV+nRkTIunzOYBMLQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.18.0':
     resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}
     cpu: [arm]
@@ -6953,11 +6957,6 @@ packages:
   '@rollup/rollup-android-arm-eabi@4.20.0':
     resolution: {integrity: sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.17.2':
-    resolution: {integrity: sha512-yeX/Usk7daNIVwkq2uGoq2BYJKZY1JfyLTaHO/jaiSwi/lsf8fTFoQW/n6IdAsx5tx+iotu2zCJwz8MxI6D/Bw==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.18.0':
@@ -6970,11 +6969,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.17.2':
-    resolution: {integrity: sha512-kcMLpE6uCwls023+kknm71ug7MZOrtXo+y5p/tsg6jltpDtgQY1Eq5sGfHcQfb+lfuKwhBmEURDga9N0ol4YPw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.18.0':
     resolution: {integrity: sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==}
     cpu: [arm64]
@@ -6983,11 +6977,6 @@ packages:
   '@rollup/rollup-darwin-arm64@4.20.0':
     resolution: {integrity: sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.17.2':
-    resolution: {integrity: sha512-AtKwD0VEx0zWkL0ZjixEkp5tbNLzX+FCqGG1SvOu993HnSz4qDI6S4kGzubrEJAljpVkhRSlg5bzpV//E6ysTQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.18.0':
@@ -7000,11 +6989,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.17.2':
-    resolution: {integrity: sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.18.0':
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
     cpu: [arm]
@@ -7012,11 +6996,6 @@ packages:
 
   '@rollup/rollup-linux-arm-gnueabihf@4.20.0':
     resolution: {integrity: sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.17.2':
-    resolution: {integrity: sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==}
     cpu: [arm]
     os: [linux]
 
@@ -7030,11 +7009,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.17.2':
-    resolution: {integrity: sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
     cpu: [arm64]
@@ -7042,11 +7016,6 @@ packages:
 
   '@rollup/rollup-linux-arm64-gnu@4.20.0':
     resolution: {integrity: sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.17.2':
-    resolution: {integrity: sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==}
     cpu: [arm64]
     os: [linux]
 
@@ -7060,11 +7029,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.17.2':
-    resolution: {integrity: sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
     cpu: [ppc64]
@@ -7073,11 +7037,6 @@ packages:
   '@rollup/rollup-linux-powerpc64le-gnu@4.20.0':
     resolution: {integrity: sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==}
     cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.17.2':
-    resolution: {integrity: sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==}
-    cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
@@ -7090,11 +7049,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.17.2':
-    resolution: {integrity: sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
     cpu: [s390x]
@@ -7105,11 +7059,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.17.2':
-    resolution: {integrity: sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.18.0':
     resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
     cpu: [x64]
@@ -7117,11 +7066,6 @@ packages:
 
   '@rollup/rollup-linux-x64-gnu@4.20.0':
     resolution: {integrity: sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.17.2':
-    resolution: {integrity: sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==}
     cpu: [x64]
     os: [linux]
 
@@ -7135,11 +7079,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.17.2':
-    resolution: {integrity: sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
     resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
     cpu: [arm64]
@@ -7150,11 +7089,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.17.2':
-    resolution: {integrity: sha512-7II/QCSTAHuE5vdZaQEwJq2ZACkBpQDOmQsE6D6XUbnBHW8IAhm4eTufL6msLJorzrHDFv3CF8oCA/hSIRuZeQ==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.18.0':
     resolution: {integrity: sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==}
     cpu: [ia32]
@@ -7163,11 +7097,6 @@ packages:
   '@rollup/rollup-win32-ia32-msvc@4.20.0':
     resolution: {integrity: sha512-GabekH3w4lgAJpVxkk7hUzUf2hICSQO0a/BLFA11/RMxQT92MabKAqyubzDZmMOC/hcJNlc+rrypzNzYl4Dx7A==}
     cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.17.2':
-    resolution: {integrity: sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==}
-    cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.18.0':
@@ -7554,8 +7483,8 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
 
-  '@sveltejs/adapter-node@5.1.1':
-    resolution: {integrity: sha512-BQYLa9aWrL8D367p/NgSkDA58QOkoxoYs8HD7exYciAhyKx83LfF6QN8w+Uidg+H9ZX4nib7Fg0yDOKaxT4mxw==}
+  '@sveltejs/adapter-node@5.2.10':
+    resolution: {integrity: sha512-U0SCdULhHbSYCDgvvrHRtKUykl9GZkM/b3NyeIUtaxM39upQFd5059pWmXgTNaNTU1HMdj4xx0xvNAvQcIzmXQ==}
     peerDependencies:
       '@sveltejs/kit': ^2.4.0
 
@@ -7582,14 +7511,14 @@ packages:
       svelte: ^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0
       vite: ^4.0.0
 
-  '@sveltejs/kit@2.5.18':
-    resolution: {integrity: sha512-+g06hvpVAnH7b4CDjhnTDgFWBKBiQJpuSmQeGYOuzbO3SC3tdYjRNlDCrafvDtKbGiT2uxY5Dn9qdEUGVZdWOQ==}
+  '@sveltejs/kit@2.12.1':
+    resolution: {integrity: sha512-M3rPijGImeOkI0DBJSwjqz+YFX2DyOf6NzWgHVk3mqpT06dlYCpcv5xh1q4rYEqB58yQlk4QA1Y35PUqnUiFKw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.3
+      vite: ^5.0.3 || ^6.0.0
 
   '@sveltejs/kit@2.5.7':
     resolution: {integrity: sha512-6uedTzrb7nQrw6HALxnPrPaXdIN2jJJTzTIl96Z3P5NiG+OAfpdPbrWrvkJ3GN4CfWqrmU4dJqwMMRMTD/C7ow==}
@@ -7623,6 +7552,14 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
 
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1':
+    resolution: {integrity: sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^4.0.0-next.0||^4.0.0
+      svelte: ^5.0.0-next.96 || ^5.0.0
+      vite: ^5.0.0
+
   '@sveltejs/vite-plugin-svelte@2.5.3':
     resolution: {integrity: sha512-erhNtXxE5/6xGZz/M9eXsmI7Pxa6MS7jyTy06zN3Ck++ldrppOnOlJwHHTsMC7DHDQdgUp4NAc4cDNQ9eGdB/w==}
     engines: {node: ^14.18.0 || >= 16}
@@ -7642,6 +7579,13 @@ packages:
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.0
+
+  '@sveltejs/vite-plugin-svelte@4.0.3':
+    resolution: {integrity: sha512-J7nC5gT5qpmvyD2pmzPUntLUgoinyEaNy9sTpGGE6N7pblggO0A1NyneJJvR2ELlzK6ti28aF2SLXG1yJdnJeA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0-next.96 || ^5.0.0
       vite: ^5.0.0
 
   '@swc/counter@0.1.3':
@@ -10102,6 +10046,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
     engines: {node: '>=0.10.0'}
@@ -10312,6 +10265,9 @@ packages:
 
   devalue@5.0.0:
     resolution: {integrity: sha512-gO+/OMXF7488D+u3ue+G7Y4AA3ZmUnB3eHJXmBTgNHvr4ZNzl36A0ZtG+XCRNYCkYx/bFmw4qtkoFLa+wSrwAA==}
+
+  devalue@5.1.1:
+    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -11185,6 +11141,14 @@ packages:
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  fdir@6.4.2:
+    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
@@ -13014,6 +12978,9 @@ packages:
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
   magicast@0.2.11:
     resolution: {integrity: sha512-6saXbRDA1HMkqbsvHOU6HBjCVgZT460qheRkLhJQHWAbhXoWESI3Kn/dGGXyKs15FFKR85jsUqFx2sMK0wy/5g==}
 
@@ -14347,9 +14314,16 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
 
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
@@ -14532,6 +14506,10 @@ packages:
 
   postcss@8.4.39:
     resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
   posthog-js@1.130.2:
@@ -15337,11 +15315,6 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.17.2:
-    resolution: {integrity: sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.18.0:
     resolution: {integrity: sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -15612,6 +15585,10 @@ packages:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
 
+  sirv@3.0.0:
+    resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -15723,6 +15700,10 @@ packages:
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.19:
@@ -16099,8 +16080,8 @@ packages:
     resolution: {integrity: sha512-hRm52FjYUfd24eUlkBS41JSmqHOx6wt0cV+wMzgwqhhxIpJoz96eiMcnvcLqXx+gTxM1m0Pt/+7xP3vlm2QvPg==}
     engines: {node: '>=18'}
 
-  svelte@5.10.1:
-    resolution: {integrity: sha512-JOBw4VStdoP/Iw93vrzGAOUWdV4Gk8hCuprvTwjbdMZG3GyYxbLogR56XqrO2M7E6PifoPkwDphXu0s49R2wvw==}
+  svelte@5.14.1:
+    resolution: {integrity: sha512-DET9IJw6LUStRnu5rTXnlBs1fsJt417C9QXE8J+gIEWc4IsqxcJsa3OYUsf7ZJmDQbaBudcp4pxI7Za0NR1QYg==}
     engines: {node: '>=18'}
 
   symbol-tree@3.2.4:
@@ -17256,10 +17237,49 @@ packages:
       terser:
         optional: true
 
+  vite@5.4.11:
+    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vitefu@0.2.5:
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  vitefu@1.0.4:
+    resolution: {integrity: sha512-y6zEE3PQf6uu/Mt6DTJ9ih+kyJLr4XcSgHR2zUkM8SWDhuixEJxfJ6CZGMHh1Ec3vPLoEA0IHU5oWzVqw8ulow==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -18044,9 +18064,9 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/svelte@5.7.0(astro@4.12.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)(typescript@5.5.3))(svelte@4.2.18)(typescript@5.5.3)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
+  '@astrojs/svelte@5.7.0(astro@4.12.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)(typescript@5.5.3))(svelte@4.2.18)(typescript@5.5.3)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.18)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.18)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
       astro: 4.12.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)(typescript@5.5.3)
       svelte: 4.2.18
       svelte2tsx: 0.7.13(svelte@4.2.18)(typescript@5.5.3)
@@ -18058,7 +18078,7 @@ snapshots:
   '@astrojs/telemetry@3.1.0':
     dependencies:
       ci-info: 4.0.0
-      debug: 4.3.6
+      debug: 4.4.0
       dlv: 1.1.3
       dset: 3.1.3
       is-docker: 3.0.0
@@ -18223,7 +18243,7 @@ snapshots:
       '@babel/traverse': 7.25.3
       '@babel/types': 7.25.2
       convert-source-map: 2.0.0
-      debug: 4.3.6
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -18311,7 +18331,7 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.6
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -19224,7 +19244,7 @@ snapshots:
       '@babel/parser': 7.25.3
       '@babel/template': 7.25.0
       '@babel/types': 7.25.2
-      debug: 4.3.6
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -19913,7 +19933,7 @@ snapshots:
   '@eslint/eslintrc@3.0.2':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.6
+      debug: 4.4.0
       espree: 10.0.1
       globals: 14.0.0
       ignore: 5.3.1
@@ -20008,7 +20028,7 @@ snapshots:
   '@humanwhocodes/config-array@0.12.3':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.6
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21618,6 +21638,7 @@ snapshots:
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -21793,20 +21814,21 @@ snapshots:
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
-      magic-string: 0.30.11
+      magic-string: 0.30.17
     optionalDependencies:
       rollup: 4.20.0
 
-  '@rollup/plugin-commonjs@26.0.1(rollup@4.17.2)':
+  '@rollup/plugin-commonjs@28.0.2(rollup@4.20.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.20.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      glob: 10.4.1
+      fdir: 6.4.2(picomatch@4.0.2)
       is-reference: 1.2.1
-      magic-string: 0.30.11
+      magic-string: 0.30.17
+      picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.17.2
+      rollup: 4.20.0
 
   '@rollup/plugin-inject@5.0.5(rollup@4.20.0)':
     dependencies:
@@ -21821,12 +21843,6 @@ snapshots:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.1)
     optionalDependencies:
       rollup: 3.29.1
-
-  '@rollup/plugin-json@6.1.0(rollup@4.17.2)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
-    optionalDependencies:
-      rollup: 4.17.2
 
   '@rollup/plugin-json@6.1.0(rollup@4.20.0)':
     dependencies:
@@ -21845,23 +21861,11 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.1
 
-  '@rollup/plugin-node-resolve@15.2.3(rollup@4.17.2)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-builtin-module: 3.2.1
-      is-module: 1.0.0
-      resolve: 1.22.8
-    optionalDependencies:
-      rollup: 4.17.2
-
-  '@rollup/plugin-node-resolve@15.2.3(rollup@4.20.0)':
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.20.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.20.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
-      is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
     optionalDependencies:
@@ -21877,7 +21881,7 @@ snapshots:
   '@rollup/plugin-replace@5.0.7(rollup@4.20.0)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.20.0)
-      magic-string: 0.30.11
+      magic-string: 0.30.17
     optionalDependencies:
       rollup: 4.20.0
 
@@ -21917,38 +21921,24 @@ snapshots:
 
   '@rollup/pluginutils@5.1.0(rollup@3.29.1)':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 3.29.1
 
-  '@rollup/pluginutils@5.1.0(rollup@4.17.2)':
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.17.2
-
   '@rollup/pluginutils@5.1.0(rollup@4.20.0)':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 4.20.0
 
-  '@rollup/rollup-android-arm-eabi@4.17.2':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.18.0':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.20.0':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.17.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.18.0':
@@ -21957,16 +21947,10 @@ snapshots:
   '@rollup/rollup-android-arm64@4.20.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.17.2':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.18.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.20.0':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.17.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.18.0':
@@ -21975,16 +21959,10 @@ snapshots:
   '@rollup/rollup-darwin-x64@4.20.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.17.2':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.20.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.17.2':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
@@ -21993,16 +21971,10 @@ snapshots:
   '@rollup/rollup-linux-arm-musleabihf@4.20.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.17.2':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.20.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.17.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
@@ -22011,16 +21983,10 @@ snapshots:
   '@rollup/rollup-linux-arm64-musl@4.20.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.17.2':
-    optional: true
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.20.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.17.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
@@ -22029,16 +21995,10 @@ snapshots:
   '@rollup/rollup-linux-riscv64-gnu@4.20.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.17.2':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.20.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.17.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
@@ -22047,16 +22007,10 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.20.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.17.2':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.18.0':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.20.0':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.17.2':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
@@ -22065,16 +22019,10 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.20.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.17.2':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.18.0':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.20.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.17.2':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.18.0':
@@ -22354,7 +22302,7 @@ snapshots:
     dependencies:
       solid-js: 1.8.17
 
-  '@solidjs/start@1.0.2(rollup@4.20.0)(solid-js@1.8.17)(vinxi@0.3.12(@azure/identity@4.2.0)(@types/node@20.14.10)(ioredis@5.4.1)(lightningcss@1.25.1)(terser@5.31.6)(webpack-sources@3.2.3))(vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))':
+  '@solidjs/start@1.0.2(rollup@4.20.0)(solid-js@1.8.17)(vinxi@0.3.12(@azure/identity@4.2.0)(@types/node@20.14.10)(ioredis@5.4.1)(lightningcss@1.25.1)(terser@5.31.6)(webpack-sources@3.2.3))(vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
       '@vinxi/plugin-directives': 0.3.1(vinxi@0.3.12(@azure/identity@4.2.0)(@types/node@20.14.10)(ioredis@5.4.1)(lightningcss@1.25.1)(terser@5.31.6)(webpack-sources@3.2.3))
       '@vinxi/server-components': 0.3.3(vinxi@0.3.12(@azure/identity@4.2.0)(@types/node@20.14.10)(ioredis@5.4.1)(lightningcss@1.25.1)(terser@5.31.6)(webpack-sources@3.2.3))
@@ -22369,8 +22317,8 @@ snapshots:
       shikiji: 0.9.19
       source-map-js: 1.2.0
       terracotta: 1.0.5(solid-js@1.8.17)
-      vite-plugin-inspect: 0.7.42(rollup@4.20.0)(vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))
-      vite-plugin-solid: 2.10.2(solid-js@1.8.17)(vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))
+      vite-plugin-inspect: 0.7.42(rollup@4.20.0)(vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))
+      vite-plugin-solid: 2.10.2(solid-js@1.8.17)(vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@testing-library/jest-dom'
@@ -22546,7 +22494,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-vite@7.6.19(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)':
+  '@storybook/builder-vite@7.6.19(typescript@5.5.4)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)':
     dependencies:
       '@storybook/channels': 7.6.19
       '@storybook/client-logger': 7.6.19
@@ -22564,7 +22512,7 @@ snapshots:
       fs-extra: 11.2.0
       magic-string: 0.30.10
       rollup: 3.29.1
-      vite: 5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -22892,9 +22840,9 @@ snapshots:
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
 
-  '@storybook/web-components-vite@7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)':
+  '@storybook/web-components-vite@7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)':
     dependencies:
-      '@storybook/builder-vite': 7.6.19(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
+      '@storybook/builder-vite': 7.6.19(typescript@5.5.4)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
       '@storybook/core-server': 7.6.19
       '@storybook/node-logger': 7.6.19
       '@storybook/web-components': 7.6.19(lit@3.1.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22913,9 +22861,9 @@ snapshots:
       - vite-plugin-glimmerx
       - webpack-sources
 
-  '@storybook/web-components-vite@7.6.19(lit@3.1.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)':
+  '@storybook/web-components-vite@7.6.19(lit@3.1.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)':
     dependencies:
-      '@storybook/builder-vite': 7.6.19(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
+      '@storybook/builder-vite': 7.6.19(typescript@5.5.4)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))(webpack-sources@3.2.3)
       '@storybook/core-server': 7.6.19
       '@storybook/node-logger': 7.6.19
       '@storybook/web-components': 7.6.19(lit@3.1.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -22975,21 +22923,21 @@ snapshots:
       '@sveltejs/kit': 1.30.4(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/adapter-node@5.1.1(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))':
+  '@sveltejs/adapter-node@5.2.10(@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))':
     dependencies:
-      '@rollup/plugin-commonjs': 26.0.1(rollup@4.17.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.17.2)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.17.2)
-      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
-      rollup: 4.17.2
+      '@rollup/plugin-commonjs': 28.0.2(rollup@4.20.0)
+      '@rollup/plugin-json': 6.1.0(rollup@4.20.0)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.20.0)
+      '@sveltejs/kit': 2.12.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      rollup: 4.20.0
 
   '@sveltejs/adapter-static@2.0.3(@sveltejs/kit@1.30.4(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))':
     dependencies:
       '@sveltejs/kit': 1.30.4(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
 
-  '@sveltejs/adapter-static@3.0.1(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))':
+  '@sveltejs/adapter-static@3.0.1(@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))':
     dependencies:
-      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      '@sveltejs/kit': 2.12.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
 
   '@sveltejs/adapter-vercel@2.4.3(@sveltejs/kit@1.30.4(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))':
     dependencies:
@@ -23020,23 +22968,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
+  '@sveltejs/kit@2.12.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      '@sveltejs/vite-plugin-svelte': 4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
-      devalue: 5.0.0
-      esm-env: 1.0.0
+      devalue: 5.1.1
+      esm-env: 1.2.1
       import-meta-resolve: 4.1.0
       kleur: 4.1.5
-      magic-string: 0.30.10
+      magic-string: 0.30.11
       mrmime: 2.0.0
       sade: 1.8.1
       set-cookie-parser: 2.6.0
-      sirv: 2.0.4
-      svelte: 5.10.1
+      sirv: 3.0.0
+      svelte: 5.14.1
       tiny-glob: 0.2.9
-      vite: 5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
 
   '@sveltejs/kit@2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.0.0-next.143)(vite@5.3.3(@types/node@20.12.12)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.0.0-next.143)(vite@5.3.3(@types/node@20.12.12)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
@@ -23070,7 +23018,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
-      debug: 4.3.6
+      debug: 4.4.0
       svelte: 3.59.2
       vite: 4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
@@ -23079,37 +23027,37 @@ snapshots:
   '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.0.0-next.143)(vite@5.3.3(@types/node@20.12.12)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.0.0-next.143)(vite@5.3.3(@types/node@20.12.12)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.0.0-next.143)(vite@5.3.3(@types/node@20.12.12)(lightningcss@1.25.1)(terser@5.31.6))
-      debug: 4.3.6
+      debug: 4.4.0
       svelte: 5.0.0-next.143
       vite: 5.3.3(@types/node@20.12.12)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@4.2.18)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
-      debug: 4.3.6
-      svelte: 5.10.1
-      vite: 5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.18)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      debug: 4.4.0
+      svelte: 4.2.18
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@4.2.18)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.18)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
-      debug: 4.3.6
-      svelte: 4.2.18
-      vite: 5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+      '@sveltejs/vite-plugin-svelte': 4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      debug: 4.4.0
+      svelte: 5.14.1
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
       - supports-color
 
   '@sveltejs/vite-plugin-svelte@2.5.3(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
       '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@3.59.2)(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
-      debug: 4.3.6
+      debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       svelte: 3.59.2
       svelte-hmr: 0.15.3(svelte@3.59.2)
       vite: 4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
@@ -23131,31 +23079,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
+  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.10.1)(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
-      debug: 4.3.4(supports-color@8.1.1)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@4.2.18)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
-      magic-string: 0.30.10
-      svelte: 5.10.1
-      svelte-hmr: 0.16.0(svelte@5.10.1)
-      vite: 5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
-      vitefu: 0.2.5(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      magic-string: 0.30.17
+      svelte: 4.2.18
+      svelte-hmr: 0.16.0(svelte@4.2.18)
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+      vitefu: 0.2.5(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
+  '@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@4.2.18)(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
-      debug: 4.3.6
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.3(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)))(svelte@5.14.1)(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
-      magic-string: 0.30.11
-      svelte: 4.2.18
-      svelte-hmr: 0.16.0(svelte@4.2.18)
-      vite: 5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
-      vitefu: 0.2.5(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
+      magic-string: 0.30.17
+      svelte: 5.14.1
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+      vitefu: 1.0.4(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -23424,7 +23371,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   '@types/argparse@1.0.38': {}
 
@@ -23514,21 +23461,21 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 8.56.10
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   '@types/eslint@7.29.0':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
 
   '@types/eslint@8.56.10':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   '@types/estree@1.0.5': {}
 
@@ -23809,7 +23756,7 @@ snapshots:
       '@types/node': 20.14.10
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2)':
+  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
@@ -23824,7 +23771,7 @@ snapshots:
       semver: 7.6.3
       tsutils: 3.21.0(typescript@5.0.3)
     optionalDependencies:
-      typescript: 5.3.2
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -23896,7 +23843,7 @@ snapshots:
       '@typescript-eslint/type-utils': 7.7.0(eslint@9.0.0)(typescript@5.2.2)
       '@typescript-eslint/utils': 7.7.0(eslint@9.0.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.3.6
+      debug: 4.4.0
       eslint: 9.0.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -23986,7 +23933,7 @@ snapshots:
       '@typescript-eslint/types': 7.7.0
       '@typescript-eslint/typescript-estree': 7.7.0(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.3.6
+      debug: 4.4.0
       eslint: 9.0.0
     optionalDependencies:
       typescript: 5.2.2
@@ -24017,7 +23964,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.0.3)
       '@typescript-eslint/utils': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
-      debug: 4.3.6
+      debug: 4.4.0
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.0.3)
     optionalDependencies:
@@ -24065,7 +24012,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.7.0(typescript@5.2.2)
       '@typescript-eslint/utils': 7.7.0(eslint@9.0.0)(typescript@5.2.2)
-      debug: 4.3.6
+      debug: 4.4.0
       eslint: 9.0.0
       ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
@@ -24085,7 +24032,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.56.0
       '@typescript-eslint/visitor-keys': 5.56.0
-      debug: 4.3.6
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -24099,7 +24046,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.6
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -24173,7 +24120,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.7.0
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.3.6
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -24342,7 +24289,7 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.7.1
       outdent: 0.8.0
-      vite: 5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
       vite-node: 1.6.0(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
       - '@types/node'
@@ -24350,6 +24297,7 @@ snapshots:
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -24449,14 +24397,14 @@ snapshots:
       recast: 0.23.6
       vinxi: 0.3.12(@azure/identity@4.2.0)(@types/node@20.14.10)(ioredis@5.4.1)(lightningcss@1.25.1)(terser@5.31.6)(webpack-sources@3.2.3)
 
-  '@vitejs/plugin-react@4.2.1(vite@5.3.4(@types/node@20.12.7)(lightningcss@1.25.1)(terser@5.31.6))':
+  '@vitejs/plugin-react@4.2.1(vite@5.4.11(@types/node@20.12.7)(lightningcss@1.25.1)(terser@5.31.6))':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-transform-react-jsx-self': 7.24.5(@babel/core@7.24.5)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.5)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.3.4(@types/node@20.12.7)(lightningcss@1.25.1)(terser@5.31.6)
+      vite: 5.4.11(@types/node@20.12.7)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -25107,7 +25055,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.6
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25583,7 +25531,7 @@ snapshots:
     dependencies:
       '@fastify/error': 3.4.1
       archy: 1.0.0
-      debug: 4.3.6
+      debug: 4.4.0
       fastq: 1.17.1
     transitivePeerDependencies:
       - supports-color
@@ -26707,6 +26655,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   decamelize-keys@1.1.1:
     dependencies:
       decamelize: 1.2.0
@@ -26905,7 +26857,7 @@ snapshots:
   detect-port@1.5.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.6
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -26916,6 +26868,8 @@ snapshots:
   devalue@4.3.3: {}
 
   devalue@5.0.0: {}
+
+  devalue@5.1.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -27257,7 +27211,7 @@ snapshots:
 
   esbuild-register@3.5.0(esbuild@0.18.20):
     dependencies:
-      debug: 4.3.6
+      debug: 4.4.0
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
@@ -27443,7 +27397,7 @@ snapshots:
       '@babel/eslint-parser': 7.21.3(@babel/core@7.21.4)(eslint@8.57.0)
       '@babel/preset-react': 7.18.6(@babel/core@7.21.4)
       '@next/eslint-plugin-next': 13.2.4
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3)
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
       confusing-browser-globals: 1.0.11
       eslint: 8.57.0
@@ -27453,7 +27407,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0)
       eslint-plugin-etc: 2.0.2(eslint@8.57.0)(typescript@5.0.3)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0)
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -27732,12 +27686,12 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3):
+  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.0.3)
       eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -28186,12 +28140,12 @@ snapshots:
   esrap@1.2.2:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   esrap@1.2.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   esrecurse@4.3.0:
     dependencies:
@@ -28203,11 +28157,11 @@ snapshots:
 
   estree-util-attach-comments@2.1.1:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   estree-util-build-jsx@2.2.2:
     dependencies:
@@ -28559,6 +28513,10 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+
+  fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   fetch-blob@3.2.0:
     dependencies:
@@ -28913,7 +28871,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.3.6
+      debug: 4.4.0
       fs-extra: 11.2.0
     transitivePeerDependencies:
       - supports-color
@@ -29304,7 +29262,7 @@ snapshots:
 
   hast-util-to-estree@2.3.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/estree-jsx': 1.0.5
       '@types/hast': 2.3.10
       '@types/unist': 2.0.10
@@ -29324,7 +29282,7 @@ snapshots:
 
   hast-util-to-estree@3.1.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -29360,7 +29318,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/hast': 3.0.4
       '@types/unist': 3.0.2
       comma-separated-tokens: 2.0.3
@@ -29496,7 +29454,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.6
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -29504,14 +29462,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.6
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.6
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -29559,7 +29517,7 @@ snapshots:
   https-proxy-agent@4.0.0:
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.6
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -29580,7 +29538,7 @@ snapshots:
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.6
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -29705,7 +29663,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.6
+      debug: 4.4.0
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -30674,6 +30632,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   magicast@0.2.11:
     dependencies:
       '@babel/parser': 7.25.3
@@ -31330,7 +31292,7 @@ snapshots:
 
   micromark-extension-mdx-expression@1.0.8:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
@@ -31341,7 +31303,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.1
       micromark-factory-space: 2.0.0
@@ -31353,7 +31315,7 @@ snapshots:
   micromark-extension-mdx-jsx@1.0.5:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       estree-util-is-identifier-name: 2.1.0
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
@@ -31366,7 +31328,7 @@ snapshots:
   micromark-extension-mdx-jsx@3.0.0:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.1
@@ -31386,7 +31348,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@1.0.5:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       micromark-core-commonmark: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
@@ -31398,7 +31360,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
       micromark-util-character: 2.1.0
@@ -31458,7 +31420,7 @@ snapshots:
 
   micromark-factory-mdx-expression@1.0.9:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
       micromark-util-symbol: 1.1.0
@@ -31469,7 +31431,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.1:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       devlop: 1.1.0
       micromark-util-character: 2.1.0
       micromark-util-events-to-acorn: 2.0.2
@@ -31585,7 +31547,7 @@ snapshots:
   micromark-util-events-to-acorn@1.2.3:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/unist': 2.0.10
       estree-util-visit: 1.2.1
       micromark-util-symbol: 1.1.0
@@ -31596,7 +31558,7 @@ snapshots:
   micromark-util-events-to-acorn@2.0.2:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/unist': 3.0.2
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -31661,7 +31623,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.6
+      debug: 4.4.0
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -31683,7 +31645,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.6
+      debug: 4.4.0
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -31917,7 +31879,7 @@ snapshots:
 
   nanospinner@1.1.0:
     dependencies:
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   napi-build-utils@1.0.2:
     optional: true
@@ -32017,7 +31979,7 @@ snapshots:
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.20.0)
       '@rollup/plugin-inject': 5.0.5(rollup@4.20.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.20.0)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.20.0)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.20.0)
       '@rollup/plugin-replace': 5.0.7(rollup@4.20.0)
       '@rollup/plugin-terser': 0.4.4(rollup@4.20.0)
       '@rollup/pluginutils': 5.1.0(rollup@4.20.0)
@@ -32050,7 +32012,7 @@ snapshots:
       klona: 2.0.6
       knitwork: 1.1.0
       listhen: 1.7.2
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       mime: 4.0.4
       mlly: 1.7.1
       mri: 1.2.0
@@ -32664,7 +32626,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.1
-      debug: 4.3.6
+      debug: 4.4.0
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.2
@@ -32878,7 +32840,11 @@ snapshots:
 
   picocolors@1.0.1: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  picomatch@4.0.2: {}
 
   pidtree@0.6.0: {}
 
@@ -33013,15 +32979,6 @@ snapshots:
       postcss: 8.4.39
       ts-node: 10.9.2(@types/node@20.14.15)(typescript@5.3.2)
 
-  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)):
-    dependencies:
-      lilconfig: 3.1.2
-      yaml: 2.4.2
-    optionalDependencies:
-      postcss: 8.4.39
-      ts-node: 10.9.2(@types/node@20.14.15)(typescript@5.3.3)
-    optional: true
-
   postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.2
@@ -33045,6 +33002,24 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.39
       ts-node: 10.9.2(@types/node@20.5.9)(typescript@5.5.3)
+
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.4.2
+    optionalDependencies:
+      postcss: 8.4.49
+      ts-node: 10.9.2(@types/node@20.14.15)(typescript@5.3.3)
+    optional: true
+
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.4.2
+    optionalDependencies:
+      postcss: 8.4.49
+      ts-node: 10.9.2(@types/node@20.14.15)(typescript@5.5.4)
+    optional: true
 
   postcss-modules-extract-imports@3.1.0(postcss@8.4.39):
     dependencies:
@@ -33119,6 +33094,12 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
+
+  postcss@8.4.49:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   posthog-js@1.130.2:
     dependencies:
@@ -33346,7 +33327,7 @@ snapshots:
   proxy-agent@6.3.0:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.6
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.2
       lru-cache: 7.18.3
@@ -33359,7 +33340,7 @@ snapshots:
   proxy-agent@6.3.1:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.6
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.2
       lru-cache: 7.18.3
@@ -33409,7 +33390,7 @@ snapshots:
   puppeteer-core@2.1.1:
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.3.6
+      debug: 4.4.0
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -34165,15 +34146,6 @@ snapshots:
       rollup: 3.29.1
       svelte: 5.0.0-next.143
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.17.2):
-    dependencies:
-      open: 8.4.2
-      picomatch: 2.3.1
-      source-map: 0.7.4
-      yargs: 17.7.2
-    optionalDependencies:
-      rollup: 4.17.2
-
   rollup-plugin-visualizer@5.12.0(rollup@4.20.0):
     dependencies:
       open: 8.4.2
@@ -34194,28 +34166,6 @@ snapshots:
 
   rollup@3.29.1:
     optionalDependencies:
-      fsevents: 2.3.3
-
-  rollup@4.17.2:
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.17.2
-      '@rollup/rollup-android-arm64': 4.17.2
-      '@rollup/rollup-darwin-arm64': 4.17.2
-      '@rollup/rollup-darwin-x64': 4.17.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.17.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.17.2
-      '@rollup/rollup-linux-arm64-gnu': 4.17.2
-      '@rollup/rollup-linux-arm64-musl': 4.17.2
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.17.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.17.2
-      '@rollup/rollup-linux-s390x-gnu': 4.17.2
-      '@rollup/rollup-linux-x64-gnu': 4.17.2
-      '@rollup/rollup-linux-x64-musl': 4.17.2
-      '@rollup/rollup-win32-arm64-msvc': 4.17.2
-      '@rollup/rollup-win32-ia32-msvc': 4.17.2
-      '@rollup/rollup-win32-x64-msvc': 4.17.2
       fsevents: 2.3.3
 
   rollup@4.18.0:
@@ -34570,6 +34520,12 @@ snapshots:
       mrmime: 2.0.0
       totalist: 3.0.1
 
+  sirv@3.0.0:
+    dependencies:
+      '@polka/url': 1.0.0-next.25
+      mrmime: 2.0.0
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@7.1.2:
@@ -34586,7 +34542,7 @@ snapshots:
       globby: 11.1.0
       lilconfig: 2.1.0
       nanospinner: 1.1.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   slash@2.0.0: {}
 
@@ -34612,7 +34568,7 @@ snapshots:
   socks-proxy-agent@8.0.3:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.6
+      debug: 4.4.0
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -34718,6 +34674,8 @@ snapshots:
       is-plain-obj: 1.1.0
 
   source-map-js@1.2.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.19:
     dependencies:
@@ -35012,7 +34970,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.7.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)))(postcss@8.4.39)(svelte@3.59.2):
+  svelte-check@3.7.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)))(postcss@8.4.49)(svelte@3.59.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
@@ -35021,7 +34979,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.59.2
-      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)))(postcss@8.4.39)(svelte@3.59.2)(typescript@5.5.4)
+      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)))(postcss@8.4.49)(svelte@3.59.2)(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -35034,7 +34992,7 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-check@3.7.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)))(postcss@8.4.39)(svelte@5.10.1):
+  svelte-check@3.7.1(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)))(postcss@8.4.49)(svelte@5.14.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
@@ -35042,8 +35000,8 @@ snapshots:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 5.10.1
-      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)))(postcss@8.4.39)(svelte@5.10.1)(typescript@5.5.4)
+      svelte: 5.14.1
+      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)))(postcss@8.4.49)(svelte@5.14.1)(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -35072,36 +35030,32 @@ snapshots:
     dependencies:
       svelte: 5.0.0-next.143
 
-  svelte-hmr@0.16.0(svelte@5.10.1):
-    dependencies:
-      svelte: 5.10.1
-
-  svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)))(postcss@8.4.39)(svelte@3.59.2)(typescript@5.5.4):
+  svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3)))(postcss@8.4.49)(svelte@3.59.2)(typescript@5.5.4):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 3.59.2
     optionalDependencies:
       '@babel/core': 7.25.2
-      postcss: 8.4.39
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3))
+      postcss: 8.4.49
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.3.3))
       typescript: 5.5.4
 
-  svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)))(postcss@8.4.39)(svelte@5.10.1)(typescript@5.5.4):
+  svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4)))(postcss@8.4.49)(svelte@5.14.1)(typescript@5.5.4):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 5.10.1
+      svelte: 5.14.1
     optionalDependencies:
       '@babel/core': 7.25.2
-      postcss: 8.4.39
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4))
+      postcss: 8.4.49
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.14.15)(typescript@5.5.4))
       typescript: 5.5.4
 
   svelte2tsx@0.7.13(svelte@4.2.18)(typescript@5.5.3):
@@ -35153,11 +35107,11 @@ snapshots:
       magic-string: 0.30.10
       zimmerframe: 1.1.2
 
-  svelte@5.10.1:
+  svelte@5.14.1:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       acorn: 8.12.1
       acorn-typescript: 1.4.13(acorn@8.12.1)
       aria-query: 5.3.2
@@ -36087,7 +36041,7 @@ snapshots:
     dependencies:
       acorn: 8.12.1
       estree-walker: 3.0.3
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       unplugin: 1.14.1(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - webpack-sources
@@ -36180,7 +36134,7 @@ snapshots:
       estree-walker: 3.0.3
       fast-glob: 3.3.2
       local-pkg: 0.5.0
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       mlly: 1.7.1
       pathe: 1.1.2
       pkg-types: 1.1.3
@@ -36370,7 +36324,7 @@ snapshots:
   unwasm@0.3.9(webpack-sources@3.2.3):
     dependencies:
       knitwork: 1.1.0
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       mlly: 1.7.1
       pathe: 1.1.2
       pkg-types: 1.1.3
@@ -36601,7 +36555,7 @@ snapshots:
       unctx: 2.3.1(webpack-sources@3.2.3)
       unenv: 1.10.0
       unstorage: 1.10.2(@azure/identity@4.2.0)(ioredis@5.4.1)
-      vite: 5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
+      vite: 5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
       zod: 3.23.8
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -36627,6 +36581,7 @@ snapshots:
       - lightningcss
       - magicast
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -36642,7 +36597,7 @@ snapshots:
       mlly: 1.7.1
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
+      vite: 4.5.2(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -36656,15 +36611,16 @@ snapshots:
   vite-node@1.6.0(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.6
+      debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
       - lightningcss
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
@@ -36687,17 +36643,17 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(rollup@4.20.0)(vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)):
+  vite-plugin-inspect@0.7.42(rollup@4.20.0)(vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)):
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0(rollup@4.20.0)
-      debug: 4.3.6
+      debug: 4.4.0
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 9.1.0
       picocolors: 1.0.1
       sirv: 2.0.4
-      vite: 5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
+      vite: 5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -36735,7 +36691,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.10.2(solid-js@1.8.17)(vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)):
+  vite-plugin-solid@2.10.2(solid-js@1.8.17)(vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)):
     dependencies:
       '@babel/core': 7.25.2
       '@types/babel__core': 7.20.5
@@ -36743,8 +36699,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.8.17
       solid-refresh: 0.6.3(solid-js@1.8.17)
-      vite: 5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
-      vitefu: 0.2.5(vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))
+      vite: 5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
+      vitefu: 0.2.5(vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -36822,6 +36778,17 @@ snapshots:
       lightningcss: 1.25.1
       terser: 5.31.6
 
+  vite@4.5.2(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6):
+    dependencies:
+      esbuild: 0.18.20
+      postcss: 8.4.39
+      rollup: 3.29.1
+    optionalDependencies:
+      '@types/node': 20.14.10
+      fsevents: 2.3.3
+      lightningcss: 1.25.1
+      terser: 5.31.6
+
   vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6):
     dependencies:
       esbuild: 0.18.20
@@ -36866,28 +36833,6 @@ snapshots:
       lightningcss: 1.25.1
       terser: 5.31.6
 
-  vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.39
-      rollup: 4.18.0
-    optionalDependencies:
-      '@types/node': 20.14.15
-      fsevents: 2.3.3
-      lightningcss: 1.25.1
-      terser: 5.31.6
-
-  vite@5.3.4(@types/node@20.12.7)(lightningcss@1.25.1)(terser@5.31.6):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.39
-      rollup: 4.18.0
-    optionalDependencies:
-      '@types/node': 20.12.7
-      fsevents: 2.3.3
-      lightningcss: 1.25.1
-      terser: 5.31.6
-
   vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6):
     dependencies:
       esbuild: 0.21.5
@@ -36910,6 +36855,39 @@ snapshots:
       lightningcss: 1.25.1
       terser: 5.31.6
 
+  vite@5.4.11(@types/node@20.12.7)(lightningcss@1.25.1)(terser@5.31.6):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.20.0
+    optionalDependencies:
+      '@types/node': 20.12.7
+      fsevents: 2.3.3
+      lightningcss: 1.25.1
+      terser: 5.31.6
+
+  vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.20.0
+    optionalDependencies:
+      '@types/node': 20.14.10
+      fsevents: 2.3.3
+      lightningcss: 1.25.1
+      terser: 5.31.6
+
+  vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.20.0
+    optionalDependencies:
+      '@types/node': 20.14.15
+      fsevents: 2.3.3
+      lightningcss: 1.25.1
+      terser: 5.31.6
+
   vitefu@0.2.5(vite@4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)):
     optionalDependencies:
       vite: 4.5.2(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
@@ -36922,17 +36900,21 @@ snapshots:
     optionalDependencies:
       vite: 5.3.3(@types/node@20.12.12)(lightningcss@1.25.1)(terser@5.31.6)
 
-  vitefu@0.2.5(vite@5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)):
-    optionalDependencies:
-      vite: 5.3.3(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
-
-  vitefu@0.2.5(vite@5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)):
-    optionalDependencies:
-      vite: 5.3.4(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
-
   vitefu@0.2.5(vite@5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)):
     optionalDependencies:
       vite: 5.3.4(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+
+  vitefu@0.2.5(vite@5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)):
+    optionalDependencies:
+      vite: 5.4.11(@types/node@20.14.10)(lightningcss@1.25.1)(terser@5.31.6)
+
+  vitefu@0.2.5(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)):
+    optionalDependencies:
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
+
+  vitefu@1.0.4(vite@5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)):
+    optionalDependencies:
+      vite: 5.4.11(@types/node@20.14.15)(lightningcss@1.25.1)(terser@5.31.6)
 
   vitest@0.34.6(jsdom@22.1.0)(lightningcss@1.25.1)(playwright@1.39.0)(safaridriver@0.1.2)(terser@5.31.6)(webdriverio@8.39.1(typescript@5.2.2)):
     dependencies:
@@ -37255,7 +37237,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.3.6
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Closes https://github.com/opral/inlang-paraglide-js/issues/262. 

Changes: 

- update components to svelte 5 runes
- update dependencies of paraglide sveltekit example