### PR TITLE
refactor: rename `parent` to `from`

### DIFF
--- a/.changeset/slow-pens-occur.md
+++ b/.changeset/slow-pens-occur.md
@@ -1,0 +1,10 @@
+---
+"@lix-js/sdk": patch
+---
+
+refactor: rename `parent` to `from` in `createVersion()` https://github.com/opral/lix-sdk/issues/213
+
+```diff
+-await createVersion({ lix, parent: currentVersion })
++await createVersion({ lix, from: currentVersion })
+```

--- a/packages/csv-app/src/layouts/OpenFileLayout.tsx
+++ b/packages/csv-app/src/layouts/OpenFileLayout.tsx
@@ -276,7 +276,7 @@ const VersionDropdown = () => {
 					onClick={async () => {
 						const newversion = await createVersion({
 							lix,
-							parent: currentVersion,
+							from: currentVersion,
 							name: humanId({
 								separator: "-",
 								capitalize: false,

--- a/packages/lix-file-manager/src/components/VersionDropdown.tsx
+++ b/packages/lix-file-manager/src/components/VersionDropdown.tsx
@@ -55,7 +55,7 @@ export function VersionDropdown() {
 
 		const newVersion = await createVersion({
 			lix,
-			parent: currentVersion,
+			from: currentVersion,
 			name: humanId({
 				separator: "-",
 				capitalize: false,

--- a/packages/lix-sdk/src/sync/sync-process.test.ts
+++ b/packages/lix-sdk/src/sync/sync-process.test.ts
@@ -68,7 +68,7 @@ test("versions should be synced", async () => {
 			.executeTakeFirstOrThrow();
 		version0 = await createVersion({
 			lix: { ...lix0, db: trx },
-			parent: currentVersion,
+			from: currentVersion,
 			name: "version0",
 		});
 		await switchVersion({ lix: { ...lix0, db: trx }, to: version0 });
@@ -180,7 +180,7 @@ test("switching synced versions should work", async () => {
 	const version0 = await createVersion({
 		lix: lix0,
 		name: "version0",
-		parent: currentVersion,
+		from: currentVersion,
 	});
 
 	await switchVersion({ lix: lix0, to: version0 });

--- a/packages/lix-sdk/src/version/create-version.test.ts
+++ b/packages/lix-sdk/src/version/create-version.test.ts
@@ -42,7 +42,7 @@ test("it should copy the changes from the parent version", async () => {
 
 	const version1 = await createVersion({
 		lix,
-		parent: version0,
+		from: version0,
 	});
 
 	const changesInversion0 = await lix.db
@@ -132,7 +132,7 @@ test("it should copy change conflict pointers from the parent version", async ()
 
 	const version1 = await createVersion({
 		lix,
-		parent: version0,
+		from: version0,
 		name: "version1",
 	});
 

--- a/packages/lix-sdk/src/version/switch-version.test.ts
+++ b/packages/lix-sdk/src/version/switch-version.test.ts
@@ -18,7 +18,7 @@ test("switching versiones should update the current_version", async () => {
 	const newVersion = await lix.db.transaction().execute(async (trx) => {
 		const newVersion = await createVersion({
 			lix: { db: trx },
-			parent: currentVersion,
+			from: currentVersion,
 		});
 		await switchVersion({ lix: { ...lix, db: trx }, to: newVersion });
 		return newVersion;
@@ -60,7 +60,7 @@ test("switching a version does not lead to duplicate changes", async () => {
 
 	const newVersion = await createVersion({
 		lix: lix,
-		parent: currentVersion,
+		from: currentVersion,
 	});
 
 	const changesBefore = await lix.db.selectFrom("change").selectAll().execute();
@@ -181,7 +181,7 @@ test("a deleted file in one version does not impact a version which did not dele
 
 	expect(mockTxtPlugin.detectChanges).toHaveBeenCalledTimes(1);
 
-	const versionB = await createVersion({ lix, parent: versionA });
+	const versionB = await createVersion({ lix, from: versionA });
 
 	await switchVersion({ lix, to: versionB });
 


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/213