### PR TITLE
Parjs-404-align-localizeurl-and-localizehref

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
@@ -143,7 +143,7 @@ deLocalizeHref("/de/about")
 
 > **deLocalizeUrl**(`url`): `URL`
 
-Defined in: [runtime/localize-url.js:42](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js)
+Defined in: [runtime/localize-url.js:48](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js)
 
 ### Parameters
 
@@ -349,9 +349,9 @@ localizeHref("/about")
 
 ## localizeUrl()
 
-> **localizeUrl**(`url`, `options`): `URL`
+> **localizeUrl**(`url`, `options`?): `URL`
 
-Defined in: [runtime/localize-url.js:10](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js)
+Defined in: [runtime/localize-url.js:13](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js)
 
 Localizes a URL to a specific locale using the new namedGroups API.
 
@@ -363,11 +363,11 @@ The URL to localize.
 
 `string` | `URL`
 
-#### options
+#### options?
 
-Options containing the target locale.
+Options
 
-##### locale
+##### locale?
 
 `string`
 

--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
@@ -106,13 +106,16 @@ If the input is not a locale.
 
 > **deLocalizeHref**(`href`): `string`
 
-Defined in: [runtime/localize-href.js:64](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js)
+Defined in: [runtime/localize-href.js:104](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js)
 
-De-localizes an href.
+High-level URL de-localization function optimized for client-side UI usage.
 
-In contrast to `deLocalizeUrl()`, this function automatically
-calls `getLocale()` to determine the base locale and
-returns a relative path if appropriate.
+This is a convenience wrapper around `deLocalizeUrl()` that provides features
+needed in the UI:
+
+- Accepts relative paths (e.g., "/de/about")
+- Returns relative paths when possible
+- Handles string input/output instead of URL objects
 
 ### Parameters
 
@@ -120,22 +123,43 @@ returns a relative path if appropriate.
 
 `string`
 
+The href to de-localize (can be relative or absolute)
+
 ### Returns
 
 `string`
 
-- The de-localized href.
+The de-localized href, relative if input was relative
 
 ### Example
 
-```ts
-deLocalizeHref("/de/about")
-  // => "/about"
+```typescript
+// In a React/Vue/Svelte component
+const LocaleSwitcher = ({ href }) => {
+  // Remove locale prefix before switching
+  const baseHref = deLocalizeHref(href);
+  return locales.map(locale =>
+    <a href={localizeHref(baseHref, { locale })}>
+      Switch to {locale}
+    </a>
+  );
+};
 
