### PR TITLE
docs: update documentation for identicalPattern lint rule

### DIFF
--- a/inlang/source-code/message-lint-rules/identicalPattern/README.md
+++ b/inlang/source-code/message-lint-rules/identicalPattern/README.md
@@ -9,18 +9,36 @@ Besides installing the lint rule through `manage.inlang.com` you could also conf
 ### Settings
 
 Type:
+
 ```ts
 type MessageLintRuleLevel = "error" | "warning"
 ```
 
 Example in the `project.inlang/settings.json`:
-```json
+
+```jsonc
 {
-    // other configuration
-    "messageLintRuleLevels": {
-		"messageLintRule.inlang.identicalPattern": "error",
-	}
+  // other configuration
+  "messageLintRuleLevels": {
+    "messageLintRule.inlang.identicalPattern": "error",
+  }
 }
 ```
 
 The default level is `warning`
+
+### Ignore patterns
+
+**DEPRECATED:** Ignore message values by adding them to the `ignore` option.
+
+This rule will report `$schema` as an identical pattern. In order to avoid
+linting errors or warnings, add the URL to the `ignore` option.
+
+```jsonc
+{
+  // other configuration
+  "messageLintRule.inlang.identicalPattern": {
+    "ignore": ["https://inlang.com/schema/inlang-message-format"]
+  }
+}
+```


### PR DESCRIPTION
- add information on `ignore`
- mark documentation as deprecated