### PR TITLE
refactor: removes the `anonymous_` prefix from "anonymous accounts".

### DIFF
--- a/.changeset/slimy-kiwis-vanish.md
+++ b/.changeset/slimy-kiwis-vanish.md
@@ -1,0 +1,9 @@
+---
+"@lix-js/sdk": minor
+---
+
+refactor: removes the `anonymous_` prefix from "anonymous accounts". 
+
+Closes https://github.com/opral/lix-sdk/issues/233. 
+
+There is no difference between an account prefixed with `anonymous` and one that is not. This change removes the prefix to avoid confusion. 

--- a/packages/lix-sdk/src/account/database-schema.test.ts
+++ b/packages/lix-sdk/src/account/database-schema.test.ts
@@ -18,7 +18,7 @@ type AccountSchema = {
 	active_account: ActiveAccountTable;
 };
 
-test("account table should have no entry in the beginning and activte account should be an anonymous account", async () => {
+test("account table should have no entry but an active account", async () => {
 	const sqlite = await createInMemoryDatabase({
 		readOnly: false,
 	});
@@ -38,11 +38,8 @@ test("account table should have no entry in the beginning and activte account sh
 		}),
 	});
 
-	const account = await db
-		.selectFrom("account")
-		.selectAll()
-		.where("id", "=", "anonymous")
-		.execute();
+	const account = await db.selectFrom("account").selectAll().execute();
+
 	expect(account?.length).toBe(0);
 
 	const active_account = await db
@@ -50,7 +47,7 @@ test("account table should have no entry in the beginning and activte account sh
 		.selectAll()
 		.executeTakeFirst();
 
-	expect(active_account?.id).toBe("anonymous_mock_uuid_v7");
+	expect(active_account?.id).toBe("mock_uuid_v7");
 });
 
 test("account.id should default to uuid_v7", async () => {
@@ -131,7 +128,7 @@ test('it should drop the temp "current_account" table on reboot to not persist t
 		id: "test",
 	});
 
-	const blob = contentFromDatabase(sqlite);
+	const blob = contentFromDatabase(sqlite) as unknown as ArrayBuffer;
 
 	// re-open the database
 
@@ -158,7 +155,7 @@ test('it should drop the temp "current_account" table on reboot to not persist t
 		.executeTakeFirst();
 
 	expect(account2).toMatchObject({
-		id: "anonymous_mock_uuid_v7-2",
+		id: "mock_uuid_v7-2",
 	});
 });
 

--- a/packages/lix-sdk/src/account/database-schema.ts
+++ b/packages/lix-sdk/src/account/database-schema.ts
@@ -21,10 +21,6 @@ export function applyAccountDatabaseSchema(
     name TEXT NOT NULL
   ) STRICT;
 
-  -- default anonymous account
-  -- INSERT OR IGNORE INTO account (id, name) 
-  -- VALUES ('anonymous', 'anonymous');
-
   -- current account(s)
   -- temp table because current accounts are session
   -- specific and should not be persisted
@@ -34,8 +30,8 @@ export function applyAccountDatabaseSchema(
     -- can't use foreign keys in temp tables... :(
   ) STRICT;
 
-  -- default to the anonymous account
-  INSERT INTO active_account (id, name) values ('anonymous_' || uuid_v7(), '${anonymousAccountName}');
+  -- default to a new account
+  INSERT INTO active_account (id, name) values (uuid_v7(), '${anonymousAccountName}');
 `;
 
 	return sqlite.exec(sql);

--- a/packages/lix-sdk/src/file-queue/file-queue-process.test.ts
+++ b/packages/lix-sdk/src/file-queue/file-queue-process.test.ts
@@ -104,8 +104,7 @@ test("should use queue and settled correctly", async () => {
 				content: {
 					text: "insert text",
 				},
-				// handles the author (which defaults to anonymous)
-				account_id: expect.stringMatching(/^anonymous_/),
+				account_id: expect.stringMatching(/./),
 			}),
 		])
 	);
@@ -209,7 +208,7 @@ test("should use queue and settled correctly", async () => {
 				content: {
 					text: "insert text",
 				},
-				account_id: expect.stringMatching(/^anonymous_/),
+				account_id: expect.stringMatching(/./),
 			}),
 			expect.objectContaining({
 				entity_id: "test",
@@ -219,7 +218,7 @@ test("should use queue and settled correctly", async () => {
 				content: {
 					text: "updated text",
 				},
-				account_id: expect.stringMatching(/^anonymous_/),
+				account_id: expect.stringMatching(/./),
 			}),
 			expect.objectContaining({
 				file_id: "test",
@@ -229,7 +228,7 @@ test("should use queue and settled correctly", async () => {
 				content: {
 					text: "second text update",
 				},
-				account_id: expect.stringMatching(/^anonymous_/),
+				account_id: expect.stringMatching(/./),
 			}),
 		])
 	);


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/233.

There is no difference between an account prefixed with `anonymous` and one that is not. This change removes the prefix to avoid confusion.