### PR TITLE
add: `loadProject({ account })`

### DIFF
--- a/inlang/packages/sdk/src/project/loadProject.test.ts
+++ b/inlang/packages/sdk/src/project/loadProject.test.ts
@@ -116,6 +116,26 @@ test("if a project has no id, it should be generated", async () => {
 	expect(validate(id)).toBe(true);
 });
 
+test("providing an account should work", async () => {
+	const mockAccount = {
+		id: "mock-account-id",
+		name: "peter",
+	};
+
+	const project = await loadProjectInMemory({
+		blob: await newProject(),
+		account: mockAccount,
+	});
+
+	const activeAccount = await project.lix.db
+		.selectFrom("active_account")
+		.selectAll()
+		.execute();
+
+	expect(activeAccount).toEqual([mockAccount]);
+});
+
+
 // test("subscribing to errors should work", async () => {
 // 	const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/inlang/packages/sdk/src/project/loadProject.ts
+++ b/inlang/packages/sdk/src/project/loadProject.ts
@@ -1,4 +1,4 @@
-import { toBlob, type Lix } from "@lix-js/sdk";
+import { toBlob, type Account, type Lix } from "@lix-js/sdk";
 import type { InlangPlugin } from "../plugin/schema.js";
 import type { ProjectSettings } from "../json-schema/settings.js";
 import { type SqliteDatabase } from "sqlite-wasm-kysely";
@@ -22,6 +22,16 @@ import { exportFiles } from "../import-export/exportFiles.js";
 export async function loadProject(args: {
 	sqlite: SqliteDatabase;
 	lix: Lix;
+	/**
+	 * The account that loaded the project.
+	 *
+	 * Defaults to an anonymous/new account if undefined.
+	 *
+	 * @example
+	 *   const account = localStorage.getItem("account")
+	 *   const project = await loadProject({ account })
+	 */
+	account?: Account;
 	/**
 	 * Provide plugins to the project.
 	 *

--- a/inlang/packages/sdk/src/project/loadProjectInMemory.ts
+++ b/inlang/packages/sdk/src/project/loadProjectInMemory.ts
@@ -12,6 +12,7 @@ export async function loadProjectInMemory(
 ) {
 	const lix = await openLixInMemory({
 		blob: args.blob,
+		account: args.account,
 		providePlugins: [
 			// inlangLixPluginV1
 		],


### PR DESCRIPTION
Adds the possibility to provide an account upon opening an inlang project.