### PR TITLE
Replace `{locale}` with `{languageTag}` in path patterns

### DIFF
--- a/inlang/packages/paraglide/paraglide-astro/README.md
+++ b/inlang/packages/paraglide/paraglide-astro/README.md
@@ -22,7 +22,7 @@ npx @inlang/paraglide-js@latest init
 npm i @inlang/paraglide-astro
 ```
 
-This will generate `messages/{locale}.json` files for each of your languages. 
+This will generate `messages/{languageTag}.json` files for each of your languages. 
 
 Register the Integration in `astro.config.mjs`:
 

--- a/inlang/packages/paraglide/paraglide-js/README.md
+++ b/inlang/packages/paraglide/paraglide-js/README.md
@@ -16,7 +16,7 @@ This will:
 
 ## Adding and editing Messages
 
-Messages are stored in `messages/{locale}.json` as key-value pairs. You can add parameters with curly braces.
+Messages are stored in `messages/{languageTag}.json` as key-value pairs. You can add parameters with curly braces.
 
 ```diff
 // messages/en.json

--- a/inlang/packages/paraglide/paraglide-js/docs/usage.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/usage.md
@@ -13,7 +13,7 @@ imports:
 
 ## Working with the Inlang Message Format
 
-It expects messages to be in `messages/{locale}.json` relative to your repo root.
+It expects messages to be in `messages/{languageTag}.json` relative to your repo root.
 
 ```json
 //messages/en.json
@@ -23,7 +23,7 @@ It expects messages to be in `messages/{locale}.json` relative to your repo root
 }
 ```
 
-The `messages/{locale}.json` file contains a flat map of message IDs and their translations. You can use curly braces to insert `{parameters}` into translations
+The `messages/{languageTag}.json` file contains a flat map of message IDs and their translations. You can use curly braces to insert `{parameters}` into translations
 
 **Nesting purposely isn't supported in the inlang message format (but other plugins do support it!)**. Nested messages are way harder to interact with from complementary tools like the [Sherlock IDE Extension](https://inlang.com/m/r7kp499g/app-inlang-ideExtension), the [Parrot Figma Plugin](https://inlang.com/m/gkrpgoir/app-parrot-figmaPlugin), or the [Fink Localization editor](https://inlang.com/m/tdozzpar/app-inlang-finkLocalizationEditor). Intellisense also becomes less helpful since it only shows the messages at the current level, not all messages. Additionally enforcing an organization-style side-steps organization discussions with other contributors.
 
