### PR TITLE
remove `comment.created_at` and `comment.created_by` 

### DIFF
--- a/.changeset/dirty-parents-carry.md
+++ b/.changeset/dirty-parents-carry.md
@@ -1,0 +1,7 @@
+---
+"@lix-js/sdk": patch
+---
+
+refactor: remove `comment.created_at` and `comment.created_by` https://github.com/opral/lix-sdk/issues/175
+
+Comments and discussions are now change controlled. Hence, knowing when a comment or discussion has been created can be queried via the changes. This removes the need for the `created_at` and `created_by` fields on the `Comment` and `Discussion` entities, and thereby simplifies the schema, avoids duplicate date, and reduces the risk of inconsistencies.

--- a/packages/csv-app/src/components/ChangeSet.tsx
+++ b/packages/csv-app/src/components/ChangeSet.tsx
@@ -10,7 +10,7 @@ import {
 } from "@lix-js/sdk";
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
-import { activeAccountsAtom, currentVersionAtom, lixAtom } from "../state.ts";
+import { currentVersionAtom, lixAtom } from "../state.ts";
 import clsx from "clsx";
 import {
 	activeFileAtom,
@@ -142,7 +142,6 @@ const ConfirmChangesBox = () => {
 	const [description, setDescription] = useState("");
 	const [lix] = useAtom(lixAtom);
 	const [unconfirmedChanges] = useAtom(unconfirmedChangesAtom);
-	const [activeAccounts] = useAtom(activeAccountsAtom);
 
 	const handleConfirmChanges = async () => {
 		const changeSet = await confirmChanges(lix, unconfirmedChanges);
@@ -151,7 +150,6 @@ const ConfirmChangesBox = () => {
 				lix,
 				changeSet,
 				content: description,
-				createdBy: activeAccounts[0],
 			});
 			await saveLixToOpfs({ lix });
 		}

--- a/packages/lix-file-manager/src/components/ChatInput.tsx
+++ b/packages/lix-file-manager/src/components/ChatInput.tsx
@@ -4,109 +4,121 @@ import { Form, FormControl, FormField, FormItem } from "./ui/form.tsx";
 import { useForm } from "react-hook-form";
 import { Button } from "./ui/button.tsx";
 import { Avatar, AvatarImage, AvatarFallback } from "./ui/avatar.tsx";
-import { activeAccountAtom, discussionSearchParamsAtom, lixAtom } from "@/state.ts";
+import {
+	activeAccountAtom,
+	currentVersionAtom,
+	discussionSearchParamsAtom,
+	lixAtom,
+} from "@/state.ts";
 import IconArrow from "./icons/IconArrow.tsx";
-import { createComment } from "@lix-js/sdk";
+import { changeInVersion, createComment } from "@lix-js/sdk";
 import { saveLixToOpfs } from "@/helper/saveLixToOpfs.ts";
 
 const ChatInput = () => {
-  const [activeAccount] = useAtom(activeAccountAtom);
-  const [discussionSearchParams] = useAtom(discussionSearchParamsAtom);
-  const [lix] = useAtom(lixAtom);
+	const [activeAccount] = useAtom(activeAccountAtom);
+	const [discussionSearchParams] = useAtom(discussionSearchParamsAtom);
+	const [currentVersion] = useAtom(currentVersionAtom);
+	const [lix] = useAtom(lixAtom);
 
-  const form = useForm({
-    defaultValues: {
-      comment: "",
-    },
-  });
-  const { handleSubmit, watch, formState: { isValid } } = form;
-  const commentValue = watch("comment");
+	const form = useForm({
+		defaultValues: {
+			comment: "",
+		},
+	});
+	const {
+		handleSubmit,
+		watch,
+		formState: { isValid },
+	} = form;
+	const commentValue = watch("comment");
 
-  const handleTextareaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    event.target.style.height = "auto";
-    event.target.style.height = `${event.target.scrollHeight}px`;
-  };
+	const handleTextareaChange = (
+		event: React.ChangeEvent<HTMLTextAreaElement>
+	) => {
+		event.target.style.height = "auto";
+		event.target.style.height = `${event.target.scrollHeight}px`;
+	};
 
-  const handleAddComment = async () => {
-    const resolve = await lix.db.transaction().execute(
-      async (trx) => {
-        const parentComment = await trx
-          .selectFrom("comment")
-          .where("discussion_id", "=", discussionSearchParams)
-          .orderBy("created_at", "desc")
-          .selectAll()
-          .limit(1)
-          .executeTakeFirstOrThrow();
-        const createdBy = await trx
-          .selectFrom("active_account")
-          .selectAll()
-          .executeTakeFirstOrThrow();
-        return await createComment({
-          lix: { ...lix, db: trx },
-          parentComment,
-          content: commentValue,
-          createdBy,
-        });
-      }
-    );
-    await saveLixToOpfs({ lix });
-    form.reset();
-    console.log(resolve);
-  };
+	const handleAddComment = async () => {
+		await lix.db.transaction().execute(async (trx) => {
+			const parentComment = await trx
+				.selectFrom("comment")
+				.where("discussion_id", "=", discussionSearchParams)
+				.innerJoin("change", (join) =>
+					join
+						.onRef("change.entity_id", "=", "comment.id")
+						.on("change.schema_key", "=", "lix_comment_table")
+				)
+				.where(changeInVersion(currentVersion!))
+				.orderBy("created_at", "desc")
+				.selectAll("comment")
+				.executeTakeFirstOrThrow();
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-      event.preventDefault();
-      handleSubmit(handleAddComment)();
-    }
-  };
+			return await createComment({
+				lix: { ...lix, db: trx },
+				parentComment,
+				content: commentValue,
+			});
+		});
+		await saveLixToOpfs({ lix });
+		form.reset();
+	};
 
