### PR TITLE
Change new variant behavior to default to `literal-match` instead of `catch-all`

### DIFF
--- a/inlang/packages/ui-components/editor-component/src/stories/message/inlang-message.ts
+++ b/inlang/packages/ui-components/editor-component/src/stories/message/inlang-message.ts
@@ -286,8 +286,9 @@ export default class InlangMessage extends LitElement {
 										messageId: this.message.id,
 										// combine the matches that are already present with the new category -> like a matrix
 										matches: this.message.selectors.map((selector) => ({
-											type: "catchall-match",
+											type: "literal-match",
 											key: selector.name,
+											value: "",
 										})),
 										pattern: [],
 									};


### PR DESCRIPTION
#### **Change Summary**  
This update modifies the default behavior of new variants in `InlangMessage`, ensuring they default to a **literal match** instead of a **catch-all match** when created.  

#### **File Affected:**  
- `inlang/packages/ui-components/editor-component/src/stories/message/inlang-message.ts`  

#### **Code Diff Breakdown:**  
- **Before:**  
  ```ts
  matches: this.message.selectors.map((selector) => ({
      type: "catchall-match",
      key: selector.name
  })),
  ```
- **After:**  
  ```ts
  matches: this.message.selectors.map((selector) => ({
      type: "literal-match",
      key: selector.name,
      value: "",
  })),
  ```
  
#### **Reason for Change:**  
- Previously, new variants defaulted to `catchall-match`, potentially leading to unintended broad pattern matches.  
- This update ensures that new variants behave more predictably by defaulting to `literal-match`, which aligns better with expected usage patterns.  

#### **Impact:**  
✅ Prevents unexpected matches from being created by default.  
✅ Improves consistency in how selectors are interpreted.  
✅ Ensures new variants adhere to the intended match behavior.  