-  // requires full URL and locale
-  deLocalizeUrl("http://example.com/de/about")
-  // => "http://example.com/about"
+// Examples:
+deLocalizeHref("/de/about")  // => "/about"
+deLocalizeHref("/fr/store")  // => "/store"
+
+// Cross-origin links remain absolute
+deLocalizeHref("https://example.com/de/about")
+// => "https://example.com/about"
 ```
+
+For server-side URL de-localization (e.g., in middleware), use `deLocalizeUrl()`
+which provides more precise control over URL handling.
+
+### See
+
+deLocalizeUrl - For low-level URL de-localization in server contexts
 
 ***
 
@@ -143,17 +167,54 @@ deLocalizeHref("/de/about")
 
 > **deLocalizeUrl**(`url`): `URL`
 
-Defined in: [runtime/localize-url.js:48](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js)
+Defined in: [runtime/localize-url.js:116](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js)
+
+Low-level URL de-localization function, primarily used in server contexts.
+
+This function is designed for server-side usage where you need precise control
+over URL de-localization, such as in middleware or request handlers. It works with
+URL objects and always returns absolute URLs.
+
+For client-side UI components, use `deLocalizeHref()` instead, which provides
+a more convenient API with relative paths.
 
 ### Parameters
 
 #### url
+
+The URL to de-localize. If string, must be absolute.
 
 `string` | `URL`
 
 ### Returns
 
 `URL`
+
+The de-localized URL, always absolute
+
+### Examples
+
+```typescript
+// Server middleware example
+app.use((req, res, next) => {
+  const url = new URL(req.url, `${req.protocol}://${req.headers.host}`);
+  const baseUrl = deLocalizeUrl(url);
+
+  // Store the base URL for later use
+  req.baseUrl = baseUrl;
+  next();
+});
+```
+
+```typescript
+// Using with URL patterns
+const url = new URL("https://example.com/de/about");
+deLocalizeUrl(url); // => URL("https://example.com/about")
+
+// Using with domain-based localization
+const url = new URL("https://de.example.com/store");
+deLocalizeUrl(url); // => URL("https://example.com/store")
+```
 
 ***
 
@@ -306,13 +367,17 @@ if (isLocale(params.locale)) {
 
 > **localizeHref**(`href`, `options`?): `string`
 
-Defined in: [runtime/localize-href.js:24](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js)
+Defined in: [runtime/localize-href.js:43](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js)
 
-Localizes an href.
+High-level URL localization function optimized for client-side UI usage.
 
-In contrast to `localizeUrl()`, this function automatically
-calls `getLocale()` to determine the target locale and
-returns a relative path if appropriate.
+This is a convenience wrapper around `localizeUrl()` that provides features
+needed in UI:
+
+- Accepts relative paths (e.g., "/about")
+- Returns relative paths when possible
+- Automatically detects current locale if not specified
+- Handles string input/output instead of URL objects
 
 ### Parameters
 
@@ -320,30 +385,46 @@ returns a relative path if appropriate.
 
 `string`
 
+The href to localize (can be relative or absolute)
+
 #### options?
 
-Options
+Options for localization
 
 ##### locale?
 
 `string`
 
-The target locale.
+Target locale. If not provided, uses `getLocale()`
 
 ### Returns
 
 `string`
 
+The localized href, relative if input was relative
+
 ### Example
 
-```ts
-localizeHref("/about")
-  // => "/de/about"
+```typescript
+// In a React/Vue/Svelte component
+const NavLink = ({ href }) => {
+  // Automatically uses current locale, keeps path relative
+  return <a href={localizeHref(href)}>...</a>;
+};
 
-  // requires full URL and locale
-  localizeUrl("http://example.com/about", { locale: "de" })
-  // => "http://example.com/de/about"
+// Examples:
+localizeHref("/about")
+// => "/de/about" (if current locale is "de")
+localizeHref("/store", { locale: "fr" })
+// => "/fr/store" (explicit locale)
+
+// Cross-origin links remain absolute
+localizeHref("https://other-site.com/about")
+// => "https://other-site.com/de/about"
 ```
+
+For server-side URL localization (e.g., in middleware), use `localizeUrl()`
+which provides more precise control over URL handling.
 
 ***
 
@@ -351,33 +432,67 @@ localizeHref("/about")
 
 > **localizeUrl**(`url`, `options`?): `URL`
 
-Defined in: [runtime/localize-url.js:13](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js)
+Defined in: [runtime/localize-url.js:47](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js)
 
-Localizes a URL to a specific locale using the new namedGroups API.
+Lower-level URL localization function, primarily used in server contexts.
+
+This function is designed for server-side usage where you need precise control
+over URL localization, such as in middleware or request handlers. It works with
+URL objects and always returns absolute URLs.
+
+For client-side UI components, use `localizeHref()` instead, which provides
+a more convenient API with relative paths and automatic locale detection.
 
 ### Parameters
 
 #### url
 
-The URL to localize.
+The URL to localize. If string, must be absolute.
 
 `string` | `URL`
 
 #### options?
 
-Options
+Options for localization
 
 ##### locale?
 
 `string`
 
-The target locale.
+Target locale. If not provided, uses getLocale()
 
 ### Returns
 
 `URL`
 