-  return (
-    <div className="flex items-end justify-between gap-1.5 px-2.5 py-5 border-t border-slate-100">
-      <Avatar className="w-8 h-8 mb-1 cursor-pointer hover:opacity-90 transition-opacity">
-        <AvatarImage src="#" alt="#" />
-        <AvatarFallback className="bg-[#fff] text-[#141A21] border border-[#DBDFE7]">
-          {activeAccount?.name ? activeAccount.name.substring(0, 2).toUpperCase() : "XX"}
-        </AvatarFallback>
-      </Avatar>
-      <Form {...form}>
-        <form
-          onSubmit={handleSubmit(handleAddComment)}
-          className="flex flex-1 items-center ring-1 ring-slate-100 rounded-md pl-3 pr-1 py-0.5 bg-slate-50"
-        >
-          <FormField
-            control={form.control}
-            name="comment"
-            rules={{ required: "Comment content is required" }}
-            render={({ field }) => (
-              < FormItem className="flex-1">
-                <FormControl>
-                  <Textarea
-                    {...field}
-                    rows={1}
-                    placeholder="Add a comment ..."
-                    className="flex-1 border-none resize-none overflow-hidden shadow-none px-0 pt-2 focus-visible:ring-0"
-                    onInput={handleTextareaChange}
-                    onKeyDown={handleKeyDown}
-                    style={{ minHeight: "24px", fontSize: "1rem" }}
-                  />
-                </FormControl>
-              </FormItem>
-            )}
-          />
-          <Button
-            type="submit"
-            disabled={!isValid || commentValue === ""}
-            size="sm"
-            variant="ghost"
-            className="px-1 mt-auto mb-1"
-          >
-            <IconArrow />
-          </Button>
-        </form>
-      </Form>
-    </div >
-  );
+	const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+			event.preventDefault();
+			handleSubmit(handleAddComment)();
+		}
+	};
+
+	return (
+		<div className="flex items-end justify-between gap-1.5 px-2.5 py-5 border-t border-slate-100">
+			<Avatar className="w-8 h-8 mb-1 cursor-pointer hover:opacity-90 transition-opacity">
+				<AvatarImage src="#" alt="#" />
+				<AvatarFallback className="bg-[#fff] text-[#141A21] border border-[#DBDFE7]">
+					{activeAccount?.name
+						? activeAccount.name.substring(0, 2).toUpperCase()
+						: "XX"}
+				</AvatarFallback>
+			</Avatar>
+			<Form {...form}>
+				<form
+					onSubmit={handleSubmit(handleAddComment)}
+					className="flex flex-1 items-center ring-1 ring-slate-100 rounded-md pl-3 pr-1 py-0.5 bg-slate-50"
+				>
+					<FormField
+						control={form.control}
+						name="comment"
+						rules={{ required: "Comment content is required" }}
+						render={({ field }) => (
+							<FormItem className="flex-1">
+								<FormControl>
+									<Textarea
+										{...field}
+										rows={1}
+										placeholder="Add a comment ..."
+										className="flex-1 border-none resize-none overflow-hidden shadow-none px-0 pt-2 focus-visible:ring-0"
+										onInput={handleTextareaChange}
+										onKeyDown={handleKeyDown}
+										style={{ minHeight: "24px", fontSize: "1rem" }}
+									/>
+								</FormControl>
+							</FormItem>
+						)}
+					/>
+					<Button
+						type="submit"
+						disabled={!isValid || commentValue === ""}
+						size="sm"
+						variant="ghost"
+						className="px-1 mt-auto mb-1"
+					>
+						<IconArrow />
+					</Button>
+				</form>
+			</Form>
+		</div>
+	);
 };
 
 export default ChatInput;