@@ -123,8 +123,8 @@ If you want your language files to be in a different location you can change the
 // project.inlang/settings.json
 {
 	"plugin.inlang.messageFormat": {
--		"pathPattern": "./messages/{locale}.json"
-+		"pathPattern": "./i18n/{locale}.json"
+-		"pathPattern": "./messages/{languageTag}.json"
++		"pathPattern": "./i18n/{languageTag}.json"
 	}
 }
 ```

--- a/inlang/packages/paraglide/paraglide-js/examples/cli/project.inlang/settings.json
+++ b/inlang/packages/paraglide/paraglide-js/examples/cli/project.inlang/settings.json
@@ -4,6 +4,6 @@
 	"locales": ["en", "de", "en-US"],
 	"modules": ["../../../../plugins/inlang-message-format/dist/index.js"],
 	"plugin.inlang.messageFormat": {
-		"pathPattern": "./messages/{locale}.json"
+		"pathPattern": "./messages/{languageTag}.json"
 	}
 }

--- a/inlang/packages/paraglide/paraglide-js/examples/react/project.inlang/settings.json
+++ b/inlang/packages/paraglide/paraglide-js/examples/react/project.inlang/settings.json
@@ -7,6 +7,6 @@
 		"../../../../plugins/m-function-matcher/dist/index.js"
 	],
 	"plugin.inlang.messageFormat": {
-		"pathPattern": "./messages/{locale}.json"
+		"pathPattern": "./messages/{languageTag}.json"
 	}
 }

--- a/inlang/packages/paraglide/paraglide-js/src/cli/defaults.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/cli/defaults.ts
@@ -13,7 +13,7 @@ const defaultProjectSettings = {
 		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@1/dist/index.js",
 	],
 	"plugin.inlang.messageFormat": {
-		pathPattern: "./messages/{locale}.json",
+		pathPattern: "./messages/{languageTag}.json",
 	},
 } satisfies ProjectSettings;
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile.bench.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile.bench.ts
@@ -36,7 +36,7 @@ bench("compile 1000 messages", async () => {
 			locales: ["en"],
 			modules: ["/plugin.js"],
 			"plugin.inlang.messageFormat": {
-				pathPattern: "/{locale}.json",
+				pathPattern: "/{languageTag}.json",
 			},
 		}),
 	}).fs as unknown as typeof import("node:fs");

--- a/inlang/packages/paraglide/paraglide-next/example/project.inlang/settings.json
+++ b/inlang/packages/paraglide/paraglide-next/example/project.inlang/settings.json
@@ -10,6 +10,6 @@
     "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@1/dist/index.js"
   ],
   "plugin.inlang.messageFormat": {
-    "pathPattern": "./messages/{locale}.json"
+    "pathPattern": "./messages/{languageTag}.json"
   }
 }

--- a/inlang/packages/paraglide/paraglide-sveltekit/example/project.inlang/settings.json
+++ b/inlang/packages/paraglide/paraglide-sveltekit/example/project.inlang/settings.json
@@ -7,6 +7,6 @@
 		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js"
 	],
 	"plugin.inlang.messageFormat": {
-		"pathPattern": "./messages/{locale}.json"
+		"pathPattern": "./messages/{languageTag}.json"
 	}
 }

--- a/inlang/packages/plugins/i18next/README.md
+++ b/inlang/packages/plugins/i18next/README.md
@@ -6,7 +6,7 @@ This plugin reads and writes messages for [i18next](https://inlang.com/m/kl95463
 
 - Add this to the modules in your `project.inlang/settings.json`
 - Change the `baseLocale` if needed 
-- Include existing locaels in the `locales` array
+- Include existing locales in the `locales` array
 
 ```diff
 {
@@ -16,7 +16,7 @@ This plugin reads and writes messages for [i18next](https://inlang.com/m/kl95463
 +		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@latest/dist/index.js"
   	],
 +	"plugin.inlang.i18next": {
-+		"pathPattern": "./resources/{locale}.json"
++		"pathPattern": "./resources/{languageTag}.json"
 +  	}
 }
 ```
@@ -35,13 +35,13 @@ type PluginSettings = {
 
 ## `pathPattern`
 
-To use our plugin, you need to provide a path to the directory where your language-specific files are stored. Use the dynamic path syntax `{locale}` to specify the language name.
+To use our plugin, you need to provide a path to the directory where your language-specific files are stored. Use the dynamic path syntax `{languageTag}` to specify the language name.
 
 ### pathPattern without namespaces
 
 ```json
 "plugin.inlang.i18next": {
-	"pathPattern": "./resources/{locale}.json"
+	"pathPattern": "./resources/{languageTag}.json"
 }
 ```
 
@@ -51,8 +51,8 @@ To use our plugin, you need to provide a path to the directory where your langua
 ```json
 "plugin.inlang.i18next": {
 	"pathPattern": {
-		"common": "./resources/{locale}/common.json",
-		"vital": "./resources/{locale}/vital.json"
+		"common": "./resources/{languageTag}/common.json",
+		"vital": "./resources/{languageTag}/vital.json"
 	}
 }
 ```

--- a/inlang/packages/plugins/i18next/example/project.inlang/settings.json
+++ b/inlang/packages/plugins/i18next/example/project.inlang/settings.json
@@ -3,6 +3,6 @@
   "locales": ["en", "de"],
   "modules": ["../dist/index.js"],
   "plugin.inlang.i18next": {
-    "pathPattern": "./translations/{locale}.json"
+    "pathPattern": "./translations/{languageTag}.json"
   }
 }

--- a/inlang/packages/plugins/i18next/src/import-export/toBeImportedFiles.test.ts
+++ b/inlang/packages/plugins/i18next/src/import-export/toBeImportedFiles.test.ts
@@ -8,7 +8,7 @@ test("it should work for a single namespace", async () => {
       baseLocale: "en",
       locales: ["en", "de"],
       "plugin.inlang.i18next": {
-        pathPattern: "/translations/{locale}.json",
+        pathPattern: "/translations/{languageTag}.json",
       },
     },
   });
@@ -32,8 +32,8 @@ test("it should work for multiple namespaces", async () => {
       locales: ["en", "de"],
       "plugin.inlang.i18next": {
         pathPattern: {
-          common: "/resources/{locale}/common.json",
-          vital: "/resources/{locale}/vital.json",
+          common: "/resources/{languageTag}/common.json",
+          vital: "/resources/{languageTag}/vital.json",
         },
       } satisfies PluginSettings,
     },
@@ -82,7 +82,7 @@ test("returns [] if the pathPattern is not provided", async () => {
       "plugin.inlang.i18next": {
         // @ts-expect-error - testing defined plugin settings without pathPattern
         "some-other-prop": "value",
-        // pathPattern: "/translations/{locale}.json",
+        // pathPattern: "/translations/{languageTag}.json",
       },
     },
   });

--- a/inlang/packages/plugins/i18next/src/settings.test.ts
+++ b/inlang/packages/plugins/i18next/src/settings.test.ts
@@ -4,11 +4,11 @@ import { PluginSettings } from "./settings.js";
 
 test("valid path patterns", async () => {
   const validPathPatterns = [
-    "/folder/{locale}.json",
-    "./{locale}/file.json",
-    "../folder/{locale}/file.json",
-    "./{locale}.json",
-    "./{locale}/folder/file.json",
+    "/folder/{languageTag}.json",
+    "./{languageTag}/file.json",
+    "../folder/{languageTag}/file.json",
+    "./{languageTag}.json",
+    "./{languageTag}/folder/file.json",
   ];
 
   for (const pathPattern of validPathPatterns) {
@@ -20,14 +20,14 @@ test("valid path patterns", async () => {
 });
 
 test("it should fail if the path pattern does not start as a ralaitve path with a /,./ or ../", async () => {
-  const pathPattern = "{locale}.json";
+  const pathPattern = "{languageTag}.json";
 
   const isValid = Value.Check(PluginSettings, {
     pathPattern,
   });
   expect(isValid).toBe(false);
 });
-test("if path patter does include the word `{locale}`", async () => {
+test("if path patter does include the word `{languageTag}`", async () => {
   const pathPattern = "./examplePath.json";
 
   const isValid = Value.Check(PluginSettings, {
@@ -37,7 +37,7 @@ test("if path patter does include the word `{locale}`", async () => {
 });
 
 test("should fail if the path does not end with .json", async () => {
-  const pathPattern = "./{locale}.";
+  const pathPattern = "./{languageTag}.";
 
   const isValid = Value.Check(PluginSettings, {
     pathPattern,
@@ -55,7 +55,7 @@ test("if curly brackets {} does to cointain the word languageTag", async () => {
 });
 
 test("if pathPattern doesn't includes a '*' wildcard. This was deprecated in version 3.0.0.", async () => {
-  const pathPattern = "./{locale}/*.json";
+  const pathPattern = "./{languageTag}/*.json";
   const isValid = Value.Check(PluginSettings, {
     pathPattern,
   });
@@ -64,9 +64,9 @@ test("if pathPattern doesn't includes a '*' wildcard. This was deprecated in ver
 
 test("if pathPattern with namespaces include the correct pathpattern schema", async () => {
   const pathPattern = {
-    website: "./{locale}folder/file.json",
-    app: "../{locale}folder/file.json",
-    footer: "./{locale}folder/file.json",
+    website: "./{languageTag}folder/file.json",
+    app: "../{languageTag}folder/file.json",
+    footer: "./{languageTag}folder/file.json",
   };
   const isValid = Value.Check(PluginSettings, {
     pathPattern,
@@ -77,8 +77,8 @@ test("if pathPattern with namespaces include the correct pathpattern schema", as
 test("if pathPattern with namespaces include a incorrect pathpattern", async () => {
   const pathPattern = {
     website: "./folder/file.json",
-    app: "../{locale}folder/file.json",
-    footer: "./{locale}folder/file.json",
+    app: "../{languageTag}folder/file.json",
+    footer: "./{languageTag}folder/file.json",
   };
   const isValid = Value.Check(PluginSettings, {
     pathPattern,
@@ -88,9 +88,9 @@ test("if pathPattern with namespaces include a incorrect pathpattern", async () 
 
 test("if sourceLanguageFilePath with namespaces include the correct sourceLanguageFilePath schema", async () => {
   const sourceLanguageFilePath = {
-    website: "./{locale}folder/file.json",
-    app: "../{locale}folder/file.json",
-    footer: "./{locale}folder/file.json",
+    website: "./{languageTag}folder/file.json",
+    app: "../{languageTag}folder/file.json",
+    footer: "./{languageTag}folder/file.json",
   };
   const isValid = Value.Check(PluginSettings, {
     sourceLanguageFilePath,

--- a/inlang/packages/plugins/i18next/src/settings.ts
+++ b/inlang/packages/plugins/i18next/src/settings.ts
@@ -2,14 +2,14 @@
 import { Type, type Static } from "@sinclair/typebox";
 
 const PathPattern = Type.String({
-  pattern: "^(\\./|\\../|/)[^*]*\\{(languageTag|locale)\\}[^*]*\\.json$",
+  pattern: "^(\\./|\\../|/)[^*]*\\{languageTag\\}[^*]*\\.json$",
   title: "Path to language files",
   description:
-    "Specify the pathPattern to locate language files in your repository. It must include `{locale}` and end with `.json`.",
+    "Specify the pathPattern to locate language files in your repository. It must include `{languageTag}` and end with `.json`.",
   examples: [
-    "./{locale}/file.json",
-    "../folder/{locale}/file.json",
-    "./{locale}.json",
+    "./{languageTag}/file.json",
+    "../folder/{languageTag}/file.json",
+    "./{languageTag}.json",
   ],
 });
 const NameSpacePathPattern = Type.Record(

--- a/inlang/packages/plugins/inlang-message-format/README.md
+++ b/inlang/packages/plugins/inlang-message-format/README.md
@@ -36,7 +36,7 @@ Install the plugin in your Inlang Project by adding it to your `"modules"` in `p
 +    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"
   ],
 + "plugin.inlang.messageFormat": {
-+   "pathPattern": "./messages/{locale}.json" 
++   "pathPattern": "./messages/{languageTag}.json" 
 + }
 }
 ```
@@ -47,14 +47,14 @@ Configuration happens in `project.inlang/settings.json` under the `"plugin.inlan
 
 ### `pathPattern`
 
