### PR TITLE
fix `serverMiddleware()` throws in next js when `url` strategy is not used 

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix `serverMiddleware()` only imports async_hooks on the server
 - add `serverMiddleware(req, resolve, { disableAsyncLocalStorage: true })` to disable async local storage
+- fix `serverMiddleware()` throws in next js when `url` strategy is not used https://github.com/opral/inlang-paraglide-js/issues/411#issuecomment-2683530533
 
 ## 2.0.0-beta.21
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/server-middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/server-middleware.js
@@ -117,7 +117,9 @@ export async function serverMiddleware(request, resolve, options = {}) {
 	// the server can't render the correct page.
 	const newRequest = strategy.includes("url")
 		? new Request(deLocalizeUrl(request.url), request)
-		: request;
+		: // need to create a new request object because some metaframeworks (nextjs!) throw otherwise
+			// https://github.com/opral/inlang-paraglide-js/issues/411
+			new Request(request);
 
 	// If AsyncLocalStorage is disabled, create a mock implementation
 	if (disableAsyncLocalStorage) {


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/411#issuecomment-2683530533