### PR TITLE
adds unique and default human readable version names

### DIFF
--- a/.changeset/nine-seahorses-love.md
+++ b/.changeset/nine-seahorses-love.md
@@ -1,0 +1,8 @@
+---
+"@lix-js/sdk": minor
+---
+
+adds unique and default human readable version names
+
+- removes nullability of `version.name` which eases conditional logic. 
+- apps don't need custom default version naming logic anymore

--- a/packages/csv-app/package.json
+++ b/packages/csv-app/package.json
@@ -18,7 +18,6 @@
 		"@shoelace-style/shoelace": "^2.17.1",
 		"@xyflow/react": "^12.3.4",
 		"clsx": "^2.1.1",
-		"human-id": "^4.1.1",
 		"jotai": "^2.10.1",
 		"lodash-es": "^4.17.21",
 		"native-file-system-adapter": "^3.0.1",

--- a/packages/csv-app/src/layouts/OpenFileLayout.tsx
+++ b/packages/csv-app/src/layouts/OpenFileLayout.tsx
@@ -29,7 +29,6 @@ import {
 	switchVersion,
 	mergeVersion,
 } from "@lix-js/sdk";
-import { humanId } from "human-id";
 import CustomLink from "../components/CustomLink.tsx";
 
 export default function Layout(props: { children: React.ReactNode }) {
@@ -277,11 +276,6 @@ const VersionDropdown = () => {
 						const newversion = await createVersion({
 							lix,
 							from: currentVersion,
-							name: humanId({
-								separator: "-",
-								capitalize: false,
-								adjectiveCount: 0,
-							}),
 						});
 						await switchToversion(newversion);
 					}}

--- a/packages/lix-file-manager/package.json
+++ b/packages/lix-file-manager/package.json
@@ -31,7 +31,6 @@
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"date-fns": "^2.29.3",
-		"human-id": "^4.1.1",
 		"jotai": "^2.10.1",
 		"lodash-es": "^4.17.21",
 		"lucide-react": "^0.460.0",

--- a/packages/lix-file-manager/src/components/VersionDropdown.tsx
+++ b/packages/lix-file-manager/src/components/VersionDropdown.tsx
@@ -23,7 +23,6 @@ import {
 } from "../state.js";
 import { Version, createVersion, switchVersion } from "@lix-js/sdk";
 import { saveLixToOpfs } from "../helper/saveLixToOpfs.js";
-import { humanId } from "human-id";
 import { Check, Trash2, ChevronDown, Plus } from "lucide-react";
 import { MergeDialog } from "./MergeDialog.js";
 import IconMerge from "./icons/IconMerge.js";
@@ -56,11 +55,6 @@ export function VersionDropdown() {
 		const newVersion = await createVersion({
 			lix,
 			from: currentVersion,
-			name: humanId({
-				separator: "-",
-				capitalize: false,
-				adjectiveCount: 0,
-			}),
 		});
 
 		await switchToVersion(newVersion);

--- a/packages/lix-file-manager/src/components/ui/form.tsx
+++ b/packages/lix-file-manager/src/components/ui/form.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils"
 // @ts-expect-error - no types
 import { Label } from "@/components/ui/label"
 
-const Form = FormProvider
+const Form: any = FormProvider;
 
 type FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -201,14 +201,7 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
   CREATE TABLE IF NOT EXISTS version (
     id TEXT PRIMARY KEY DEFAULT (uuid_v7()),
 
-    -- name is optional. 
-    -- 
-    -- "anonymous" versiones can ease workflows. 
-    -- For example, a user can create a version 
-    -- without a name to experiment with
-    -- changes with no mental overhead of 
-    -- naming the version.
-    name TEXT
+    name TEXT NOT NULL UNIQUE DEFAULT (human_id())
   ) STRICT;
 
   CREATE TABLE IF NOT EXISTS version_change (

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -524,3 +524,18 @@ test("version_change must have a unique entity_id, file_id, version_id, and sche
 		.values({ ...versionChange, version_id: version1.id })
 		.execute();
 });
+
+
+test("versions have a unique and default human readable name", async () => {
+	const lix = await openLixInMemory({});
+
+	const version0 = await createVersion({ lix });
+	const version1 = await createVersion({ lix });
+
+	expect(version0.name).not.toBe(version1.name);
+
+	await expect(
+		createVersion({ lix, name: version0.name }),
+		"version.name is unique"
+	).rejects.toThrow();
+});

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -525,7 +525,6 @@ test("version_change must have a unique entity_id, file_id, version_id, and sche
 		.execute();
 });
 
