### PR TITLE
fix: Cannot mkdir project.inlang/cache/puligns in window OSS using git bash terminal

### DIFF
--- a/.changeset/tricky-taxis-appear.md
+++ b/.changeset/tricky-taxis-appear.md
@@ -1,0 +1,7 @@
+---
+"@inlang/sdk": patch
+---
+
+fix: Cannot mkdir project.inlang/cache/puligns in window OSS using git bash terminal
+
+https://github.com/opral/inlang-paraglide-js/issues/377

--- a/inlang/packages/sdk/src/project/loadProjectFromDirectory.ts
+++ b/inlang/packages/sdk/src/project/loadProjectFromDirectory.ts
@@ -466,9 +466,20 @@ async function syncLixFsFiles(args: {
 				if (lixState.state == "unknown") {
 					// ADD TO FS (6)
 					// create directory if not exists
-					args.fs.mkdirSync(nodePath.dirname(nodePath.join(args.path, path)), {
-						recursive: true,
-					});
+					try {
+						args.fs.mkdirSync(
+							nodePath.dirname(nodePath.join(args.path, path)),
+							{
+								recursive: true,
+							}
+						);
+					} catch (e) {
+						// ignore if directory already exists
+						// https://github.com/opral/inlang-paraglide-js/issues/377
+						if ((e as any)?.code !== "EEXIST") {
+							throw e;
+						}
+					}
 					// write file
 					args.fs.writeFileSync(
 						nodePath.join(args.path, path),


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/377

- adds a try catch if the directory already exists
- race condition seems to be the root cause. i hope that this quickfix is good enough

disclaimer: i can't test the code because i have no windows machine. 