### PR TITLE
improve: clears the OPFS in case the lix file can't be loaded.

### DIFF
--- a/.changeset/calm-masks-argue.md
+++ b/.changeset/calm-masks-argue.md
@@ -1,0 +1,7 @@
+---
+"lix-file-manager": minor
+---
+
+improve: clears the OPFS in case the lix file can't be loaded.
+
+If the lix schema changed, loading existing lix'es breaks with no possibility for users to fix the situation. Auto clearing the OPFS ledas to the creation of a new lix file with the new schema.

--- a/packages/lix-file-manager/src/state.ts
+++ b/packages/lix-file-manager/src/state.ts
@@ -109,10 +109,25 @@ export const lixAtom = atom(async (get) => {
 		}
 	}
 
-	const lix = await openLixInMemory({
-		blob: lixBlob!,
-		providePlugins: [csvPlugin],
-	});
+	let lix: Lix;
+
+	try {
+		lix = await openLixInMemory({
+			blob: lixBlob!,
+			providePlugins: [csvPlugin],
+		});
+	} catch {
+		// https://linear.app/opral/issue/INBOX-199/fix-loading-lix-file-if-schema-changed
+		// CLEAR OPFS. The lix file is likely corrupted.
+		for await (const entry of rootHandle.values()) {
+			if (entry.kind === "file") {
+				await rootHandle.removeEntry(entry.name);
+			}
+		}
+		window.location.reload();
+		// tricksing the TS typechecker. This will never be reached.
+		lix = {} as any;
+	}
 
 	const lixId = await lix.db
 		.selectFrom("key_value")


### PR DESCRIPTION
If the lix schema changed, loading existing lix'es breaks with no possibility for users to fix the situation. Auto clearing the OPFS ledas to the creation of a new lix file with the new schema.