-
 test("versions have a unique and default human readable name", async () => {
 	const lix = await openLixInMemory({});
 

--- a/packages/lix-sdk/src/database/init-db.ts
+++ b/packages/lix-sdk/src/database/init-db.ts
@@ -9,6 +9,7 @@ import { ParseJsonBPluginV1 } from "./kysely-plugin/parse-jsonb-plugin-v1.js";
 import { SerializeJsonBPlugin } from "./kysely-plugin/serialize-jsonb-plugin.js";
 import { createSession } from "./mutation-log/lix-session.js";
 import { applyOwnChangeControlTriggers } from "../own-change-control/database-triggers.js";
+import { humanId } from "human-id";
 
 export function initDb(args: {
 	sqlite: SqliteDatabase;
@@ -90,5 +91,11 @@ function initFunctions(args: { sqlite: SqliteDatabase }) {
 		name: "lix_session_clock_tick",
 		arity: 0,
 		xFunc: () => lixSession.sessionClockTick(),
+	});
+
+	args.sqlite.createFunction({
+		name: "human_id",
+		arity: 0,
+		xFunc: () => humanId({ separator: "-", capitalize: false }),
 	});
 }

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -202,7 +202,7 @@ export type Newversion = Insertable<VersionTable>;
 export type VersionUpdate = Updateable<VersionTable>;
 type VersionTable = {
 	id: Generated<string>;
-	name: string | null;
+	name: Generated<string>;
 };
 
 export type VersionChange = Selectable<VersionChangeTable>;

--- a/packages/lix-sdk/src/file-queue/file-queue-process.ts
+++ b/packages/lix-sdk/src/file-queue/file-queue-process.ts
@@ -27,7 +27,6 @@ export async function initFileQueueProcess(args: {
 	let hasMoreEntriesSince: number | undefined = undefined;
 
 	async function queueWorker(trail = false) {
-
 		if (args.lix.sqlite.isOpen() === false) {
 			console.log("sqlite is closed");
 			return;

--- a/packages/lix-website-server/src/main.ts
+++ b/packages/lix-website-server/src/main.ts
@@ -81,9 +81,10 @@ app.use(express.static(`${node_modules}/lix-website/build/client`));
 // Serve the website server routes
 app.all(
   "*",
+  // @ts-ignore
   createRequestHandler({
     build: require(`${node_modules}/lix-website/build/server`),
-  }),
+  })
 );
 
 // Start the server

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      human-id:
-        specifier: ^4.1.1
-        version: 4.1.1
       jotai:
         specifier: ^2.10.1
         version: 2.10.1(@types/react@18.3.11)(react@18.3.1)
@@ -390,7 +387,7 @@ importers:
         version: 10.0.0
       '@vitest/coverage-v8':
         specifier: ^2.0.5
-        version: 2.1.3(@vitest/browser@2.1.3(@vitest/spy@2.1.3)(playwright@1.48.1)(typescript@5.6.3)(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))(vitest@2.1.3)(webdriverio@9.2.1))(vitest@2.1.3(@types/node@22.10.1)(@vitest/browser@2.1.3)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.4.11(typescript@5.6.3))(terser@5.36.0))
+        version: 2.1.3(@vitest/browser@2.1.3(@vitest/spy@2.1.8)(playwright@1.48.1)(typescript@5.6.3)(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))(vitest@2.1.3)(webdriverio@9.2.1))(vitest@2.1.3(@types/node@22.10.1)(@vitest/browser@2.1.3)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.4.11(typescript@5.6.3))(terser@5.36.0))
       eslint:
         specifier: ^9.12.0
         version: 9.13.0(jiti@2.3.3)
