### PR TITLE
refactor: LIXDK-321 change "confirmed" to "checkpoint" and "intermediate"

### DIFF
--- a/.changeset/lemon-cherries-unite.md
+++ b/.changeset/lemon-cherries-unite.md
@@ -1,0 +1,7 @@
+---
+"lix-file-manager": minor
+"csv-app": minor
+"@lix-js/sdk": minor
+---
+
+Refactor: change "confirmed" to "checkpoint" and "unconfirmed" to "intermediate"

--- a/inlang/packages/fink/src/routes/changes/Page.tsx
+++ b/inlang/packages/fink/src/routes/changes/Page.tsx
@@ -26,7 +26,7 @@ export default function App() {
 				.where("id", "=", change.id)
 				.set("meta", {
 					...change.meta,
-					tag: "confirmed",
+					tag: "checkpoint",
 					change_set: humanId(),
 				})
 				.executeTakeFirst();
@@ -74,7 +74,7 @@ export default function App() {
 									setShowDialog(true);
 								}}
 							>
-								Confirm changes
+								Create checkpoint
 							</SlButton>
 							<SlDialog
 								label="Add commit details"
@@ -100,7 +100,7 @@ export default function App() {
 									</div>
 									<div className="mt-6 flex justify-end">
 										<SlButton variant="primary" slot="footer" type="submit">
-											Confirm changes
+											Create checkpoint
 										</SlButton>
 									</div>
 								</form>

--- a/packages/csv-app/src/layouts/OpenFileLayout.tsx
+++ b/packages/csv-app/src/layouts/OpenFileLayout.tsx
@@ -84,14 +84,14 @@ export default function Layout(props: { children: React.ReactNode }) {
 						</div>
 
 						<div className="mr-1 flex items-center gap-1.5">
-							{/* {unconfirmedChanges.length > 0 && (
+							{/* {intermediateChanges.length > 0 && (
 								<SlButton
 									size="small"
 									variant="neutral"
-									disabled={unconfirmedChanges.length === 0}
-									onClick={() => setShowConfirmChangesDialog(true)}
+									disabled={intermediateChanges.length === 0}
+									onClick={() => setShowIntermediateChangesDialog(true)}
 								>
-									Confirm Changes
+									Create Checkpoint
 								</SlButton>
 							)} */}
 						</div>
@@ -105,8 +105,8 @@ export default function Layout(props: { children: React.ReactNode }) {
 							// which assumes that nothing is auto saved
 							//
 							// counter={
-							// 	unconfirmedChanges.length !== 0
-							// 		? unconfirmedChanges.length
+							// 	intermediateChanges.length !== 0
+							// 		? intermediateChanges.length
 							// 		: undefined
 							// }
 							name="Changes"

--- a/packages/csv-app/src/routes/changes/Page.tsx
+++ b/packages/csv-app/src/routes/changes/Page.tsx
@@ -4,7 +4,7 @@ import { atom, useAtom } from "jotai";
 import { lixAtom, withPollingAtom } from "../../state.ts";
 import {
 	activeFileAtom,
-	unconfirmedChangesAtom,
+	intermediateChangesAtom,
 } from "../../state-active-file.ts";
 import { changeSetHasLabel } from "@lix-js/sdk";
 
@@ -32,7 +32,7 @@ const changeSetsAtom = atom(async (get) => {
 		.leftJoin("comment", "comment.discussion_id", "discussion.id")
 		.where("comment.parent_id", "is", null) // Filter to get only the first comment
 		.where("change.file_id", "=", activeFile!.id)
-		.where(changeSetHasLabel("confirmed"))
+		.where(changeSetHasLabel("checkpoint"))
 		.groupBy("change_set.id")
 		.orderBy("change.created_at", "desc")
 		.select("change_set.id")
@@ -44,7 +44,7 @@ const changeSetsAtom = atom(async (get) => {
 
 export default function Page() {
 	const [changeSets] = useAtom(changeSetsAtom);
-	const [unconfirmedChanges] = useAtom(unconfirmedChangesAtom);
+	const [intermediateChanges] = useAtom(intermediateChangesAtom);
 
 	return (
 		<>
@@ -52,10 +52,10 @@ export default function Page() {
 				<div className="px-3 pb-6 pt-3 md:pt-5">
 					<div className="mx-auto max-w-7xl bg-white border border-zinc-200 rounded-lg divide-y divide-zinc-200 overflow-hidden">
 						{/* virtual change set for uncommitted changes */}
-						{unconfirmedChanges.length > 0 && (
+						{intermediateChanges.length > 0 && (
 							<ChangeSet
-								key={"unconfirmed-changes"}
-								id={"unconfirmed-changes"}
+								key={"intermediate-changes"}
+								id={"intermediate-changes"}
 								firstComment={null}
 								authorName={null}
 							/>

--- a/packages/csv-app/src/state-active-file.ts
+++ b/packages/csv-app/src/state-active-file.ts
@@ -140,8 +140,8 @@ export const activeCellChangesAtom = atom(async (get) => {
 	return changes;
 });
 
-// The CSV app treats changes that are not in a change set as unconfirmed changes.
-export const unconfirmedChangesAtom = atom(async (get) => {
+// The CSV app treats changes that are not in a change set as intermediate changes.
+export const intermediateChangesAtom = atom(async (get) => {
 	get(withPollingAtom);
 	const lix = await get(lixAtom);
 	const activeFile = await get(activeFileAtom);
@@ -153,7 +153,7 @@ export const unconfirmedChangesAtom = atom(async (get) => {
 		.selectFrom("change")
 		.where("change.file_id", "=", activeFile.id)
 		.where(changeIsLeafInVersion(currentBranch))
-		.where((eb) => eb.not(changeHasLabel("confirmed")))
+		.where((eb) => eb.not(changeHasLabel("checkpoint")))
 		.selectAll("change")
 		.execute();
 });

--- a/packages/lix-file-manager/src/state-active-file.ts
+++ b/packages/lix-file-manager/src/state-active-file.ts
@@ -149,8 +149,8 @@ export const activeCellChangesAtom = atom(async (get) => {
 	return changes;
 });
 
-// The CSV app treats changes that are not in a change set as unconfirmed changes.
-export const unconfirmedChangesAtom = atom(async (get) => {
+// The file manager app treats changes that are not in a change set as intermediate changes.
+export const intermediateChangesAtom = atom(async (get) => {
 	get(withPollingAtom);
 	const lix = await get(lixAtom);
 	const activeFile = await get(activeFileAtom);
@@ -161,7 +161,7 @@ export const unconfirmedChangesAtom = atom(async (get) => {
 		.selectFrom("change")
 		.where("change.file_id", "=", activeFile.id)
 		.where(changeIsLeafInVersion(currentBranch))
-		.where((eb) => eb.not(changeHasLabel("confirmed")))
+		.where((eb) => eb.not(changeHasLabel("checkpoint")))
 		.selectAll("change")
 		.execute();
 });

--- a/packages/lix-sdk/docs/20-concepts/40-label.md
+++ b/packages/lix-sdk/docs/20-concepts/40-label.md
@@ -10,9 +10,9 @@ TODO
 
 ## Pre-defined Labels
 
-- `confirmed` - Confirming changes acts as filter for the graph. Seeing all changes is oftentimes overwhelming. Use confirmed as filter for the history. 
+- `checkpoint` - Creating checkpoints as filter for the graph. Seeing all changes is oftentimes overwhelming. Use checkpoint as filter for the history.
 
 ## Examples
 
-- Tag a change set as confirmed e.g. the changes in the set should not be changed anymore.
+- Tag a change set as checkpoint e.g. the changes in the set should not be changed anymore.
 

--- a/packages/lix-sdk/src/database/apply-schema.ts
+++ b/packages/lix-sdk/src/database/apply-schema.ts
@@ -189,11 +189,11 @@ export function applySchema(args: { sqlite: SqliteDatabase }): SqliteDatabase {
   CREATE TABLE IF NOT EXISTS label (
     id TEXT PRIMARY KEY DEFAULT (nano_id(8)),
     
-    name TEXT NOT NULL UNIQUE  -- e.g., 'confirmed', 'reviewed'
+    name TEXT NOT NULL UNIQUE  -- e.g., 'checkpoint', 'reviewed'
     
   ) STRICT;
 
-  INSERT OR IGNORE INTO label (name) VALUES ('confirmed');
+  INSERT OR IGNORE INTO label (name) VALUES ('checkpoint');
   INSERT OR IGNORE INTO label (name) VALUES ('grouped');
 
   -- versions

--- a/packages/lix-sdk/src/database/init-db.test.ts
+++ b/packages/lix-sdk/src/database/init-db.test.ts
@@ -362,7 +362,7 @@ test("creating multiple discussions for one change set should be possible", asyn
 	expect(discussions).toHaveLength(2);
 });
 
-test("the confirmed label should be created if it doesn't exist", async () => {
+test("the checkpoint label should be created if it doesn't exist", async () => {
 	const sqlite = await createInMemoryDatabase({
 		readOnly: false,
 	});
@@ -371,11 +371,11 @@ test("the confirmed label should be created if it doesn't exist", async () => {
 	const tag = await db
 		.selectFrom("label")
 		.selectAll()
-		.where("name", "=", "confirmed")
+		.where("name", "=", "checkpoint")
 		.executeTakeFirst();
 
 	expect(tag).toMatchObject({
-		name: "confirmed",
+		name: "checkpoint",
 	});
 });
 

--- a/packages/lix-sdk/src/query-filter/change-has-label.ts
+++ b/packages/lix-sdk/src/query-filter/change-has-label.ts
@@ -7,7 +7,7 @@ import type { LixDatabaseSchema } from "../database/schema.js";
  * @example
  *   ```ts
  *   await lix.db.selectFrom("change")
- *      .where(changeHasLabel("confirmed"))
+ *      .where(changeHasLabel("checkpoint"))
  *      .selectAll()
  *      .execute();
  *   ```
@@ -17,7 +17,7 @@ import type { LixDatabaseSchema } from "../database/schema.js";
  *
  *   ```ts
  *   await lix.db.selectFrom("change")
- * 		.where((eb) => eb.not(changeHasLabel("confirmed")))
+ * 		.where((eb) => eb.not(changeHasLabel("checkpoint")))
  * 		.selectAll()
  * 		.execute();
  *   ```

--- a/packages/lix-sdk/src/query-filter/change-set-has-label.ts
+++ b/packages/lix-sdk/src/query-filter/change-set-has-label.ts
@@ -7,7 +7,7 @@ import type { LixDatabaseSchema } from "../database/schema.js";
  * @example
  *   ```ts
  *   await lix.db.selectFrom("change_set")
- *      .where(changeSetHasLabel("confirmed"))
+ *      .where(changeSetHasLabel("checkpoint"))
  *      .selectAll()
  *      .execute();
  *   ```
@@ -17,7 +17,7 @@ import type { LixDatabaseSchema } from "../database/schema.js";
  *
  *   ```ts
  *   await lix.db.selectFrom("change_set")
- * 		.where((eb) => eb.not(changeSetHasLabel("confirmed")))
+ * 		.where((eb) => eb.not(changeSetHasLabel("checkpoint")))
  * 		.selectAll()
  * 		.execute();
  *   ```


### PR DESCRIPTION
"Confirmed" was not understand or used in similar fashion like "save".

The concept of a checkpoint seem to fit the use and visual representation. It is also a known concept from video games for non-technical users.

Therefore:
- "confirmed" is renamed to "checkpoint"
- "confirm changes" is renamed to "create checkpoint"
- "unconfirmed changes" is renamed to "intermediate changes"