### PR TITLE
Fix incorrect element reference in `InlangVariant` event binding

### DIFF
--- a/inlang/packages/ui-components/editor-component/src/stories/variant/inlang-variant.ts
+++ b/inlang/packages/ui-components/editor-component/src/stories/variant/inlang-variant.ts
@@ -163,9 +163,9 @@ export default class InlangVariant extends LitElement {
                     size="small"
                     value=${match.type === "literal-match" ? match.value : "*"}
                     @sl-blur=${(e: Event) => {
-                      const element = this.shadowRoot?.getElementById(
-                        `${this.variant.id}-${match}`
-                      );
+											const element = this.shadowRoot?.getElementById(
+												`${this.variant.id}-${match.key}`
+											);
                       if (element && e.target === element) {
                         this._updateMatch(
                           match.key,


### PR DESCRIPTION
### **Change Summary**
The update corrects an incorrect element reference in `inlang-variant.ts`, ensuring that the event target properly matches the expected element.

### **Detailed Diff Analysis**
- **File:** `inlang/packages/ui-components/editor-component/src/stories/variant/inlang-variant.ts`
- **Lines Modified:** 163-169
- **Changes Made:**
  - **Before:** 
    ```ts
    const element = this.shadowRoot?.getElementById(
      `${this.variant.id}-${match}`
    );
    ```
  - **After:**
    ```ts
    const element = this.shadowRoot?.getElementById(
      `${this.variant.id}-${match.key}`
    );
    ```
  - **Issue Fixed:** 
    - Previously, `match` was used directly in the element ID.
    - The correct property to reference is `match.key`, ensuring proper retrieval of the associated element.
  - **Impact:** Fixes event binding issues where the variant was not emitting the event correctly due to mismatched element references.

### **Key Takeaway**
This fix ensures that the `@sl-blur` event is correctly linked to the expected UI element, preventing potential UI inconsistencies or event misfires.