### PR TITLE
stable lix ids when opening a project with `loadProjectFromDirectory()`

### DIFF
--- a/.changeset/cyan-boxes-battle.md
+++ b/.changeset/cyan-boxes-battle.md
@@ -1,0 +1,5 @@
+---
+"@lix-js/sdk": patch
+---
+
+expose `KeyValue` types

--- a/.changeset/eighty-islands-do.md
+++ b/.changeset/eighty-islands-do.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": minor
+---
+
+stable lix ids when opening a project with `loadProjectFromDirectory()` https://github.com/opral/inlang-sdk/issues/228

--- a/inlang/packages/sdk/src/project/loadProjectFromDirectory.ts
+++ b/inlang/packages/sdk/src/project/loadProjectFromDirectory.ts
@@ -31,6 +31,22 @@ export async function loadProjectFromDirectory(
 		await args.fs.promises.readFile(settingsPath, "utf8")
 	) as ProjectSettings;
 
+	let inlangId: string | undefined = undefined;
+
+	try {
+		inlangId = await args.fs.promises.readFile(
+			nodePath.join(args.path, "project_id"),
+			"utf8"
+		);
+	} catch {
+		// await args.fs.promises.writeFile(
+		// 	nodePath.join(args.path, "project_id"),
+		// 	,
+		// 	{ encoding: "utf8" }
+		// );
+		// file doesn't exist yet
+	}
+
 	const localImport = await importLocalPlugins({
 		fs: args.fs,
 		settings,
@@ -49,6 +65,10 @@ export async function loadProjectFromDirectory(
 	const project = await loadProjectInMemory({
 		...args,
 		providePlugins: providePluginsWithLocalPlugins,
+		lixKeyValues: inlangId
+			? // reversing the id to have distinguishable lix ids from inlang ids
+				[{ key: "lix_id", value: inlangId }]
+			: undefined,
 		blob: await newProject({
 			settings,
 		}),

--- a/inlang/packages/sdk/src/project/loadProjectInMemory.ts
+++ b/inlang/packages/sdk/src/project/loadProjectInMemory.ts
@@ -1,4 +1,4 @@
-import { openLixInMemory } from "@lix-js/sdk";
+import { openLixInMemory, type NewKeyValue } from "@lix-js/sdk";
 import { createInMemoryDatabase, importDatabase } from "sqlite-wasm-kysely";
 import { loadProject } from "./loadProject.js";
 
@@ -8,11 +8,13 @@ import { loadProject } from "./loadProject.js";
 export async function loadProjectInMemory(
 	args: {
 		blob: Blob;
+		lixKeyValues?: NewKeyValue[];
 	} & Omit<Parameters<typeof loadProject>[0], "sqlite" | "lix">
 ) {
 	const lix = await openLixInMemory({
 		blob: args.blob,
 		account: args.account,
+		keyValues: args.lixKeyValues,
 		providePlugins: [
 			// inlangLixPluginV1
 		],

--- a/inlang/packages/sdk/src/project/newProject.test.ts
+++ b/inlang/packages/sdk/src/project/newProject.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "vitest";
 import { defaultProjectSettings, newProject } from "./newProject.js";
 import { loadProjectInMemory } from "./loadProjectInMemory.js";
-import { validate } from "uuid";
 
 test("it should be possible to provide settings for testing or other purposes", async () => {
 	const project = await loadProjectInMemory({
@@ -26,11 +25,20 @@ test("it should be possible to create a project with default settings", async ()
 	expect(settings).toStrictEqual(defaultProjectSettings);
 });
 
-test("it should have a uuid as project id", async () => {
+// for historical reasons, inlang files introduced a project id
+// before lix'es got their own id. having two ids for the same
+// file is not needed anymore.
+test("it should have the lix id as project id", async () => {
 	const project = await loadProjectInMemory({
 		blob: await newProject(),
 	});
+	const { value: lixId } = await project.lix.db
+		.selectFrom("key_value")
+		.select("value")
+		.where("key", "=", "lix_id")
+		.executeTakeFirstOrThrow();
+
 	const projectId = await project.id.get();
 	expect(projectId).toBeDefined();
-	expect(validate(projectId)).toBe(true);
+	expect(projectId).toBe(lixId);
 });

--- a/inlang/packages/sdk/src/project/newProject.ts
+++ b/inlang/packages/sdk/src/project/newProject.ts
@@ -1,5 +1,4 @@
 import { newLixFile, openLixInMemory, toBlob } from "@lix-js/sdk";
-import { v4 } from "uuid";
 import type { ProjectSettings } from "../json-schema/settings.js";
 import {
 	contentFromDatabase,
@@ -26,6 +25,12 @@ export async function newProject(args?: {
 
 		const lix = await openLixInMemory({ blob: await newLixFile() });
 
+		const { value: lixId } = await lix.db
+			.selectFrom("key_value")
+			.select("value")
+			.where("key", "=", "lix_id")
+			.executeTakeFirstOrThrow();
+
 		// write files to lix
 		await lix.db
 			.insertInto("file")
@@ -46,7 +51,7 @@ export async function newProject(args?: {
 				},
 				{
 					path: "/project_id",
-					data: new TextEncoder().encode(v4()),
+					data: new TextEncoder().encode(lixId),
 				},
 			])
 			.execute();

--- a/inlang/packages/sdk/src/project/saveProjectToDirectory.test.ts
+++ b/inlang/packages/sdk/src/project/saveProjectToDirectory.test.ts
@@ -329,43 +329,43 @@ test("adds a gitignore file if it doesn't exist", async () => {
 	expect(gitignore).toBe("cache");
 });
 
- test("uses exportFiles when both exportFiles and saveMessages are defined", async () => {
-		const exportFilesSpy = vi.fn().mockResolvedValue([]);
-		const saveMessagesSpy = vi.fn();
-		const mockPlugin: InlangPlugin = {
-			key: "mock",
-			exportFiles: exportFilesSpy,
-			saveMessages: saveMessagesSpy,
-		};
-		const volume = Volume.fromJSON({});
-		const project = await loadProjectInMemory({
-			blob: await newProject(),
-			providePlugins: [mockPlugin],
-		});
-		await saveProjectToDirectory({
-			path: "/foo/project.inlang",
-			fs: volume.promises as any,
-			project,
-		});
-		expect(exportFilesSpy).toHaveBeenCalled();
-		expect(saveMessagesSpy).not.toHaveBeenCalled();
- });
+test("uses exportFiles when both exportFiles and saveMessages are defined", async () => {
+	const exportFilesSpy = vi.fn().mockResolvedValue([]);
+	const saveMessagesSpy = vi.fn();
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		exportFiles: exportFilesSpy,
+		saveMessages: saveMessagesSpy,
+	};
+	const volume = Volume.fromJSON({});
+	const project = await loadProjectInMemory({
+		blob: await newProject(),
+		providePlugins: [mockPlugin],
+	});
+	await saveProjectToDirectory({
+		path: "/foo/project.inlang",
+		fs: volume.promises as any,
+		project,
+	});
+	expect(exportFilesSpy).toHaveBeenCalled();
+	expect(saveMessagesSpy).not.toHaveBeenCalled();
+});
 
- test("uses saveMessages when exportFiles is not defined", async () => {
-		const saveMessagesSpy = vi.fn().mockResolvedValue([]);
-		const mockPlugin: InlangPlugin = {
-			key: "mock",
-			saveMessages: saveMessagesSpy,
-		};
-		const volume = Volume.fromJSON({});
-		const project = await loadProjectInMemory({
-			blob: await newProject(),
-			providePlugins: [mockPlugin],
-		});
-		await saveProjectToDirectory({
-			path: "/foo/project.inlang",
-			fs: volume.promises as any,
-			project,
-		});
-		expect(saveMessagesSpy).toHaveBeenCalled();
- });
+test("uses saveMessages when exportFiles is not defined", async () => {
+	const saveMessagesSpy = vi.fn().mockResolvedValue([]);
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		saveMessages: saveMessagesSpy,
+	};
+	const volume = Volume.fromJSON({});
+	const project = await loadProjectInMemory({
+		blob: await newProject(),
+		providePlugins: [mockPlugin],
+	});
+	await saveProjectToDirectory({
+		path: "/foo/project.inlang",
+		fs: volume.promises as any,
+		project,
+	});
+	expect(saveMessagesSpy).toHaveBeenCalled();
+});

--- a/packages/lix-sdk/src/database/index.ts
+++ b/packages/lix-sdk/src/database/index.ts
@@ -1,4 +1,5 @@
 export * from "./schema.js";
+export * from "../key-value/database-schema.js";
 export { jsonObjectFrom, jsonArrayFrom } from "kysely/helpers/sqlite";
 export { sql } from "kysely";
 export { executeSync } from "./execute-sync.js";


### PR DESCRIPTION
closes https://github.com/opral/inlang-sdk/issues/228