-- The localized URL.
+The localized URL, always absolute
+
+### Examples
+
+```typescript
+// Server middleware example
+app.use((req, res, next) => {
+  const url = new URL(req.url, `${req.protocol}://${req.headers.host}`);
+  const localized = localizeUrl(url, { locale: "de" });
+
+  if (localized.href !== url.href) {
+    return res.redirect(localized.href);
+  }
+  next();
+});
+```
+
+```typescript
+// Using with URL patterns
+const url = new URL("https://example.com/about");
+localizeUrl(url, { locale: "de" });
+// => URL("https://example.com/de/about")
+
+// Using with domain-based localization
+const url = new URL("https://example.com/store");
+localizeUrl(url, { locale: "de" });
+// => URL("https://de.example.com/store")
+```
 
 ***
 
@@ -473,7 +588,7 @@ overwriteSetLocale((newLocale) => {
 
 > **serverMiddleware**\<`T`\>(`request`, `resolve`): `Promise`\<`any`\>
 
-Defined in: [runtime/server-middleware.js:64](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/server-middleware.js)
+Defined in: [runtime/server-middleware.js:62](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/server-middleware.js)
 
 Server middleware that handles locale-based routing and request processing.
 
@@ -513,7 +628,7 @@ Function to handle the request
 `Promise`\<`any`\>
 
 Returns either:
-- A Response object (302 redirect) if URL localization is needed
+- A `Response` object (302 redirect) if URL localization is needed
 - The result of the resolve function if no redirect is required
 
 ### Examples
@@ -537,10 +652,6 @@ app.use(async (req, res, next) => {
   });
 });
 ```
