### PR TITLE
use-nano-ids-for-change-controlled-tables

### DIFF
--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -19,7 +19,7 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
   -- file
 
   CREATE TABLE IF NOT EXISTS file (
-    id TEXT PRIMARY KEY DEFAULT (uuid_v7()),
+    id TEXT PRIMARY KEY DEFAULT (nano_id(10)),
     path TEXT NOT NULL UNIQUE,
     data BLOB NOT NULL,
     metadata BLOB,

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -168,14 +168,14 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
   -- discussions 
 
   CREATE TABLE IF NOT EXISTS discussion (
-    id TEXT PRIMARY KEY DEFAULT (uuid_v7()),
+    id TEXT PRIMARY KEY DEFAULT (nano_id(12)),
     change_set_id TEXT NOT NULL,
 
     FOREIGN KEY(change_set_id) REFERENCES change_set(id)
   ) STRICT;
 
   CREATE TABLE IF NOT EXISTS comment (
-    id TEXT PRIMARY KEY DEFAULT (uuid_v7()),
+    id TEXT PRIMARY KEY DEFAULT (nano_id(14)),
     parent_id TEXT,
     discussion_id TEXT NULL,
     content TEXT NOT NULL,

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -144,7 +144,7 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
   -- change sets
 
   CREATE TABLE IF NOT EXISTS change_set (
-    id TEXT PRIMARY KEY DEFAULT (uuid_v7())
+    id TEXT PRIMARY KEY DEFAULT (nano_id(16))
   ) STRICT;
 
   CREATE TABLE IF NOT EXISTS change_set_element (

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -187,7 +187,7 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
   -- labels
   
   CREATE TABLE IF NOT EXISTS label (
-    id TEXT PRIMARY KEY DEFAULT (uuid_v7()),
+    id TEXT PRIMARY KEY DEFAULT (nano_id(8)),
     
     name TEXT NOT NULL UNIQUE  -- e.g., 'confirmed', 'reviewed'
     

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -9,30 +9,26 @@ import { openLixInMemory } from "../lix/open-lix-in-memory.js";
 import { updateChangesInVersion } from "../version/update-changes-in-version.js";
 import { createVersion } from "../version/create-version.js";
 
-test("file ids should default to uuid", async () => {
-	const sqlite = await createInMemoryDatabase({
-		readOnly: false,
-	});
-	const db = initDb({ sqlite });
+// file ids are always in the URL of lix apps
+// to increase sharing, the ids should be as short as possible
+// 
+// 129 million file creations will lead to a 1% chance of a collision
+//
+// if someone uses lix to handle 129 million files, we can 
+// increase the length of the id :D
+test("file ids should default to nano_id(10)", async () => {
+	const lix = await openLixInMemory({});
 
-	// init the trigger function (usually defined by lix only)
-	sqlite.createFunction({
-		name: "triggerFileQueue",
-		arity: 0,
-		// @ts-expect-error - dynamic function
-		xFunc: () => {},
-	});
-
-	const file = await db
+	const file = await lix.db
 		.insertInto("file")
 		.values({
-			path: "/mock",
+			path: "/mock.txt",
 			data: new Uint8Array(),
 		})
 		.returningAll()
 		.executeTakeFirstOrThrow();
 
-	expect(validate(file.id)).toBe(true);
+	expect(file.id.length).toBe(10);
 });
 
 test("change ids should default to uuid", async () => {

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -240,6 +240,64 @@ test("change set items must be unique", async () => {
 	);
 });
 
+// 8B IDs needed, in order to have a 1% probability of at least one collision.
+test("discussion.id are nano_id(12)", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+	const db = initDb({ sqlite });
+
+	const changeSet = await db
+		.insertInto("change_set")
+		.defaultValues()
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	const discussion = await db
+		.insertInto("discussion")
+		.values({
+			change_set_id: changeSet.id,
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	expect(discussion.id.length).toBe(12);
+});
+
+// 499B IDs needed, in order to have a 1% probability of at least one collision.
+test("comment.id are nano_id(14)", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+	const db = initDb({ sqlite });
+
+	const changeSet = await db
+		.insertInto("change_set")
+		.defaultValues()
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	const discussion = await db
+		.insertInto("discussion")
+		.values({
+			change_set_id: changeSet.id,
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	const comment = await db
+		.insertInto("comment")
+		.values({
+			discussion_id: discussion.id,
+			content: "mock",
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	expect(comment.id.length).toBe(14);
+});
+
+
 test("creating multiple discussions for one change set should be possible", async () => {
 	const sqlite = await createInMemoryDatabase({
 		readOnly: false,

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -313,6 +313,25 @@ test("change_set.id are nano_id(16)", async () => {
 	expect(changeSet.id.length).toBe(16);
 });
 
+// 2M IDs needed, in order to have a 1% probability of at least one collision.
+// it is assumed that creating 2 million labels is ... unlikely
+test("label.id is nano_id(8)", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+	const db = initDb({ sqlite });
+
+	const label = await db
+		.insertInto("label")
+		.values({
+			name: "mock",
+		})
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	expect(label.id.length).toBe(8);
+});
+
 
 test("creating multiple discussions for one change set should be possible", async () => {
 	const sqlite = await createInMemoryDatabase({

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -297,6 +297,22 @@ test("comment.id are nano_id(14)", async () => {
 	expect(comment.id.length).toBe(14);
 });
 
+// 30T IDs needed, in order to have a 1% probability of at least one collision
+test("change_set.id are nano_id(16)", async () => {
+	const sqlite = await createInMemoryDatabase({
+		readOnly: false,
+	});
+	const db = initDb({ sqlite });
+
+	const changeSet = await db
+		.insertInto("change_set")
+		.defaultValues()
+		.returningAll()
+		.executeTakeFirstOrThrow();
+
+	expect(changeSet.id.length).toBe(16);
+});
+
 
 test("creating multiple discussions for one change set should be possible", async () => {
 	const sqlite = await createInMemoryDatabase({

--- a/packages/lix-sdk/src/database/init-db.ts
+++ b/packages/lix-sdk/src/database/init-db.ts
@@ -10,6 +10,7 @@ import { SerializeJsonBPlugin } from "./kysely-plugin/serialize-jsonb-plugin.js"
 import { createSession } from "./mutation-log/lix-session.js";
 import { applyOwnChangeControlTriggers } from "../own-change-control/database-triggers.js";
 import { humanId } from "human-id";
+import { nanoid } from "./nano-id.js";
 
 export function initDb(args: {
 	sqlite: SqliteDatabase;
@@ -97,5 +98,14 @@ function initFunctions(args: { sqlite: SqliteDatabase }) {
 		name: "human_id",
 		arity: 0,
 		xFunc: () => humanId({ separator: "-", capitalize: false }),
+	});
+
+	args.sqlite.createFunction({
+		name: "nano_id",
+		arity: 1,
+		// @ts-expect-error - not sure why this is not working
+		xFunc: (_ctx: number, length: number) => {
+			return nanoid(length);
+		},
 	});
 }

--- a/packages/lix-sdk/src/database/nano-id.test.ts
+++ b/packages/lix-sdk/src/database/nano-id.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "vitest";
+import { _nanoIdAlphabet, nanoid } from "./nano-id.js";
+
+test("length is obeyed", () => {
+	const id = nanoid(10);
+	expect(id.length).toBe(10);
+});
+
+test("the alphabet does not contain underscores `_` because they are not URL safe", () => {
+	expect(_nanoIdAlphabet).not.toContain("_");
+});
+
+test("the alphabet does not contain dashes `-` because they break selecting the ID from the URL in the browser", () => {
+	expect(_nanoIdAlphabet).not.toContain("-");
+});

--- a/packages/lix-sdk/src/database/nano-id.ts
+++ b/packages/lix-sdk/src/database/nano-id.ts
@@ -1,0 +1,72 @@
+/**
+ * Code taken from the [nanoid](https://github.com/ai/nanoid/blob/main/index.browser.js)
+ * browser implementation. The code is licensed under the MIT license.
+ *
+ */
+
+const random = (bytes: any) => crypto.getRandomValues(new Uint8Array(bytes));
+
+const customRandom = (
+	alphabet: string,
+	defaultSize: number,
+	getRandom: any
+) => {
+	// First, a bitmask is necessary to generate the ID. The bitmask makes bytes
+	// values closer to the alphabet size. The bitmask calculates the closest
+	// `2^31 - 1` number, which exceeds the alphabet size.
+	// For example, the bitmask for the alphabet size 30 is 31 (00011111).
+	// `Math.clz32` is not used, because it is not available in browsers.
+	const mask = (2 << Math.log2(alphabet.length - 1)) - 1;
+	// Though, the bitmask solution is not perfect since the bytes exceeding
+	// the alphabet size are refused. Therefore, to reliably generate the ID,
+	// the random bytes redundancy has to be satisfied.
+
+	// Note: every hardware random generator call is performance expensive,
+	// because the system call for entropy collection takes a lot of time.
+	// So, to avoid additional system calls, extra bytes are requested in advance.
+
+	// Next, a step determines how many random bytes to generate.
+	// The number of random bytes gets decided upon the ID size, mask,
+	// alphabet size, and magic number 1.6 (using 1.6 peaks at performance
+	// according to benchmarks).
+
+	// `-~f => Math.ceil(f)` if f is a float
+	// `-~i => i + 1` if i is an integer
+	const step = -~((1.6 * mask * defaultSize) / alphabet.length);
+
+	return (size = defaultSize) => {
+		let id = "";
+		while (true) {
+			const bytes = getRandom(step);
+			// A compact alternative for `for (var i = 0; i < step; i++)`.
+			let j = step | 0;
+			while (j--) {
+				// Adding `|| ''` refuses a random byte that exceeds the alphabet size.
+				id += alphabet[bytes[j] & mask] || "";
+				if (id.length >= size) return id;
+			}
+		}
+	};
+};
+
+const customAlphabet = (alphabet: string, size = 21) =>
+	customRandom(alphabet, size | 0, random);
+
+/**
+ * Uses every character from nano id except for the `-` and `_` character.
+ *
+ * - Underscore `_` is not URL safe https://github.com/ai/nanoid/issues/347.
+ * - Dash `-` breaks selecting the ID from the URL in the browser.
+ */
+export const _nanoIdAlphabet =
+	"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Generate secure URL-friendly unique ID.
+ *
+ * Use https://zelark.github.io/nano-id-cc/ to calculate the length
+ * of the ID for the use case with the alphabet provided in the
+ * implementation.
+ */
+export const nanoid: (size?: number) => string =
+	customAlphabet(_nanoIdAlphabet);

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -225,9 +225,9 @@ type VersionChangeConflictTable = {
 	change_conflict_id: string;
 };
 
-export type Currentversion = Selectable<CurrentVersionTable>;
-export type NewCurrentversion = Insertable<CurrentVersionTable>;
-export type CurrentversionUpdate = Updateable<CurrentVersionTable>;
+export type CurrentVersion = Selectable<CurrentVersionTable>;
+export type NewCurrentVersion = Insertable<CurrentVersionTable>;
+export type CurrentVersionUpdate = Updateable<CurrentVersionTable>;
 type CurrentVersionTable = {
 	id: string;
 };

--- a/packages/lix-sdk/src/key-value/database-schema.test.ts
+++ b/packages/lix-sdk/src/key-value/database-schema.test.ts
@@ -1,7 +1,6 @@
 import { sql } from "kysely";
 import { expect, test } from "vitest";
 import { openLixInMemory } from "../lix/open-lix-in-memory.js";
-import { validate as validateUuid } from "uuid";
 
 test("string values are accepted", async () => {
 	const lix = await openLixInMemory({});
@@ -94,7 +93,8 @@ test("using json as value should work", async () => {
 	});
 });
 
-test("it should default add a uuid lix_id if not exits", async () => {
+// 1919T IDs needed, in order to have a 1% probability of at least one collision.
+test("it should default add nano_id(18) for the lix_id if not exits", async () => {
 	const lix = await openLixInMemory({});
 
 	const result = await lix.db
@@ -103,7 +103,7 @@ test("it should default add a uuid lix_id if not exits", async () => {
 		.selectAll()
 		.executeTakeFirstOrThrow();
 
-	expect(validateUuid(result.value)).toBe(true);
+	expect(result.value).toHaveLength(18);
 });
 
 test("default value for lix_sync to reduce conditional logic (the key is always set)", async () => {

--- a/packages/lix-sdk/src/key-value/database-schema.ts
+++ b/packages/lix-sdk/src/key-value/database-schema.ts
@@ -14,7 +14,7 @@ export function applyKeyValueDatabaseSchema(
 	) STRICT;
 
 	INSERT OR IGNORE INTO key_value (key, value)
-	VALUES ('lix_id', uuid_v4());
+	VALUES ('lix_id', nano_id(18));
 
 	-- default value for lix sync to false
 	-- if not exist to remove conditional logic


### PR DESCRIPTION
Refactor: Use [nano-ids](https://zelark.github.io/nano-id-cc/) for change controlled tables like discussions, comments, and labels. 

- severely shortens the length of shareable URLs
- closes https://github.com/opral/lix-sdk/issues/189.

```diff
-http://localhost:3005/app/fm/?f=0193f041-21ce-7ffc-ba6e-d2d62b399383&d=0193f041-2457-7ffc-ba7e-494efc37b1b8&l=55a7bcc8-63d8-43b7-af0b-3916618fc258
+http://localhost:3005/app/fm/?f=tUYFRUe4lb&d=rrzumhqqTOwq&l=MftKxYHfDw2bSVr8Bs
```

**Additional information**

The pattern is still not human readable. I assume that we will introduce a human readable pattern in the future in addition to permalinks. This change is a incremental step towards better link sharing and good enough for now. 

**Performance implications**

Nano IDs are not sortable and theoretically make insertions slower. However, until we get lix'es that have billions of rows we need to get users first. Sharing is a key feature to get users. 