### PR TITLE
rename options to compilerOptions to align with typescript naming

### DIFF
--- a/inlang/packages/paraglide-js/examples/vite/vite.config.js
+++ b/inlang/packages/paraglide-js/examples/vite/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: "./project.inlang",
 			outdir: "./src/paraglide",
-			options: {
+			compilerOptions: {
 				outputStructure: "locale-modules",
 			},
 		}),

--- a/inlang/packages/paraglide-js/src/bundler-plugins/unplugin.ts
+++ b/inlang/packages/paraglide-js/src/bundler-plugins/unplugin.ts
@@ -19,7 +19,7 @@ export const unpluginFactory: UnpluginFactory<{
 	 * @example "./src/paraglide"
 	 */
 	outdir: string;
-	options?: ParaglideCompilerOptions;
+	compilerOptions?: ParaglideCompilerOptions;
 }> = (args) => ({
 	name: PLUGIN_NAME,
 	enforce: "pre",
@@ -28,7 +28,7 @@ export const unpluginFactory: UnpluginFactory<{
 		await compile({
 			project: args.project,
 			outdir: args.outdir,
-			options: args.options,
+			compilerOptions: args.compilerOptions,
 			fs: wrappedFs,
 		});
 
@@ -43,7 +43,7 @@ export const unpluginFactory: UnpluginFactory<{
 			await compile({
 				project: args.project,
 				outdir: args.outdir,
-				options: args.options,
+				compilerOptions: args.compilerOptions,
 				fs: wrappedFs,
 			});
 		}
@@ -55,7 +55,7 @@ export const unpluginFactory: UnpluginFactory<{
 			await compile({
 				project: args.project,
 				outdir: args.outdir,
-				options: args.options,
+				compilerOptions: args.compilerOptions,
 				fs: wrappedFs,
 			});
 		});

--- a/inlang/packages/paraglide-js/src/compiler/compile.ts
+++ b/inlang/packages/paraglide-js/src/compiler/compile.ts
@@ -28,7 +28,7 @@ export async function compile(args: {
 	project: string;
 	outdir: string;
 	fs?: typeof import("node:fs");
-	options?: ParaglideCompilerOptions;
+	compilerOptions?: ParaglideCompilerOptions;
 }): Promise<void> {
 	const fs = args.fs ?? (await import("node:fs"));
 	const absoluteOutdir = path.resolve(process.cwd(), args.outdir);
@@ -44,7 +44,7 @@ export async function compile(args: {
 
 	const output = await compileProject({
 		project,
-		options: args.options,
+		compilerOptions: args.compilerOptions,
 	});
 
 	await writeOutput(absoluteOutdir, output, fs.promises);

--- a/inlang/packages/paraglide-js/src/compiler/compileProject.ts
+++ b/inlang/packages/paraglide-js/src/compiler/compileProject.ts
@@ -52,11 +52,11 @@ const defaultCompilerOptions: ParaglideCompilerOptions = {
  */
 export const compileProject = async (args: {
 	project: InlangProject;
-	options?: ParaglideCompilerOptions;
+	compilerOptions?: ParaglideCompilerOptions;
 }): Promise<Record<string, string>> => {
 	const optionsWithDefaults = {
 		...defaultCompilerOptions,
-		...args.options,
+		...args.compilerOptions,
 	};
 
 	const settings = await args.project.settings.get();


### PR DESCRIPTION
Align with typescript naming by renaming `options` to `compilerOptions`. 