@@ -9781,6 +9778,29 @@ snapshots:
       - vite
     optional: true
 
+  '@vitest/browser@2.1.3(@vitest/spy@2.1.8)(playwright@1.48.1)(typescript@5.6.3)(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))(vitest@2.1.3)(webdriverio@9.2.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.8)(msw@2.4.11(typescript@5.6.3))(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))
+      '@vitest/utils': 2.1.3
+      magic-string: 0.30.12
+      msw: 2.4.11(typescript@5.6.3)
+      sirv: 2.0.4
+      tinyrainbow: 1.2.0
+      vitest: 2.1.3(@types/node@22.10.1)(@vitest/browser@2.1.3)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.4.11(typescript@5.6.3))(terser@5.36.0)
+      ws: 8.18.0
+    optionalDependencies:
+      playwright: 1.48.1
+      webdriverio: 9.2.1
+    transitivePeerDependencies:
+      - '@vitest/spy'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser@2.1.3(@vitest/spy@2.1.8)(playwright@1.48.1)(typescript@5.7.2)(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))(vitest@2.1.3)(webdriverio@9.2.1)':
     dependencies:
       '@testing-library/dom': 10.4.0
@@ -9840,7 +9860,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.3(@vitest/browser@2.1.3(@vitest/spy@2.1.3)(playwright@1.48.1)(typescript@5.6.3)(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))(vitest@2.1.3)(webdriverio@9.2.1))(vitest@2.1.3(@types/node@22.10.1)(@vitest/browser@2.1.3)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.4.11(typescript@5.6.3))(terser@5.36.0))':
+  '@vitest/coverage-v8@2.1.3(@vitest/browser@2.1.3(@vitest/spy@2.1.8)(playwright@1.48.1)(typescript@5.6.3)(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))(vitest@2.1.3)(webdriverio@9.2.1))(vitest@2.1.3(@types/node@22.10.1)(@vitest/browser@2.1.3)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.4.11(typescript@5.6.3))(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -9856,7 +9876,7 @@ snapshots:
       tinyrainbow: 1.2.0
       vitest: 2.1.3(@types/node@22.10.1)(@vitest/browser@2.1.3)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.4.11(typescript@5.6.3))(terser@5.36.0)
     optionalDependencies:
-      '@vitest/browser': 2.1.3(@vitest/spy@2.1.3)(playwright@1.48.1)(typescript@5.6.3)(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))(vitest@2.1.3)(webdriverio@9.2.1)
+      '@vitest/browser': 2.1.3(@vitest/spy@2.1.8)(playwright@1.48.1)(typescript@5.6.3)(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))(vitest@2.1.3)(webdriverio@9.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9915,6 +9935,16 @@ snapshots:
     optionalDependencies:
       msw: 2.4.11(typescript@5.7.2)
       vite: 5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0)
+
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.8)(msw@2.4.11(typescript@5.6.3))(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.12
+    optionalDependencies:
+      msw: 2.4.11(typescript@5.6.3)
+      vite: 5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0)
+    optional: true
 
   '@vitest/mocker@2.1.3(@vitest/spy@2.1.8)(msw@2.4.11(typescript@5.7.2))(vite@5.4.9(@types/node@22.10.1)(lightningcss@1.27.0)(terser@5.36.0))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,9 +180,6 @@ importers:
       date-fns:
         specifier: ^2.29.3
         version: 2.30.0
-      human-id:
-        specifier: ^4.1.1
-        version: 4.1.1
       jotai:
         specifier: ^2.10.1
         version: 2.10.1(@types/react@18.3.11)(react@18.3.1)


### PR DESCRIPTION

closes https://github.com/opral/lix-sdk/issues/160

- removes nullability of `version.name` which eases conditional logic. 
- apps don't need custom default version naming logic anymore