### PR TITLE
WIP filter out OPFS warning

### DIFF
--- a/.changeset/dry-berries-jam.md
+++ b/.changeset/dry-berries-jam.md
@@ -1,0 +1,5 @@
+---
+"sqlite-wasm-kysely": patch
+---
+
+We intercept SQLite's logging to mute OPFS warnings. Since we explicitly run SQLite in memory on the main thread, there is no need for OPFS.

--- a/packages/sqlite-wasm-kysely/src/util/createInMemoryDatabase.ts
+++ b/packages/sqlite-wasm-kysely/src/util/createInMemoryDatabase.ts
@@ -1,4 +1,16 @@
+// @ts-ignore
+globalThis.sqlite3ApiConfig = {
+  warn: (message: string, details: any) => {
+    if (message === "Ignoring inability to install OPFS sqlite3_vfs:") {
+      // filter out
+      return;
+    }
+    console.log(message + " " + details);
+  },
+};
+
 import sqlite3InitModule from "@eliaspourquoi/sqlite-node-wasm";
+
 import { setSqliteModule, sqliteModule } from "../kysely/sqliteModule.js";
 import { wasmBinary } from "./sqliteWasmBinary.js";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1184,8 +1184,6 @@ importers:
         specifier: 2.1.8
         version: 2.1.8(@types/node@20.5.9)(@vitest/browser@2.1.8)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.7.0(@types/node@20.5.9)(typescript@5.7.2))(terser@5.36.0)
 
-  inlang/packages/website/dist/server: {}
-
   inlang/packages/website/tailwind-color-plugin:
     dependencies:
       '@ctrl/tinycolor':


### PR DESCRIPTION
We intercept SQLite's logging to mute OPFS warnings. Since we explicitly run SQLite in memory on the main thread, there is no need for OPFS.