### PR TITLE
refactor: remove `change_set_label_author` table.

### DIFF
--- a/.changeset/loud-peaches-lie.md
+++ b/.changeset/loud-peaches-lie.md
@@ -1,0 +1,9 @@
+---
+"@lix-js/sdk": patch
+---
+
+refactor: remove `change_set_label_author` table. 
+
+Closes https://github.com/opral/lix-sdk/issues/227
+
+Change set labels are now under own change control. Querying who created a label can happen via the change table itself. 

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -165,16 +165,6 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
     FOREIGN KEY(change_set_id) REFERENCES change_set(id)
   ) STRICT;
 
-  CREATE TABLE IF NOT EXISTS change_set_label_author (
-    label_id TEXT NOT NULL,
-    change_set_id TEXT NOT NULL,
-    account_id TEXT NOT NULL,
-
-    PRIMARY KEY(label_id, change_set_id, account_id),
-    FOREIGN KEY(label_id, change_set_id) REFERENCES change_set_label(label_id, change_set_id),
-    FOREIGN KEY(account_id) REFERENCES account(id)
-  ) STRICT;
-
   -- discussions 
 
   CREATE TABLE IF NOT EXISTS discussion (
@@ -279,32 +269,7 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
       WHERE id = NEW.account_id;
   END;
   
-  CREATE TEMP TRIGGER IF NOT EXISTS insert_account_if_not_exists_on_change_set_label_author
-  BEFORE INSERT ON change_set_label_author
-  FOR EACH ROW
-  WHEN NEW.account_id NOT IN (SELECT id FROM account) AND NEW.account_id IN (SELECT id FROM temp.active_account)
-  BEGIN
-    INSERT OR IGNORE INTO account
-      SELECT 
-      *
-      FROM active_account 
-      WHERE id = NEW.account_id;
-  END;
   `;
-
-	// CREATE TRIGGER IF NOT EXISTS insert_account_if_not_exists_on_change_set_label_author
-	// BEFORE INSERT ON change_set_label_author
-	// FOR EACH ROW
-	// BEGIN
-	//   INSERT OR IGNORE INTO account (id, name)
-	//   VALUES (
-	//     NEW.account_id,
-	//     CASE
-	//       WHEN NEW.account_id LIKE 'anonymous_%' THEN 'anonymous'
-	//       ELSE NEW.account_id
-	//     END
-	//   );
-	// END;
 
 	applyMutationLogDatabaseSchema(args.sqlite);
 

--- a/packages/lix-sdk/src/database/mutation-log/database-schema.ts
+++ b/packages/lix-sdk/src/database/mutation-log/database-schema.ts
@@ -27,8 +27,6 @@ export const tablesByDepencies: string[] = [
 	"change_set_element",
 	// Depends on: label, change_set
 	"change_set_label",
-	// Depends on: change_set_label
-	"change_set_label_author",
 	//Depends on: change_set
 	"discussion",
 	// Depends on: account, discussion, comment

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -28,7 +28,6 @@ export type LixDatabaseSchema = {
 	change_set: ChangeSetTable;
 	change_set_element: ChangeSetElementTable;
 	change_set_label: ChangeSetLabelTable;
-	change_set_label_author: ChangeSetLabelAuthorTable;
 
 	// key value
 	key_value: KeyValueTable;
@@ -194,15 +193,6 @@ export type ChangeSetLabelUpdate = Updateable<ChangeSetLabelTable>;
 type ChangeSetLabelTable = {
 	change_set_id: string;
 	label_id: string;
-};
-
-export type ChangeSetLabelAuthor = Selectable<ChangeSetLabelAuthorTable>;
-export type NewChangeSetLabelAuthor = Insertable<ChangeSetLabelAuthorTable>;
-export type ChangeSetLabelAuthorUpdate = Updateable<ChangeSetLabelAuthorTable>;
-type ChangeSetLabelAuthorTable = {
-	change_set_id: string;
-	label_id: string;
-	account_id: string;
 };
 
 // ------ versiones ------

--- a/packages/lix-sdk/src/own-change-control/change-controlled-tables.ts
+++ b/packages/lix-sdk/src/own-change-control/change-controlled-tables.ts
@@ -5,7 +5,6 @@ export const changeControlledTableIds = {
 	change_author: ["change_id", "account_id"],
 	change_set_element: ["change_set_id", "change_id"],
 	change_set_label: ["label_id", "change_set_id"],
-	change_set_label_author: ["label_id", "change_set_id", "account_id"],
 	discussion: ["id"],
 	file: ["id"],
 	key_value: ["key"],


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/227

Change set labels are now under own change control. Querying who created a label can happen via the change table itself.