### PR TITLE
refactor: replace `#*` key syntax with `skip_change_control` column

### DIFF
--- a/.changeset/unlucky-flowers-run.md
+++ b/.changeset/unlucky-flowers-run.md
@@ -1,0 +1,18 @@
+---
+"@lix-js/sdk": patch
+---
+
+refactor: replace `#*` key syntax with `skip_change_control` column
+
+closes https://github.com/opral/lix-sdk/issues/191
+
+Enables matching of flags and avoids re-names of keys. This change replaces the `#*` key syntax with a `skip_change_control` column in the `flags` table.
+
+```diff
+key_value = {
+-  key: "#mock_key",
++  key: "mock_key",
++  skip_change_control: true,
+   value: "mock_value",
+}
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,5 +20,5 @@
 ## Opening a PR
 
 1. run `pnpm run ci` to run all tests and checks
-2. run `npx changeset` to write a changelog and trigger a version bumb
+2. run `npx changeset` to write a changelog and trigger a version bumb. watch this loom video to see how to use changesets: https://www.loom.com/share/1c5467ae3a5243d79040fc3eb5aa12d6
 

--- a/packages/csv-app/src/layouts/RootLayout.tsx
+++ b/packages/csv-app/src/layouts/RootLayout.tsx
@@ -214,7 +214,7 @@ function SyncButton() {
 						.set({
 							value: "true",
 						})
-						.where("key", "=", "#lix_sync")
+						.where("key", "=", "lix_sync")
 						.execute();
 
 					await saveLixToOpfs({ lix });
@@ -235,7 +235,7 @@ function SyncStatus(props: { lix: Lix }) {
 			onClick={() => {
 				props.lix.db
 					.updateTable("key_value")
-					.where("key", "=", "#lix_sync")
+					.where("key", "=", "lix_sync")
 					.set({ value: "false" })
 					.execute();
 			}}

--- a/packages/csv-app/src/state.ts
+++ b/packages/csv-app/src/state.ts
@@ -176,7 +176,7 @@ export const isSyncingAtom = atom(async (get) => {
 
 	const sync = await lix.db
 		.selectFrom("key_value")
-		.where("key", "=", "#lix_sync")
+		.where("key", "=", "lix_sync")
 		.select("value")
 		.executeTakeFirst();
 

--- a/packages/lix-file-manager/src/components/VersionDropdown.tsx
+++ b/packages/lix-file-manager/src/components/VersionDropdown.tsx
@@ -97,7 +97,7 @@ export function VersionDropdown() {
 				.set({
 					value: "true",
 				})
-				.where("key", "=", "#lix_sync")
+				.where("key", "=", "lix_sync")
 				.execute();
 
 			await saveLixToOpfs({ lix });
@@ -111,7 +111,7 @@ export function VersionDropdown() {
 		await lix.db
 			.updateTable("key_value")
 			.set({ value: "false" })
-			.where("key", "=", "#lix_sync")
+			.where("key", "=", "lix_sync")
 			.execute();
 		await saveLixToOpfs({ lix });
 	};

--- a/packages/lix-file-manager/src/state.ts
+++ b/packages/lix-file-manager/src/state.ts
@@ -237,7 +237,7 @@ export const isSyncingAtom = atom(async (get) => {
 
 	const sync = await lix.db
 		.selectFrom("key_value")
-		.where("key", "=", "#lix_sync")
+		.where("key", "=", "lix_sync")
 		.select("value")
 		.executeTakeFirst();
 

--- a/packages/lix-sdk/src/change/apply-changes.test.ts
+++ b/packages/lix-sdk/src/change/apply-changes.test.ts
@@ -3,7 +3,7 @@ import { openLixInMemory } from "../lix/open-lix-in-memory.js";
 import { applyChanges } from "./apply-changes.js";
 import type { LixPlugin } from "../plugin/lix-plugin.js";
 import { mockJsonSnapshot } from "../snapshot/mock-json-snapshot.js";
-import type { KeyValue } from "../key-value/database-schema.js";
+import type { NewKeyValue } from "../key-value/database-schema.js";
 import { fileQueueSettled } from "../file-queue/file-queue-settled.js";
 
 test("it applies the given changes", async () => {
@@ -140,7 +140,7 @@ test("it applies own entity changes", async () => {
 	const snapshot = mockJsonSnapshot({
 		key: "mock-key",
 		value: "1+1=2",
-	} satisfies KeyValue);
+	} satisfies NewKeyValue);
 
 	await lix.db
 		.insertInto("snapshot")
@@ -170,7 +170,7 @@ test("it applies own entity changes", async () => {
 		.selectAll()
 		.executeTakeFirst();
 
-	expect(keyValue).toEqual({
+	expect(keyValue).toMatchObject({
 		key: "mock-key",
 		value: "1+1=2",
 	});

--- a/packages/lix-sdk/src/database/execute-sync.test.ts
+++ b/packages/lix-sdk/src/database/execute-sync.test.ts
@@ -100,7 +100,7 @@ test("using executeSync with a 'fake async' function should work", async () => {
 
 	const result = await fakeAyncQuery(lix);
 
-	expect(result).toEqual([{ key: "foo", value: "bar" }]);
+	expect(result).toMatchObject([{ key: "foo", value: "bar" }]);
 });
 
 test("it works with kysely transactions", async () => {

--- a/packages/lix-sdk/src/key-value/database-schema.test.ts
+++ b/packages/lix-sdk/src/key-value/database-schema.test.ts
@@ -106,14 +106,35 @@ test("it should default add a uuid lix_id if not exits", async () => {
 	expect(validateUuid(result.value)).toBe(true);
 });
 
-test("default value for #lix_sync to reduce conditional logic (the key is always set)", async () => {
+test("default value for lix_sync to reduce conditional logic (the key is always set)", async () => {
 	const lix = await openLixInMemory({});
 
 	const result = await lix.db
 		.selectFrom("key_value")
-		.where("key", "=", "#lix_sync")
+		.where("key", "=", "lix_sync")
 		.selectAll()
 		.executeTakeFirstOrThrow();
 
 	expect(result.value).toBe("false");
+});
+
+test("skip_change_control should default to false", async () => {
+	const lix = await openLixInMemory({});
+
+	const result = await lix.db
+		.insertInto("key_value")
+		.values({ key: "mock_key", value: "mock_value" })
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	expect(result.skip_change_control).toBeFalsy();
+
+	const updated = await lix.db
+		.updateTable("key_value")
+		.set({ skip_change_control: true })
+		.where("key", "=", "mock_key")
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	expect(updated.skip_change_control).toBeTruthy();
 });

--- a/packages/lix-sdk/src/lix/open-lix.test.ts
+++ b/packages/lix-sdk/src/lix/open-lix.test.ts
@@ -18,17 +18,28 @@ test("providing plugins should be possible", async () => {
 test("providing key values should be possible", async () => {
 	const lix = await openLixInMemory({
 		blob: await newLixFile(),
-		keyValues: [{ key: "key", value: "value" }],
+		keyValues: [{ key: "mock_key", value: "value" }],
 	});
-	const value = await lix.db.selectFrom("key_value").selectAll().execute();
-	expect(value).toContainEqual({ key: "key", value: "value" });
+
+	const value = await lix.db
+		.selectFrom("key_value")
+		.selectAll()
+		.where("key", "=", "mock_key")
+		.executeTakeFirstOrThrow();
+
+	expect(value).toMatchObject({ key: "mock_key", value: "value" });
 
 	// testing overwriting key values
 	const lix1 = await openLixInMemory({
 		blob: await toBlob({ lix }),
-		keyValues: [{ key: "key", value: "value2" }],
+		keyValues: [{ key: "mock_key", value: "value2" }],
 	});
 
-	const value1 = await lix1.db.selectFrom("key_value").selectAll().execute();
-	expect(value1).toContainEqual({ key: "key", value: "value2" });
+	const value1 = await lix1.db
+		.selectFrom("key_value")
+		.selectAll()
+		.where("key", "=", "mock_key")
+
+		.executeTakeFirstOrThrow();
+	expect(value1).toMatchObject({ key: "mock_key", value: "value2" });
 });

--- a/packages/lix-sdk/src/lix/open-lix.ts
+++ b/packages/lix-sdk/src/lix/open-lix.ts
@@ -6,7 +6,7 @@ import { initFileQueueProcess } from "../file-queue/file-queue-process.js";
 import type { Kysely } from "kysely";
 import type { LixDatabaseSchema } from "../database/schema.js";
 import { initSyncProcess } from "../sync/sync-process.js";
-import type { KeyValue } from "../key-value/database-schema.js";
+import type { NewKeyValue } from "../key-value/database-schema.js";
 
 export type Lix = {
 	/**
@@ -49,9 +49,9 @@ export async function openLix(args: {
 	 * Set the key values when opening the lix.
 	 *
 	 * @example
-	 *   const lix = await openLix({ keyValues: [{ key: "#lix_sync", value: "false" }] })
+	 *   const lix = await openLix({ keyValues: [{ key: "lix_sync", value: "false" }] })
 	 */
-	keyValues?: KeyValue[];
+	keyValues?: NewKeyValue[];
 }): Promise<Lix> {
 	const db = initDb({ sqlite: args.database });
 

--- a/packages/lix-sdk/src/own-change-control/apply-own-change.test.ts
+++ b/packages/lix-sdk/src/own-change-control/apply-own-change.test.ts
@@ -7,7 +7,7 @@ import type {
 } from "../database/schema.js";
 import { applyOwnChanges } from "./apply-own-change.js";
 import { mockJsonSnapshot } from "../snapshot/mock-json-snapshot.js";
-import { type KeyValue } from "../key-value/database-schema.js";
+import { type NewKeyValue } from "../key-value/database-schema.js";
 
 test("it should apply insert changes correctly", async () => {
 	const lix = await openLixInMemory({});
@@ -40,7 +40,7 @@ test("it should apply insert changes correctly", async () => {
 		.selectAll()
 		.executeTakeFirst();
 
-	expect(result).toEqual({ key: "key1", value: "value1" });
+	expect(result).toMatchObject({ key: "key1", value: "value1" });
 });
 
 test("it should apply update changes correctly", async () => {
@@ -81,7 +81,7 @@ test("it should apply update changes correctly", async () => {
 		.selectAll()
 		.executeTakeFirst();
 
-	expect(result).toEqual({ key: "key1", value: "new_value" });
+	expect(result).toMatchObject({ key: "key1", value: "new_value" });
 });
 
 test("it should apply delete changes correctly", async () => {
@@ -329,7 +329,7 @@ test("applying own entity changes doesn't lead to the creation of new changes", 
 	const snapshot = mockJsonSnapshot({
 		key: "mock-key",
 		value: "1+1=2",
-	} satisfies KeyValue);
+	} satisfies NewKeyValue);
 
 	await lix.db
 		.insertInto("snapshot")

--- a/packages/lix-sdk/src/own-change-control/database-triggers.test.ts
+++ b/packages/lix-sdk/src/own-change-control/database-triggers.test.ts
@@ -40,7 +40,7 @@ test("it works for inserts, updates and deletions", async () => {
 		expect(change.schema_key).toBe("lix_key_value_table");
 	}
 
-	expect(snapshots).toStrictEqual([
+	expect(snapshots).toMatchObject([
 		// insert
 		{ key: "key1", value: "value1" },
 		// update
@@ -125,23 +125,23 @@ test("if the trigger throws, the transaction is rolled back", async () => {
 	expect(deleteChange).toBeUndefined();
 });
 
-test("skips change control of key values if the key begins with `#`", async () => {
+test("skips change control of key values if `skip_change_control` is set to true", async () => {
 	const lix = await openLixInMemory({});
 
 	await lix.db
 		.insertInto("key_value")
-		.values({ key: "#key1", value: "value1" })
+		.values({ key: "key1", value: "value1", skip_change_control: true })
 		.execute();
 
 	const key1 = await lix.db
 		.selectFrom("key_value")
-		.where("key", "=", "#key1")
+		.where("key", "=", "key1")
 		.selectAll()
 		.executeTakeFirst();
 
 	const key1Change = await lix.db
 		.selectFrom("change")
-		.where("entity_id", "=", "#key1")
+		.where("entity_id", "=", "key1")
 		.selectAll()
 		.executeTakeFirst();
 

--- a/packages/lix-sdk/src/own-change-control/database-triggers.ts
+++ b/packages/lix-sdk/src/own-change-control/database-triggers.ts
@@ -93,8 +93,8 @@ function handleLixOwnEntityChange(
 ): void {
 	const lix = { db, sqlite };
 
-	// keys starting with `#` are not change controlled
-	if (tableName === "key_value" && values[0].startsWith("#")) {
+	// key values that have skip_change_control set to true should not be change controlled
+	if (tableName === "key_value" && values[2]) {
 		return;
 	}
 
@@ -103,7 +103,7 @@ function handleLixOwnEntityChange(
 			lix,
 			query: db
 				.selectFrom("key_value")
-				.where("key", "=", "#lix_skip_own_change_control")
+				.where("key", "=", "lix_skip_own_change_control")
 				.select("value"),
 		})[0]?.value === "true";
 

--- a/packages/lix-sdk/src/own-change-control/with-skip-own-change-control.ts
+++ b/packages/lix-sdk/src/own-change-control/with-skip-own-change-control.ts
@@ -7,7 +7,11 @@ export async function withSkipOwnChangeControl<T>(
 	const executeInTransaction = async (trx: Lix["db"]) => {
 		await trx
 			.insertInto("key_value")
-			.values({ key: "#lix_skip_own_change_control", value: "true" })
+			.values({
+				key: "lix_skip_own_change_control",
+				value: "true",
+				skip_change_control: true,
+			})
 			.onConflict((oc) => oc.doUpdateSet({ value: "true" }))
 			.execute();
 
@@ -16,7 +20,7 @@ export async function withSkipOwnChangeControl<T>(
 
 		await trx
 			.deleteFrom("key_value")
-			.where("key", "=", "#lix_skip_own_change_control")
+			.where("key", "=", "lix_skip_own_change_control")
 			.execute();
 
 		// Return the result of the operation

--- a/packages/lix-sdk/src/server-api-handler/environment/create-in-memory-environment.test.ts
+++ b/packages/lix-sdk/src/server-api-handler/environment/create-in-memory-environment.test.ts
@@ -25,7 +25,7 @@ test("opening a lix works", async () => {
 		.returningAll()
 		.executeTakeFirstOrThrow();
 
-	expect(mockInsert).toEqual({
+	expect(mockInsert).toMatchObject({
 		key: "foo",
 		value: "bar",
 	});
@@ -45,7 +45,7 @@ test("opening a lix works", async () => {
 		.selectAll()
 		.executeTakeFirstOrThrow();
 
-	expect(mockSelect).toEqual({ key: "foo", value: "bar" });
+	expect(mockSelect).toMatchObject({ key: "foo", value: "bar" });
 
 	await environment.closeLix({ id: lixId, connectionId: open1.connectionId });
 });
@@ -73,7 +73,7 @@ test("it handles concurrent connections", async () => {
 		.returningAll()
 		.executeTakeFirstOrThrow();
 
-	expect(mockInsert).toEqual({
+	expect(mockInsert).toMatchObject({
 		key: "foo",
 		value: "bar",
 	});
@@ -84,7 +84,7 @@ test("it handles concurrent connections", async () => {
 		.selectAll()
 		.executeTakeFirstOrThrow();
 
-	expect(mockSelect).toEqual({ key: "foo", value: "bar" });
+	expect(mockSelect).toMatchObject({ key: "foo", value: "bar" });
 
 	// test both writing at the same time
 
@@ -125,7 +125,7 @@ test("it handles concurrent connections", async () => {
 		.selectAll()
 		.executeTakeFirstOrThrow();
 
-	expect(mockSelect2).toEqual({ key: "foo", value: "bar3" });
+	expect(mockSelect2).toMatchObject({ key: "foo", value: "bar3" });
 
 	await environment.closeLix({ id: lixId, connectionId: open2.connectionId });
 });

--- a/packages/lix-sdk/src/server-api-handler/environment/create-in-memory-environment.ts
+++ b/packages/lix-sdk/src/server-api-handler/environment/create-in-memory-environment.ts
@@ -73,7 +73,7 @@ export const createLsaInMemoryEnvironment = (): LsaEnvironment => {
 				lix = await openLixInMemory({
 					blob,
 					// don't sync the server with itself
-					keyValues: [{ key: "#lix_sync", value: "false" }],
+					keyValues: [{ key: "lix_sync", value: "false" }],
 				});
 
 				lix.sqlite.exec("PRAGMA foreign_keys = OFF;");

--- a/packages/lix-sdk/src/server-api-handler/routes/get-v1.test.ts
+++ b/packages/lix-sdk/src/server-api-handler/routes/get-v1.test.ts
@@ -104,13 +104,13 @@ test("it should return 400 for a request without lix_id", async () => {
 	expect(responseJson.error).toBe("Missing required field 'lix_id'");
 });
 
-test("#lix_sync is set to true", async () => {
+test("lix_sync is set to true", async () => {
 	const environment = createLsaInMemoryEnvironment();
 	const lsaHandler = await createServerApiHandler({ environment });
 
 	const lix = await openLixInMemory({
 		blob: await newLixFile(),
-		keyValues: [{ key: "#lix_sync", value: "false" }],
+		keyValues: [{ key: "lix_sync", value: "false" }],
 	});
 
 	// Store the lix file
@@ -139,7 +139,7 @@ test("#lix_sync is set to true", async () => {
 
 	const lixSync = await lixFromServer.db
 		.selectFrom("key_value")
-		.where("key", "=", "#lix_sync")
+		.where("key", "=", "lix_sync")
 		.selectAll()
 		.executeTakeFirstOrThrow();
 

--- a/packages/lix-sdk/src/server-api-handler/routes/get-v1.ts
+++ b/packages/lix-sdk/src/server-api-handler/routes/get-v1.ts
@@ -47,7 +47,7 @@ export const route: LixServerApiHandlerRoute = async (context) => {
 		content: new Uint8Array(await blob!.arrayBuffer()),
 	});
 
-	sqlite.exec("UPDATE key_value SET value = 'true' WHERE key = '#lix_sync'");
+	sqlite.exec("UPDATE key_value SET value = 'true' WHERE key = 'lix_sync'");
 
 	const blob2 = new Blob([contentFromDatabase(sqlite)]);
 

--- a/packages/lix-sdk/src/server-api-handler/routes/new-v1.ts
+++ b/packages/lix-sdk/src/server-api-handler/routes/new-v1.ts
@@ -11,7 +11,9 @@ export const route: LixServerApiHandlerRoute = async (context) => {
 		lix = await openLixInMemory({
 			blob,
 			// turn off sync for server
-			keyValues: [{ key: "#lix_sync", value: "false" }],
+			keyValues: [
+				{ key: "lix_sync", value: "false", skip_change_control: true },
+			],
 		});
 	} catch {
 		return new Response(null, {

--- a/packages/lix-sdk/src/sync/pull-from-server.test.ts
+++ b/packages/lix-sdk/src/sync/pull-from-server.test.ts
@@ -69,7 +69,7 @@ test("pull rows of multiple tables from server successfully and applies them", a
 		.executeTakeFirstOrThrow();
 
 	expect(account).toEqual({ id: "account0", name: "test account" });
-	expect(mockKey).toEqual({ key: "mock-key", value: "mock-value" });
+	expect(mockKey).toMatchObject({ key: "mock-key", value: "mock-value" });
 });
 
 test("it handles snapshot.content being json binary", async () => {
@@ -186,7 +186,10 @@ test("rows changed on the client more recently should not be updated", async () 
 		.selectAll()
 		.executeTakeFirstOrThrow();
 
-	expect(mockKey).toEqual({ key: "mock-key", value: "mock-value-updated" });
+	expect(mockKey).toMatchObject({
+		key: "mock-key",
+		value: "mock-value-updated",
+	});
 });
 
 // the change table now models "change control". no more last edit wins needed
@@ -378,7 +381,10 @@ test("non-conflicting changes from the server should for the same version should
 		expect.arrayContaining([
 			expect.objectContaining({
 				version_id: currentVersion.id,
-				content: { key: "mock-key", value: "mock-value" },
+				content: expect.objectContaining({
+					key: "mock-key",
+					value: "mock-value",
+				}),
 			}),
 		])
 	);
@@ -414,6 +420,6 @@ test("non-conflicting changes from the server should for the same version should
 		.select("snapshot.content as content")
 		.execute();
 
-	expect(mockKey).toEqual({ key: "mock-key", value: "mock-value" });
+	expect(mockKey).toMatchObject({ key: "mock-key", value: "mock-value" });
 	expect(versionChanges).toEqual(expect.arrayContaining(serverVersionChanges));
 });

--- a/packages/lix-sdk/src/sync/push-to-server.test.ts
+++ b/packages/lix-sdk/src/sync/push-to-server.test.ts
@@ -5,7 +5,7 @@ import { pushToServer } from "./push-to-server.js";
 import type { LixFile } from "../database/schema.js";
 import type { Account } from "../account/database-schema.js";
 import { newLixFile } from "../lix/new-lix.js";
-import type { KeyValue } from "../key-value/database-schema.js";
+import type { NewKeyValue } from "../key-value/database-schema.js";
 import { mockJsonSnapshot } from "../snapshot/mock-json-snapshot.js";
 import { pullFromServer } from "./pull-from-server.js";
 import { createLsaInMemoryEnvironment } from "../server-api-handler/environment/create-in-memory-environment.js";
@@ -84,11 +84,11 @@ test("push rows of multiple tables to server successfully", async () => {
 		{ id: "account0", name: "some account" } satisfies Account,
 	]);
 	expect(keyValueChangesOnServer.map((c) => c.content)).toEqual([
-		{
+		expect.objectContaining({
 			key: "mock-key",
 			value: "mock-value",
-		},
-	] satisfies KeyValue[]);
+		}),
+	] satisfies NewKeyValue[]);
 });
 
 test("push-pull-push with two clients", async () => {
@@ -166,10 +166,10 @@ test("push-pull-push with two clients", async () => {
 
 	expect(client2KeyValueAfterPull).toEqual(
 		expect.arrayContaining([
-			{
+			expect.objectContaining({
 				key: "mock-key",
 				value: "mock-value from client 1",
-			} satisfies KeyValue,
+			} satisfies NewKeyValue),
 		])
 	);
 
@@ -261,15 +261,18 @@ test("push-pull-push with two clients", async () => {
 
 	expect(keyValueChangesOnServer.map((c) => c.content)).toEqual(
 		expect.arrayContaining([
-			{
+			expect.objectContaining({
 				key: "mock-key",
 				value: "mock-value from client 1",
-			},
-			{
+			}),
+			expect.objectContaining({
 				key: "mock-key",
 				value: "mock-value from client 1 - updated by client 2",
-			},
-			{ key: "mock-key-2", value: "mock-value from client 2" },
+			}),
+			expect.objectContaining({
+				key: "mock-key-2",
+				value: "mock-value from client 2",
+			}),
 		])
 	);
 });

--- a/packages/lix-sdk/src/sync/sync-process.test.ts
+++ b/packages/lix-sdk/src/sync/sync-process.test.ts
@@ -40,7 +40,7 @@ test("versions should be synced", async () => {
 	// create a second client
 	const lix1 = await openLixInMemory({
 		blob: await toBlob({ lix: lix0 }),
-		keyValues: [{ key: "#lix_sync", value: "true" }],
+		keyValues: [{ key: "lix_sync", value: "true" }],
 	});
 
 	// start syncing
@@ -48,7 +48,7 @@ test("versions should be synced", async () => {
 		[lix0, lix1].map((lix) =>
 			lix.db
 				.updateTable("key_value")
-				.where("key", "=", "#lix_sync")
+				.where("key", "=", "lix_sync")
 				.set({ value: "true" })
 				.execute()
 		)
@@ -131,7 +131,7 @@ test("switching synced versions should work", async () => {
 	global.executeSync = executeSync;
 
 	const lix0 = await openLixInMemory({
-		keyValues: [{ key: "#lix_sync", value: "true" }],
+		keyValues: [{ key: "lix_sync", value: "true" }],
 	});
 	// @ts-expect-error - eases debugging
 	lix0.db.__name = "lix0";
@@ -164,7 +164,7 @@ test("switching synced versions should work", async () => {
 	// create a second client
 	const lix1 = await openLixInMemory({
 		blob: await toBlob({ lix: lix0 }),
-		keyValues: [{ key: "#lix_sync", value: "true" }],
+		keyValues: [{ key: "lix_sync", value: "true" }],
 	});
 
 	// @ts-expect-error - eases debugging
@@ -233,13 +233,13 @@ test("switching synced versions should work", async () => {
 		.selectAll()
 		.executeTakeFirst();
 
-	expect(keyValue).toEqual({
+	expect(keyValue).toMatchObject({
 		key: "mock-key",
 		value: "mock",
 	});
 });
 
-test("doesnt sync if #lix_sync is not true", async () => {
+test("doesnt sync if lix_sync is not true", async () => {
 	const environment = createLsaInMemoryEnvironment();
 	const lsaHandler = await createServerApiHandler({ environment });
 	global.fetch = vi.fn((request) => lsaHandler(request));
@@ -263,7 +263,7 @@ test("doesnt sync if #lix_sync is not true", async () => {
 	await lix.db
 		.updateTable("key_value")
 		.set({ value: "false" })
-		.where("key", "=", "#lix_sync")
+		.where("key", "=", "lix_sync")
 		.execute();
 
 	await lix.db
@@ -295,7 +295,7 @@ test("doesnt sync if #lix_sync is not true", async () => {
 	await lix.db
 		.updateTable("key_value")
 		.set({ value: "true" })
-		.where("key", "=", "#lix_sync")
+		.where("key", "=", "lix_sync")
 		.execute();
 
 	await new Promise((resolve) => setTimeout(resolve, 1010));
@@ -311,10 +311,10 @@ test("doesnt sync if #lix_sync is not true", async () => {
 	expect(keyValueChangesOnServerAfterSync).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({
-				content: {
+				content: expect.objectContaining({
 					key: "foo",
 					value: "bar",
-				},
+				}),
 			}),
 		])
 	);

--- a/packages/lix-sdk/src/sync/sync-process.ts
+++ b/packages/lix-sdk/src/sync/sync-process.ts
@@ -22,7 +22,7 @@ export async function initSyncProcess(args: {
 	const pullAndPush = async () => {
 		const shouldSync = await args.lix.db
 			.selectFrom("key_value")
-			.where("key", "=", "#lix_sync")
+			.where("key", "=", "lix_sync")
 			.select("value")
 			.executeTakeFirst();
 

--- a/packages/lix-sdk/src/version/switch-version.test.ts
+++ b/packages/lix-sdk/src/version/switch-version.test.ts
@@ -95,7 +95,7 @@ test("switch version applies the changes of the switched to version", async () =
 		.selectAll()
 		.execute();
 
-	expect(keyValues).toEqual([{ key: "foo", value: "bar" }]);
+	expect(keyValues).toMatchObject([{ key: "foo", value: "bar" }]);
 
 	await switchVersion({ lix, to: versionB });
 
@@ -123,7 +123,7 @@ test("switch version applies the changes of the switched to version", async () =
 		.execute();
 
 	// expecting to see the value from version A again
-	expect(keyValues).toEqual([{ key: "foo", value: "bar" }]);
+	expect(keyValues).toMatchObject([{ key: "foo", value: "bar" }]);
 });
 
 // https://github.com/opral/lix-sdk/issues/209


### PR DESCRIPTION
closes https://github.com/opral/lix-sdk/issues/191

Enables matching of flags and avoids re-names of keys. This change replaces the `#*` key syntax with a `skip_change_control` column in the `flags` table.

```diff
key_value = {
-  key: "#mock_key",
+  key: "mock_key",
+  skip_change_control: true,
   value: "mock_value",
}
```
