### PR TITLE
Parjs-293-module-not-found-when-running-paraglide-js

### DIFF
--- a/.changeset/gold-trainers-invent.md
+++ b/.changeset/gold-trainers-invent.md
@@ -1,0 +1,5 @@
+---
+"@inlang/recommend-sherlock": patch
+---
+
+fix: move required runtime dependencies from `devDependencies` to `dependencies`

--- a/.changeset/shaggy-scissors-pull.md
+++ b/.changeset/shaggy-scissors-pull.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix: just in case bundle monorepo dependencies to mitigate https://github.com/opral/inlang-paraglide-js/issues/289

--- a/inlang/source-code/paraglide/paraglide-js/package.json
+++ b/inlang/source-code/paraglide/paraglide-js/package.json
@@ -49,6 +49,16 @@
 		"clean": "rm -rf ./dist ./node_modules",
 		"check": "tsc --noEmit --emitDeclarationOnly false"
 	},
+	"bundleDependencies": [
+		"@inlang/detect-json-formatting",
+		"@inlang/language-tag",
+		"@inlang/plugin-message-format",
+		"@inlang/recommend-ninja",
+		"@inlang/recommend-sherlock",
+		"@inlang/sdk",
+		"@lix-js/client",
+		"@lix-js/fs"
+	],
 	"dependencies": {
 		"@inlang/recommend-sherlock": "workspace:*",
 		"@inlang/recommend-ninja": "workspace:*",

--- a/inlang/source-code/paraglide/paraglide-js/vite.config.js
+++ b/inlang/source-code/paraglide/paraglide-js/vite.config.js
@@ -4,7 +4,7 @@ import tsconfigPaths from "vite-tsconfig-paths"
 import pkg from "./package.json"
 import manifest from "./marketplace-manifest.json"
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(() => {
 	// eslint-disable-next-line no-undef
 	const pToken = process.env.PUBLIC_POSTHOG_TOKEN ?? "placeholder"
 
@@ -15,7 +15,6 @@ export default defineConfig(({ mode }) => {
 				entry: ["src/index.ts", "src/adapter-utils/index.ts", "src/cli/index.ts"],
 				formats: ["es"],
 			},
-
 			emptyOutDir: true,
 			rollupOptions: {
 				external: Object.keys(pkg.dependencies),

--- a/inlang/source-code/recommendations/recommend-sherlock/package.json
+++ b/inlang/source-code/recommendations/recommend-sherlock/package.json
@@ -21,14 +21,16 @@
 		"format": "prettier ./src --write",
 		"clean": "rm -rf ./dist ./node_modules"
 	},
-	"devDependencies": {
-		"@lix-js/fs": "workspace:*",
-		"@inlang/sdk": "workspace:*",
-		"@types/vscode": "^1.84.2",
+	"dependencies": {
 		"comment-json": "^4.2.3",
+		"@sinclair/typebox": "^0.31.17",
+		"@inlang/sdk": "workspace:*",
+		"@lix-js/fs": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/vscode": "^1.84.2",
 		"patch-package": "6.5.1",
 		"memfs": "4.6.0",
-		"@sinclair/typebox": "^0.31.17",
 		"typescript": "^5.1.3",
 		"@vitest/coverage-v8": "0.33.0",
 		"vitest": "0.33.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1420,6 +1420,22 @@ importers:
 
   inlang/source-code/paraglide/paraglide-js:
     dependencies:
+      commander:
+        specifier: 11.1.0
+        version: 11.1.0
+      consola:
+        specifier: 3.2.3
+        version: 3.2.3
+      dedent:
+        specifier: 1.5.1
+        version: 1.5.1
+      json5:
+        specifier: 2.2.3
+        version: 2.2.3
+      posthog-node:
+        specifier: ^4.0.1
+        version: 4.0.1
+    devDependencies:
       '@inlang/detect-json-formatting':
         specifier: workspace:*
         version: link:../../detect-json-formatting
@@ -1444,22 +1460,6 @@ importers:
       '@lix-js/fs':
         specifier: workspace:*
         version: link:../../../../lix/packages/fs
-      commander:
-        specifier: 11.1.0
-        version: 11.1.0
-      consola:
-        specifier: 3.2.3
-        version: 3.2.3
-      dedent:
-        specifier: 1.5.1
-        version: 1.5.1
-      json5:
-        specifier: 2.2.3
-        version: 2.2.3
-      posthog-node:
-        specifier: ^4.0.1
-        version: 4.0.1
-    devDependencies:
       '@rollup/plugin-terser':
         specifier: 0.4.3
         version: 0.4.3(rollup@3.29.1)
@@ -2285,7 +2285,7 @@ importers:
         version: 0.34.6(jsdom@22.1.0)(lightningcss@1.25.1)(playwright@1.39.0)(safaridriver@0.1.2)(terser@5.31.6)(webdriverio@8.39.1(typescript@5.5.3))
 
   inlang/source-code/recommendations/recommend-sherlock:
-    devDependencies:
+    dependencies:
       '@inlang/sdk':
         specifier: workspace:*
         version: link:../../sdk
@@ -2295,15 +2295,16 @@ importers:
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
+      comment-json:
+        specifier: ^4.2.3
+        version: 4.2.3
+    devDependencies:
       '@types/vscode':
         specifier: ^1.84.2
         version: 1.91.0
       '@vitest/coverage-v8':
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6(jsdom@22.1.0)(lightningcss@1.25.1)(playwright@1.39.0)(safaridriver@0.1.2)(terser@5.31.6)(webdriverio@8.39.1(typescript@5.5.3)))
-      comment-json:
-        specifier: ^4.2.3
-        version: 4.2.3
       memfs:
         specifier: 4.6.0
         version: 4.6.0(quill-delta@5.1.0)(rxjs@7.8.1)(tslib@2.6.2)
@@ -4498,12 +4499,15 @@ packages:
 
   '@esbuild-kit/cjs-loader@2.4.4':
     resolution: {integrity: sha512-NfsJX4PdzhwSkfJukczyUiZGc7zNNWZcEAyqeISpDnn0PTfzMJR1aR8xAIPskBejIxBJbIgCCMzbaYa9SXepIg==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -9721,7 +9725,7 @@ packages:
     resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -12510,7 +12514,7 @@ packages:
     hasBin: true
 
   json-buffer@3.0.0:
-    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
+    resolution: {integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -23756,7 +23760,7 @@ snapshots:
       '@types/node': 20.14.10
     optional: true
 
-  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2)':
+  '@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
@@ -23771,7 +23775,7 @@ snapshots:
       semver: 7.6.3
       tsutils: 3.21.0(typescript@5.0.3)
     optionalDependencies:
-      typescript: 5.3.2
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -27397,7 +27401,7 @@ snapshots:
       '@babel/eslint-parser': 7.21.3(@babel/core@7.21.4)(eslint@8.57.0)
       '@babel/preset-react': 7.18.6(@babel/core@7.21.4)
       '@next/eslint-plugin-next': 13.2.4
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3)
       '@typescript-eslint/parser': 5.56.0(eslint@8.57.0)(typescript@5.0.3)
       confusing-browser-globals: 1.0.11
       eslint: 8.57.0
@@ -27407,7 +27411,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.5.4(eslint-plugin-import@2.27.5)(eslint@8.57.0)
       eslint-plugin-etc: 2.0.2(eslint@8.57.0)(typescript@5.0.3)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint-import-resolver-typescript@3.5.4)(eslint@8.57.0)
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3)
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jest-formatting: 3.1.0(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
@@ -27686,12 +27690,12 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3))(eslint@8.57.0)(typescript@5.0.3):
+  eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.0.3)
       eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.3.2)
+      '@typescript-eslint/eslint-plugin': 5.56.0(@typescript-eslint/parser@5.56.0(eslint@8.57.0)(typescript@5.3.2))(eslint@8.57.0)(typescript@5.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
(Hopefully) closes https://github.com/opral/inlang-paraglide-js/issues/289. 

- moves `comment-json` from `devDependencies` to `dependencies`

- just in case bundles monorepo dependendencies in paraglide js 