-
-### See
-
-[Middleware Documentation](https://inlang.com/documentation/paraglide-js/server-middleware|Server)
 
 ***
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js
@@ -3,23 +3,42 @@ import { getUrlOrigin } from "./get-url-origin.js";
 import { deLocalizeUrl, localizeUrl } from "./localize-url.js";
 
 /**
- * Localizes an href.
+ * High-level URL localization function optimized for client-side UI usage.
  *
- * In contrast to `localizeUrl()`, this function automatically
- * calls `getLocale()` to determine the target locale and
- * returns a relative path if appropriate.
+ * This is a convenience wrapper around `localizeUrl()` that provides features
+ * needed in UI:
+ *
+ * - Accepts relative paths (e.g., "/about")
+ * - Returns relative paths when possible
+ * - Automatically detects current locale if not specified
+ * - Handles string input/output instead of URL objects
  *
  * @example
- *   localizeHref("/about")
- *   // => "/de/about"
+ * ```typescript
+ * // In a React/Vue/Svelte component
+ * const NavLink = ({ href }) => {
+ *   // Automatically uses current locale, keeps path relative
+ *   return <a href={localizeHref(href)}>...</a>;
+ * };
  *
- *   // requires full URL and locale
- *   localizeUrl("http://example.com/about", { locale: "de" })
- *   // => "http://example.com/de/about"
+ * // Examples:
+ * localizeHref("/about")
+ * // => "/de/about" (if current locale is "de")
+ * localizeHref("/store", { locale: "fr" })
+ * // => "/fr/store" (explicit locale)
  *
- * @param {string} href
- * @param {Object} [options] - Options
- * @param {string} [options.locale] - The target locale.
+ * // Cross-origin links remain absolute
+ * localizeHref("https://other-site.com/about")
+ * // => "https://other-site.com/de/about"
+ * ```
+ *
+ * For server-side URL localization (e.g., in middleware), use `localizeUrl()`
+ * which provides more precise control over URL handling.
+ *
+ * @param {string} href - The href to localize (can be relative or absolute)
+ * @param {Object} [options] - Options for localization
+ * @param {string} [options.locale] - Target locale. If not provided, uses `getLocale()`
+ * @returns {string} The localized href, relative if input was relative
  */
 export function localizeHref(href, options) {
 	const locale = options?.locale ?? getLocale();
@@ -44,22 +63,43 @@ export function localizeHref(href, options) {
 }
 
 /**
- * De-localizes an href.
+ * High-level URL de-localization function optimized for client-side UI usage.
  *
- * In contrast to `deLocalizeUrl()`, this function automatically
- * calls `getLocale()` to determine the base locale and
- * returns a relative path if appropriate.
+ * This is a convenience wrapper around `deLocalizeUrl()` that provides features
+ * needed in the UI:
+ *
+ * - Accepts relative paths (e.g., "/de/about")
+ * - Returns relative paths when possible
+ * - Handles string input/output instead of URL objects
  *
  * @example
- *   deLocalizeHref("/de/about")
- *   // => "/about"
+ * ```typescript
+ * // In a React/Vue/Svelte component
+ * const LocaleSwitcher = ({ href }) => {
+ *   // Remove locale prefix before switching
+ *   const baseHref = deLocalizeHref(href);
+ *   return locales.map(locale =>
+ *     <a href={localizeHref(baseHref, { locale })}>
+ *       Switch to {locale}
+ *     </a>
+ *   );
+ * };
  *
- *   // requires full URL and locale
- *   deLocalizeUrl("http://example.com/de/about")
- *   // => "http://example.com/about"
+ * // Examples:
+ * deLocalizeHref("/de/about")  // => "/about"
+ * deLocalizeHref("/fr/store")  // => "/store"
  *
- * @param {string} href
- * @returns {string} - The de-localized href.
+ * // Cross-origin links remain absolute
+ * deLocalizeHref("https://example.com/de/about")
+ * // => "https://example.com/about"
+ * ```
+ *
+ * For server-side URL de-localization (e.g., in middleware), use `deLocalizeUrl()`
+ * which provides more precise control over URL handling.
+ *
+ * @param {string} href - The href to de-localize (can be relative or absolute)
+ * @returns {string} The de-localized href, relative if input was relative
+ * @see deLocalizeUrl - For low-level URL de-localization in server contexts
  */
 export function deLocalizeHref(href) {
 	const url = new URL(href, getUrlOrigin());

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js
@@ -74,19 +74,3 @@ export function deLocalizeHref(href) {
 
 	return deLocalized.href;
 }
-
-/**
- * @deprecated use `localizeHref` instead and give feedback on here https://github.com/opral/inlang-paraglide-js/issues/380
- * @type {(href: string, options?: { locale?: string }) => string}
- */
-export function localizePath(href, options) {
-	return localizeHref(href, options);
-}
-
-/**
- * @deprecated use `deLocalizeHref` instead and give feedback on here https://github.com/opral/inlang-paraglide-js/issues/380
- * @type {(href: string) => string}
- */
-export function deLocalizePath(href) {
-	return deLocalizeHref(href);
-}

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js
@@ -25,7 +25,7 @@ export function localizeHref(href, options) {
 	const locale = options?.locale ?? getLocale();
 	const url = new URL(href, getUrlOrigin());
 
-	const localized = localizeUrl(url, { locale });
+	const localized = localizeUrl(url, options);
 
 	// if the origin is identical and the href is relative,
 	// return the relative path

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js
@@ -3,12 +3,46 @@ import { getUrlOrigin } from "./get-url-origin.js";
 import { urlPatterns } from "./variables.js";
 
 /**
- * Localizes a URL to a specific locale using the new namedGroups API.
+ * Lower-level URL localization function, primarily used in server contexts.
  *
- * @param {string | URL} url - The URL to localize.
- * @param {Object} [options] - Options
- * @param {string} [options.locale] - The target locale.
- * @returns {URL} - The localized URL.
+ * This function is designed for server-side usage where you need precise control
+ * over URL localization, such as in middleware or request handlers. It works with
+ * URL objects and always returns absolute URLs.
+ *
+ * For client-side UI components, use `localizeHref()` instead, which provides
+ * a more convenient API with relative paths and automatic locale detection.
+ *
+ * @example
+ * ```typescript
+ * // Server middleware example
+ * app.use((req, res, next) => {
+ *   const url = new URL(req.url, `${req.protocol}://${req.headers.host}`);
+ *   const localized = localizeUrl(url, { locale: "de" });
+ *
+ *   if (localized.href !== url.href) {
+ *     return res.redirect(localized.href);
+ *   }
+ *   next();
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Using with URL patterns
+ * const url = new URL("https://example.com/about");
+ * localizeUrl(url, { locale: "de" });
+ * // => URL("https://example.com/de/about")
+ *
+ * // Using with domain-based localization
+ * const url = new URL("https://example.com/store");
+ * localizeUrl(url, { locale: "de" });
+ * // => URL("https://de.example.com/store")
+ * ```
+ *
+ * @param {string | URL} url - The URL to localize. If string, must be absolute.
+ * @param {Object} [options] - Options for localization
+ * @param {string} [options.locale] - Target locale. If not provided, uses getLocale()
+ * @returns {URL} The localized URL, always absolute
  */
 export function localizeUrl(url, options) {
 	const locale = options?.locale ?? getLocale();
@@ -43,9 +77,41 @@ export function localizeUrl(url, options) {
 }
 
 /**
- * De-localizes a URL.
+ * Low-level URL de-localization function, primarily used in server contexts.
  *
- * @type {(url: string | URL) => URL}
+ * This function is designed for server-side usage where you need precise control
+ * over URL de-localization, such as in middleware or request handlers. It works with
+ * URL objects and always returns absolute URLs.
+ *
+ * For client-side UI components, use `deLocalizeHref()` instead, which provides
+ * a more convenient API with relative paths.
+ *
+ * @example
+ * ```typescript
+ * // Server middleware example
+ * app.use((req, res, next) => {
+ *   const url = new URL(req.url, `${req.protocol}://${req.headers.host}`);
+ *   const baseUrl = deLocalizeUrl(url);
+ *
+ *   // Store the base URL for later use
+ *   req.baseUrl = baseUrl;
+ *   next();
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Using with URL patterns
+ * const url = new URL("https://example.com/de/about");
+ * deLocalizeUrl(url); // => URL("https://example.com/about")
+ *
+ * // Using with domain-based localization
+ * const url = new URL("https://de.example.com/store");
+ * deLocalizeUrl(url); // => URL("https://example.com/store")
+ * ```
+ *
+ * @param {string | URL} url - The URL to de-localize. If string, must be absolute.
+ * @returns {URL} The de-localized URL, always absolute
  */
 export function deLocalizeUrl(url) {
 	const urlObj = new URL(url, getUrlOrigin());

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js
@@ -1,14 +1,19 @@
+import { getLocale } from "./get-locale.js";
+import { getUrlOrigin } from "./get-url-origin.js";
 import { urlPatterns } from "./variables.js";
 
 /**
  * Localizes a URL to a specific locale using the new namedGroups API.
+ *
  * @param {string | URL} url - The URL to localize.
- * @param {Object} options - Options containing the target locale.
- * @param {string} options.locale - The target locale.
+ * @param {Object} [options] - Options
+ * @param {string} [options.locale] - The target locale.
  * @returns {URL} - The localized URL.
  */
 export function localizeUrl(url, options) {
-	const urlObj = new URL(url);
+	const locale = options?.locale ?? getLocale();
+	const urlObj = typeof url === "string" ? new URL(url) : url;
+
 	const search = urlObj.search;
 
 	for (const element of urlPatterns) {
@@ -20,7 +25,7 @@ export function localizeUrl(url, options) {
 			const overrides = {};
 
 			for (const [groupName, value] of Object.entries(
-				element.localizedNamedGroups?.[options.locale] ?? {}
+				element.localizedNamedGroups?.[locale] ?? {}
 			)) {
 				overrides[groupName] = value;
 			}
@@ -43,7 +48,7 @@ export function localizeUrl(url, options) {
  * @type {(url: string | URL) => URL}
  */
 export function deLocalizeUrl(url) {
-	const urlObj = new URL(url);
+	const urlObj = new URL(url, getUrlOrigin());
 	const search = urlObj.search;
 
 	for (const element of urlPatterns) {

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.js
@@ -9,6 +9,7 @@ import { urlPatterns } from "./variables.js";
  */
 export function localizeUrl(url, options) {
 	const urlObj = new URL(url);
+	const search = urlObj.search;
 
 	for (const element of urlPatterns) {
 		const pattern = new URLPattern(element.pattern);
@@ -29,7 +30,7 @@ export function localizeUrl(url, options) {
 				...overrides,
 			};
 
-			return fillPattern(element.pattern, groups);
+			return fillPattern(element.pattern, groups, search);
 		}
 	}
 
@@ -43,6 +44,7 @@ export function localizeUrl(url, options) {
  */
 export function deLocalizeUrl(url) {
 	const urlObj = new URL(url);
+	const search = urlObj.search;
 
 	for (const element of urlPatterns) {
 		const pattern = new URLPattern(element.pattern);
@@ -63,7 +65,7 @@ export function deLocalizeUrl(url) {
 				...overrides,
 			};
 
-			return fillPattern(element.pattern, groups);
+			return fillPattern(element.pattern, groups, search);
 		}
 	}
 
@@ -86,9 +88,10 @@ export function deLocalizeUrl(url) {
  *
  * @param {string} pattern - The URL pattern containing named groups.
  * @param {Record<string, string | null | undefined>} values - Object of values for named groups.
+ * @param {string} [search] - Optional search (query) parameters to preserve
  * @returns {URL} - The constructed URL with named groups filled.
  */
-function fillPattern(pattern, values) {
+function fillPattern(pattern, values, search) {
 	const filled = pattern.replace(
 		/(\/?):([a-zA-Z0-9_]+)(\([^)]*\))?([?+*]?)/g,
 		(_, slash, name, __, modifier) => {
@@ -121,7 +124,11 @@ function fillPattern(pattern, values) {
 		}
 	);
 
-	return new URL(filled);
+	const url = new URL(filled);
+	if (search) {
+		url.search = search;
+	}
+	return url;
 }
 
 /**

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-url.test.ts
@@ -302,3 +302,33 @@ test("localhost with portname", async () => {
 		"https://localhost:5173/"
 	);
 });
+
+test("it keeps the query parameters", async () => {
+	const runtime = await createRuntimeForTesting({
+		baseLocale: "en",
+		locales: ["en", "de"],
+		compilerOptions: {
+			strategy: ["url"],
+			urlPatterns: [
+				{
+					pattern: "https://:domain(.*)/:locale(de)?/:path*",
+					deLocalizedNamedGroups: { locale: null },
+					localizedNamedGroups: {
+						en: { locale: null },
+						de: { locale: "de" },
+					},
+				},
+			],
+		},
+	});
+
+	expect(
+		runtime.localizeUrl("https://example.com/about?foo=bar&baz=qux", {
+			locale: "de",
+		}).href
+	).toBe("https://example.com/de/about?foo=bar&baz=qux");
+
+	expect(
+		runtime.deLocalizeUrl("https://example.com/de/about?foo=bar&baz=qux").href
+	).toBe("https://example.com/about?foo=bar&baz=qux");
+});

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/server-middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/server-middleware.js
@@ -34,7 +34,7 @@ let serverMiddlewareAsyncStorage = undefined;
  * @param {(args: { request: Request, locale: Locale }) => T | Promise<T>} resolve - Function to handle the request
  *
  * @returns {Promise<Response | any>} Returns either:
- * - A {@link Response} object (302 redirect) if URL localization is needed
+ * - A `Response` object (302 redirect) if URL localization is needed
  * - The result of the resolve function if no redirect is required
  *
  * @example
@@ -58,8 +58,6 @@ let serverMiddlewareAsyncStorage = undefined;
  *   });
  * });
  * ```
- *
- * @see {@link https://inlang.com/documentation/paraglide-js/server-middleware|Server Middleware Documentation}
  */
 export async function serverMiddleware(request, resolve) {
 	if (!serverMiddlewareAsyncStorage) {


### PR DESCRIPTION
Closes https://github.com/opral/inlang-paraglide-js/issues/402 and https://github.com/opral/inlang-paraglide-js/issues/380. 

- aligns localizeUrl and localizeHref API 
- adds docs for the distinction between both functions
- fixes search params being returned in localizeUrl