### PR TITLE
refactor: explicit `firstComment` argument in `createDiscussion()`

### DIFF
--- a/.changeset/fast-jars-love.md
+++ b/.changeset/fast-jars-love.md
@@ -1,0 +1,12 @@
+---
+"@lix-js/sdk": patch
+---
+
+refactor: explicit `firstComment` argument in `createDiscussion()` https://github.com/opral/lix-sdk/issues/164
+
+It was unclear that the `content` argument in `createDiscussion()` was meant to be the first comment. This change makes it explicit by renaming the argument to `firstComment`.
+
+```diff
+- createDiscussion({ discussion, content: "first comment" })
++ createDiscussion({ discussion, firstComment: { content: "first commment" } }})
+```

--- a/packages/csv-app/src/components/ChangeSet.tsx
+++ b/packages/csv-app/src/components/ChangeSet.tsx
@@ -149,7 +149,7 @@ const ConfirmChangesBox = () => {
 			await createDiscussion({
 				lix,
 				changeSet,
-				content: description,
+				firstComment: { content: description },
 			});
 			await saveLixToOpfs({ lix });
 		}

--- a/packages/lix-file-manager/src/components/FilterSelect.tsx
+++ b/packages/lix-file-manager/src/components/FilterSelect.tsx
@@ -47,7 +47,7 @@ const FilterSelect = () => {
         return await createDiscussion({
 					lix: { ...lix, db: trx },
 					changeSet,
-					content: discussionValue,
+					firstComment: { content: discussionValue },
 				});
       }
     );

--- a/packages/lix-sdk/src/discussion/create-discussion.test.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.test.ts
@@ -1,44 +1,19 @@
 import { expect, test } from "vitest";
 import { openLixInMemory } from "../lix/open-lix-in-memory.js";
-import { newLixFile } from "../lix/new-lix.js";
-import type { DetectedChange, LixPlugin } from "../plugin/lix-plugin.js";
 import { createDiscussion } from "./create-discussion.js";
 import { createChangeSet } from "../change-set/create-change-set.js";
-import { fileQueueSettled } from "../file-queue/file-queue-settled.js";
-
-const mockPlugin: LixPlugin = {
-	key: "mock-plugin",
-	detectChangesGlob: "*",
-	detectChanges: async ({ after }) => {
-		return [
-			{
-				schema: {
-					key: "text",
-					type: "json",
-				},
-				entity_id: "test",
-				snapshot: {
-					text: after ? new TextDecoder().decode(after.data) : undefined,
-				},
-			} satisfies DetectedChange,
-		];
-	},
-};
 
 test("should be able to start a discussion on changes", async () => {
-	const lix = await openLixInMemory({
-		blob: await newLixFile(),
-		providePlugins: [mockPlugin],
-	});
+	const lix = await openLixInMemory({});
 
-	const enc = new TextEncoder();
-
+	// produce a change
 	await lix.db
-		.insertInto("file")
-		.values({ id: "test", path: "/test.txt", data: enc.encode("test") })
+		.insertInto("key_value")
+		.values({
+			key: "mock_key",
+			value: "mock_value",
+		})
 		.execute();
-
-	await fileQueueSettled({ lix });
 
 	const changes = await lix.db
 		.selectFrom("change")
@@ -48,8 +23,8 @@ test("should be able to start a discussion on changes", async () => {
 	await lix.db.transaction().execute(async (trx) => {
 		await createDiscussion({
 			lix: { db: trx },
+			firstComment: { content: "Hello, world!" },
 			changeSet: await createChangeSet({ lix: { db: trx }, changes }),
-			content: "comment on a change",
 		});
 	});
 

--- a/packages/lix-sdk/src/discussion/create-discussion.ts
+++ b/packages/lix-sdk/src/discussion/create-discussion.ts
@@ -7,7 +7,7 @@ import type { Lix } from "../lix/open-lix.js";
  * @example
  *   ```ts
  *   const changeSet = await createChangeSet({ lix, changes: ["change1", "change2"] });
- *   const discussion = await createDiscussion({ lix, changeSet, body: "first comment" });
+ *   const discussion = await createDiscussion({ lix, changeSet, firstComment: { content: "first comment" } });
  *   ```
  *
  * @returns the created discussion
@@ -15,8 +15,8 @@ import type { Lix } from "../lix/open-lix.js";
 export async function createDiscussion(args: {
 	lix: Pick<Lix, "db">;
 	changeSet: Pick<ChangeSet, "id">;
-	content: Comment["content"];
-}): Promise<Discussion & { comment: Comment }> {
+	firstComment: Pick<Comment, "content">;
+}): Promise<Discussion & { firstComment: Comment }> {
 	const executeInTransaction = async (trx: Lix["db"]) => {
 		const discussion = await trx
 			.insertInto("discussion")
@@ -26,17 +26,17 @@ export async function createDiscussion(args: {
 			.returningAll()
 			.executeTakeFirstOrThrow();
 
-		const comment = await trx
+		const firstComment = await trx
 			.insertInto("comment")
 			.values({
 				parent_id: null,
 				discussion_id: discussion.id,
-				content: args.content,
+				content: args.firstComment.content,
 			})
 			.returningAll()
 			.executeTakeFirstOrThrow();
 
-		return { ...discussion, comment };
+		return { ...discussion, firstComment };
 	};
 
 	// user provided an open transaction

--- a/packages/lix-sdk/src/lix/merge.test.ts
+++ b/packages/lix-sdk/src/lix/merge.test.ts
@@ -724,7 +724,7 @@ test("it should copy discussion and related comments and mappings", async () => 
 	await createDiscussion({
 		lix: lix1,
 		changeSet: await createChangeSet({ lix: lix1, changes: [changes[0]!] }),
-		content: "comment on a change",
+		firstComment: { content: "comment on a change" },
 	});
 
 	await merge({ sourceLix: lix1, targetLix: lix2 });


### PR DESCRIPTION
closes https://github.com/opral/lix-sdk/issues/164

It was unclear that the `content` argument in `createDiscussion()` was meant to be the first comment. This change makes it explicit by renaming the argument to `firstComment`.