--- a/packages/lix-file-manager/src/components/ConnectedChanges.tsx
+++ b/packages/lix-file-manager/src/components/ConnectedChanges.tsx
@@ -31,8 +31,8 @@ const ConnectedChanges = () => {
 					<span className="font-medium">{filteredChanges.length}</span>
 					<span className="text-slate-500">
 						{filteredChanges.length === 1
-							? "connected change"
-							: "connected changes"}
+							? "related change"
+							: "related changes"}
 					</span>
 				</div>
 				<Button variant="ghost" size="icon">

--- a/packages/lix-file-manager/src/components/DiscussionPreview.tsx
+++ b/packages/lix-file-manager/src/components/DiscussionPreview.tsx
@@ -17,18 +17,24 @@ const DiscussionPreview = ({ discussionId }: { discussionId: string }) => {
 
   const getFirstComment = async (discussionId: string) => {
     const comment = await lix.db
-      .selectFrom("comment")
-      .innerJoin("account", "account.id", "comment.created_by")
-      .select([
-        "comment.id",
-        "comment.content",
-        "comment.created_at",
-        "account.name as author_name"
-      ])
-      .where("comment.discussion_id", "=", discussionId)
-      .orderBy("comment.created_at", "asc")
-      .limit(1)
-      .executeTakeFirstOrThrow();
+			.selectFrom("comment")
+			.innerJoin("change", (join) =>
+				join
+					.onRef("change.entity_id", "=", "comment.id")
+					.on("change.schema_key", "=", "lix_comment_table")
+			)
+			.innerJoin("change_author", "change_author.change_id", "change.id")
+			.innerJoin("account", "account.id", "change_author.account_id")
+			.select([
+				"comment.id",
+				"comment.content",
+				"change.created_at",
+				"account.name as author_name",
+			])
+			.where("comment.discussion_id", "=", discussionId)
+			.orderBy("change.created_at", "asc")
+			.limit(1)
+			.executeTakeFirstOrThrow();
 
     setFirstComment(comment);
   };

--- a/packages/lix-file-manager/src/components/FilterSelect.tsx
+++ b/packages/lix-file-manager/src/components/FilterSelect.tsx
@@ -43,16 +43,12 @@ const FilterSelect = () => {
           lix: { ...lix, db: trx },
           changes: selectedChangeIds.map((id) => { return { id } }),
         })
