### PR TITLE
fix: plugin imports on Bun

### DIFF
--- a/.changeset/sixty-cows-add.md
+++ b/.changeset/sixty-cows-add.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+fix: plugin imports on Bun

--- a/inlang/packages/sdk/src/plugin/importPlugins.ts
+++ b/inlang/packages/sdk/src/plugin/importPlugins.ts
@@ -32,14 +32,14 @@ export async function importPlugins(args: {
 			let moduleAsURL;
 			if (process.versions.bun) {
 				// In bun we need to do dynamic imports differently
-				moduleAsURL = URL.createObjectURL(new Blob([moduleAsText], { type: 'text/javascript' }));
+				moduleAsURL = URL.createObjectURL(
+					new Blob([moduleAsText], { type: "text/javascript" })
+				);
 			} else {
 				// node and others
-				moduleAsURL = 'data:text/javascript;base64,' + btoa(moduleAsText);
+				moduleAsURL = "data:text/javascript;base64," + btoa(moduleAsText);
 			}
-			const { default: module } = await import(
-				/* @vite-ignore */ moduleAsURL
-			);
+			const { default: module } = await import(/* @vite-ignore */ moduleAsURL);
 			// old legacy message lint rules are not supported
 			// and ingored for backwards compatibility
 			if (module.id?.includes("messageLintRule")) {

--- a/inlang/packages/sdk/src/plugin/importPlugins.ts
+++ b/inlang/packages/sdk/src/plugin/importPlugins.ts
@@ -29,10 +29,16 @@ export async function importPlugins(args: {
 			if (args.preprocessPluginBeforeImport) {
 				moduleAsText = await args.preprocessPluginBeforeImport(moduleAsText);
 			}
-			const moduleWithMimeType =
-				"data:application/javascript," + encodeURIComponent(moduleAsText);
+			let moduleAsURL;
+			if (process.versions.bun) {
+				// In bun we need to do dynamic imports differently
+				moduleAsURL = URL.createObjectURL(new Blob([moduleAsText], { type: 'text/javascript' }));
+			} else {
+				// node and others
+				moduleAsURL = 'data:text/javascript;base64,' + btoa(moduleAsText);
+			}
 			const { default: module } = await import(
-				/* @vite-ignore */ moduleWithMimeType
+				/* @vite-ignore */ moduleAsURL
 			);
 			// old legacy message lint rules are not supported
 			// and ingored for backwards compatibility


### PR DESCRIPTION
Bun cannot dynamically import same format as node. 
Adds bun specific dynamic import and fixes sdk usage on Bun.

https://github.com/opral/inlang-paraglide-js/issues/335