-The path pattern defines _where_ the plugin will be looking for your message files. The default is `./messages/{locale}.json`. The `{locale}` placeholder will be replaced with the language tag for each of your languages. 
+The path pattern defines _where_ the plugin will be looking for your message files. The default is `./messages/{languageTag}.json`. The `{languageTag}` placeholder will be replaced with the language tag for each of your languages. 
 
 ```json
 // project.inlang/settings.json
 {
   "modules": [ ... ],
   "plugin.inlang.messageFormat": {
-		"pathPattern": "./messages/{locale}.json"
+		"pathPattern": "./messages/{languageTag}.json"
 	}
 }
 ```
@@ -66,7 +66,7 @@ You can also define an array of paths. The last path in the array will take prec
 {
   "modules": [ ... ],
   "plugin.inlang.messageFormat": {
-    "pathPattern": ["./defaults/{locale}.json", "./customer1/{locale}.json"]
+    "pathPattern": ["./defaults/{languageTag}.json", "./customer1/{languageTag}.json"]
   }
 }
 ```

--- a/inlang/packages/plugins/inlang-message-format/example/project.inlang/settings.json
+++ b/inlang/packages/plugins/inlang-message-format/example/project.inlang/settings.json
@@ -3,6 +3,6 @@
 	"locales": ["en", "de"],
 	"modules": ["../dist/index.js"],
 	"plugin.inlang.messageFormat": {
-		"pathPattern": "./translations/{locale}.json"
+		"pathPattern": "./translations/{languageTag}.json"
 	}
 }

--- a/inlang/packages/plugins/inlang-message-format/src/import-export/toBeImportedFiles.test.ts
+++ b/inlang/packages/plugins/inlang-message-format/src/import-export/toBeImportedFiles.test.ts
@@ -7,7 +7,7 @@ test("toBeImportedFiles should work with locale as setting", async () => {
       baseLocale: "en",
       locales: ["en", "de"],
       "plugin.inlang.messageFormat": {
-        pathPattern: "/translations/{locale}.json",
+        pathPattern: "/translations/{languageTag}.json",
       },
     },
   });
@@ -33,7 +33,7 @@ test("toBeImportedFiles returns [] if the pathPattern is not provided", async ()
       "plugin.inlang.messageFormat": {
         // @ts-expect-error - testing defined plugin settings without pathPattern
         "some-other-prop": "value",
-        // pathPattern: "/translations/{locale}.json",
+        // pathPattern: "/translations/{languageTag}.json",
       },
     },
   });
@@ -70,7 +70,7 @@ test("toBeImportedFiles should work with both locale and languageTag and multipl
       baseLocale: "en",
       locales: ["en", "de"],
       "plugin.inlang.messageFormat": {
-        pathPattern: ["/defaults/{locale}.json", "/translations/{locale}.json"],
+        pathPattern: ["/defaults/{languageTag}.json", "/translations/{languageTag}.json"],
       },
     },
   });

--- a/inlang/packages/plugins/inlang-message-format/src/settings.test.ts
+++ b/inlang/packages/plugins/inlang-message-format/src/settings.test.ts
@@ -4,11 +4,11 @@ import { Value } from "@sinclair/typebox/value";
 
 test("the file path pattern must end with .json", () => {
   const valid = [
-    "./messages/{locale}.json",
-    "./src/i18n/{locale}.json",
-    "./translations/{locale}.json",
+    "./messages/{languageTag}.json",
+    "./src/i18n/{languageTag}.json",
+    "./translations/{languageTag}.json",
   ];
-  const invalid = ["./messages/{locale}.json.txt", "./messages/{locale}.js"];
+  const invalid = ["./messages/{languageTag}.json.txt", "./messages/{languageTag}.js"];
   for (const path of valid) {
     expect(
       Value.Check(PluginSettings, {
@@ -50,32 +50,32 @@ test("the file path pattern can contain the {languageTag} placeholder for legacy
 
 test("it should be possible to use an absolute path", () => {
   const settings = {
-    pathPattern: "/home/{locale}.json",
+    pathPattern: "/home/{languageTag}.json",
   } satisfies PluginSettings;
   expect(Value.Check(PluginSettings, settings)).toBe(true);
 });
 
 test("it should be possible to use a relative path", () => {
   const settings = {
-    pathPattern: "./home/{locale}.json",
+    pathPattern: "./home/{languageTag}.json",
   } satisfies PluginSettings;
   expect(Value.Check(PluginSettings, settings)).toBe(true);
 });
 
 test("it should be possible to use parent directories in the storage path", () => {
   const settings = {
-    pathPattern: "../home/{locale}.json",
+    pathPattern: "../home/{languageTag}.json",
   } satisfies PluginSettings;
   expect(Value.Check(PluginSettings, settings)).toBe(true);
 });
 
 test("it should be possible to use multiple storage paths given as array", () => {
   const valid = [
-    "./messages/{locale}.json",
-    "./src/i18n/{locale}.json",
-    "./translations/{locale}.json",
+    "./messages/{languageTag}.json",
+    "./src/i18n/{languageTag}.json",
+    "./translations/{languageTag}.json",
   ];
-  const invalid = ["./messages/{locale}.json.txt", "./messages/{locale}.js"];
+  const invalid = ["./messages/{languageTag}.json.txt", "./messages/{languageTag}.js"];
   expect(
     Value.Check(PluginSettings, {
       pathPattern: valid,

--- a/inlang/packages/plugins/inlang-message-format/src/settings.ts
+++ b/inlang/packages/plugins/inlang-message-format/src/settings.ts
@@ -1,18 +1,18 @@
 import { Type, type Static } from "@sinclair/typebox";
 
 const pathPatternString = Type.String({
-  // for legacy reasions locale can be specified as well
-  pattern: ".*\\{languageTag|locale\\}.*\\.json$",
-  examples: ["./messages/{locale}.json", "./i18n/{locale}.json"],
+  // for legacy reasons locale can be specified as well
+  pattern: ".*\\{(languageTag|locale)\\}.*\\.json$",
+  examples: ["./messages/{languageTag}.json", "./i18n/{languageTag}.json"],
   title: "Path to language files",
   description:
-    "Specify the pathPattern to locate resource files in your repository. It must include `{locale}` and end with `.json`.",
+    "Specify the pathPattern to locate resource files in your repository. It must include `{languageTag}` and end with `.json`.",
 });
 
 const pathPatternArray = Type.Array(pathPatternString, {
   title: "Paths to language files",
   description:
-    "Specify multiple pathPatterns to locate resource files in your repository. Each must include `{locale}` and end with `.json`.",
+    "Specify multiple pathPatterns to locate resource files in your repository. Each must include `{languageTag}` and end with `.json`.",
 });
 
 export type PluginSettings = Static<typeof PluginSettings>;

--- a/inlang/packages/sdk/src/project/loadProjectFromDirectory.test.ts
+++ b/inlang/packages/sdk/src/project/loadProjectFromDirectory.test.ts
@@ -763,7 +763,7 @@ test("plugin calls that use fs should be intercepted to use an absolute path", a
 			baseLocale: "en",
 			locales: ["en", "de"],
 			"plugin.mock-plugin": {
-				pathPattern: "./messages/{locale}.json",
+				pathPattern: "./messages/{languageTag}.json",
 			},
 		} satisfies ProjectSettings),
 	};
@@ -772,7 +772,7 @@ test("plugin calls that use fs should be intercepted to use an absolute path", a
 		key: "mock-plugin",
 		loadMessages: async ({ nodeishFs, settings }) => {
 			const pathPattern = settings["plugin.mock-plugin"]?.pathPattern.replace(
-				"{locale}",
+				"{languageTag}",
 				"en"
 			) as string;
 			const file = await nodeishFs.readFile(pathPattern);
@@ -787,7 +787,7 @@ test("plugin calls that use fs should be intercepted to use an absolute path", a
 		},
 		saveMessages: async ({ nodeishFs, settings }) => {
 			const pathPattern = settings["plugin.mock-plugin"]?.pathPattern.replace(
-				"{locale}",
+				"{languageTag}",
 				"en"
 			) as string;
 			const file = new TextEncoder().encode(
@@ -801,7 +801,7 @@ test("plugin calls that use fs should be intercepted to use an absolute path", a
 		},
 		toBeImportedFiles: async ({ settings }) => {
 			const pathPattern = settings["plugin.mock-plugin"]?.pathPattern.replace(
-				"{locale}",
+				"{languageTag}",
 				"en"
 			) as string;
 			return [


### PR DESCRIPTION
In many places, instead of `{languageTag}`, we still use `{locale}`, which is not working.

This PR update READMEs, usage examples, schema descriptions, and tests to use `{languageTag}`