-        const createdBy = await trx
-          .selectFrom("active_account")
-          .selectAll()
-          .executeTakeFirstOrThrow();
+
         return await createDiscussion({
-          lix: { ...lix, db: trx },
-          changeSet,
-          content: discussionValue,
-          createdBy,
-        });
+					lix: { ...lix, db: trx },
+					changeSet,
+					content: discussionValue,
+				});
       }
     );
     await saveLixToOpfs({ lix });

--- a/packages/lix-file-manager/src/state.ts
+++ b/packages/lix-file-manager/src/state.ts
@@ -164,9 +164,7 @@ export const lixAtom = atom(async (get) => {
  */
 export const withPollingAtom = atom(Date.now());
 
-export const currentVersionAtom = atom<
-	Promise<(Version & { targets: Version[] }) | null>
->(async (get) => {
+export const currentVersionAtom = atom<Promise<Version | null>>(async (get) => {
 	get(withPollingAtom);
 	const lix = await get(lixAtom);
 	if (!lix) return null;
@@ -177,7 +175,7 @@ export const currentVersionAtom = atom<
 		.selectAll("version")
 		.executeTakeFirstOrThrow();
 
-	return { ...currentVersion, targets: [] };
+	return currentVersion;
 });
 
 export const existingVersionsAtom = atom(async (get) => {
@@ -232,7 +230,6 @@ export const switchActiveAccount = async (lix: Lix, account: Account) => {
 	});
 	localStorage.setItem(ACTIVE_ACCOUNT_STORAGE_KEY, JSON.stringify(account));
 };
-
 
 export const isSyncingAtom = atom(async (get) => {
 	get(withPollingAtom);

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -188,11 +188,8 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
     id TEXT PRIMARY KEY DEFAULT (uuid_v7()),
     parent_id TEXT,
     discussion_id TEXT NULL,
-    created_at TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL,
     content TEXT NOT NULL,
-    created_by TEXT NOT NULL,
     
-    FOREIGN KEY(created_by) REFERENCES account(id),
     FOREIGN KEY(discussion_id) REFERENCES discussion(id),
     FOREIGN KEY(parent_id) REFERENCES comment(id)
   ) STRICT;
@@ -293,20 +290,6 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
       FROM active_account 
       WHERE id = NEW.account_id;
   END;
-    
-  CREATE TEMP TRIGGER IF NOT EXISTS insert_account_if_not_exists_on_comment
-  BEFORE INSERT ON comment
-  FOR EACH ROW
-  WHEN NEW.created_by NOT IN (SELECT id FROM account) AND NEW.created_by IN (SELECT id FROM temp.active_account)
-  BEGIN
-    INSERT OR IGNORE INTO account
-      SELECT 
-      *
-      FROM active_account 
-      WHERE id = NEW.created_by;
-  END;
-  
-
   `;
 
 	// CREATE TRIGGER IF NOT EXISTS insert_account_if_not_exists_on_change_set_label_author

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -175,8 +175,6 @@ type CommentTable = {
 	id: Generated<string>;
 	parent_id: string | null;
 	discussion_id: string;
-	created_at: Generated<string>;
-	created_by: string;
 	content: string;
 };
 

--- a/packages/lix-sdk/src/discussion/create-comment.ts
+++ b/packages/lix-sdk/src/discussion/create-comment.ts
@@ -1,4 +1,3 @@
-import type { Account } from "../account/database-schema.js";
 import type { Comment } from "../database/schema.js";
 import type { Lix } from "../lix/open-lix.js";
 
@@ -6,7 +5,6 @@ export async function createComment(args: {
 	lix: Pick<Lix, "db">;
 	parentComment: Pick<Comment, "id" | "discussion_id">;
 	content: string;
-	createdBy: Pick<Account, "id">;
 }): Promise<Comment> {
 	return args.lix.db
 		.insertInto("comment")
@@ -14,7 +12,6 @@ export async function createComment(args: {
 			discussion_id: args.parentComment.discussion_id,
 			parent_id: args.parentComment.id,
 			content: args.content,
-			created_by: args.createdBy.id,
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();

--- a/packages/lix-sdk/src/discussion/create-discussion.test.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.test.ts
@@ -40,11 +40,6 @@ test("should be able to start a discussion on changes", async () => {
 
 	await fileQueueSettled({ lix });
 
-	const current_author = await lix.db
-		.selectFrom("active_account")
-		.selectAll()
-		.executeTakeFirstOrThrow();
-
 	const changes = await lix.db
 		.selectFrom("change")
 		.selectAll("change")
@@ -55,7 +50,6 @@ test("should be able to start a discussion on changes", async () => {
 			lix: { db: trx },
 			changeSet: await createChangeSet({ lix: { db: trx }, changes }),
 			content: "comment on a change",
-			createdBy: { id: current_author.id },
 		});
 	});
 

--- a/packages/lix-sdk/src/discussion/create-discussion.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.ts
@@ -1,4 +1,3 @@
-import type { Account } from "../account/database-schema.js";
 import type { ChangeSet, Comment, Discussion } from "../database/schema.js";
 import type { Lix } from "../lix/open-lix.js";
 
@@ -17,7 +16,6 @@ export async function createDiscussion(args: {
 	lix: Pick<Lix, "db">;
 	changeSet: Pick<ChangeSet, "id">;
 	content: Comment["content"];
-	createdBy: Pick<Account, "id">;
 }): Promise<Discussion & { comment: Comment }> {
 	const executeInTransaction = async (trx: Lix["db"]) => {
 		const discussion = await trx
@@ -34,7 +32,6 @@ export async function createDiscussion(args: {
 				parent_id: null,
 				discussion_id: discussion.id,
 				content: args.content,
-				created_by: args.createdBy.id,
 			})
 			.returningAll()
 			.executeTakeFirstOrThrow();

--- a/packages/lix-sdk/src/lix/merge.test.ts
+++ b/packages/lix-sdk/src/lix/merge.test.ts
@@ -721,17 +721,10 @@ test("it should copy discussion and related comments and mappings", async () => 
 		])
 	);
 
-	// TODO how do know which author to use for the discussion - we can have multiple active accounts?
-	const currentAuthorLix1 = await lix1.db
-		.selectFrom("active_account")
-		.selectAll()
-		.executeTakeFirstOrThrow();
-
 	await createDiscussion({
 		lix: lix1,
 		changeSet: await createChangeSet({ lix: lix1, changes: [changes[0]!] }),
 		content: "comment on a change",
-		createdBy: { id: currentAuthorLix1.id },
 	});
 
 	await merge({ sourceLix: lix1, targetLix: lix2 });
@@ -748,21 +741,15 @@ test("it should copy discussion and related comments and mappings", async () => 
 	// lix 2 has no comments yet so after lix 1 into 2 we should be in sync
 	expect(commentsLix1).toEqual(commentsLix2AfterMerge);
 
-	const currentAuthorLix2 = await lix1.db
-		.selectFrom("active_account")
-		.selectAll()
-		.executeTakeFirstOrThrow();
 	await createComment({
 		lix: lix2,
 		parentComment: commentsLix2AfterMerge[0]!,
 		content: "wrote in lix 2",
-		createdBy: { id: currentAuthorLix2.id },
 	});
 	await createComment({
 		lix: lix1,
 		parentComment: commentsLix2AfterMerge[0]!,
 		content: "wrote in lix 1",
-		createdBy: { id: currentAuthorLix1.id },
 	});
 
 	const commentsLix1OnSecondMerge = await lix1.db


### PR DESCRIPTION
refactor: remove `comment.created_at` and `comment.created_by` https://github.com/opral/lix-sdk/issues/175

Comments and discussions are now change controlled. Hence, knowing when a comment or discussion has been created can be queried via the changes. This removes the need for the `created_at` and `created_by` fields on the `Comment` and `Discussion` entities, and thereby simplifies the schema, avoids duplicate date, and reduces the risk of inconsistencies.
