### PR TITLE
clean-outdir-on-buildstart

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.0-beta.24
 
 - changes the redirect status from `302` to `307` https://github.com/opral/inlang-paraglide-js/issues/416
+- adds a `cleanOutdir` option which defaults to true https://github.com/opral/inlang-paraglide-js/issues/420
 
 ## 2.0.0-beta.23
 

--- a/inlang/packages/paraglide/paraglide-js/docs-api/compiler-options.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/compiler-options.md
@@ -2,7 +2,7 @@
 
 > **CompilerOptions**: `object`
 
-Defined in: [compiler-options.ts:12](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:13](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 ### Type declaration
 
@@ -32,6 +32,18 @@ The output will look like this:
 +   - my-file.js
     - messages.js
     - runtime.js
+```
+
+#### cleanOutdir?
+
+> `optional` **cleanOutdir**: `boolean`
+
+Whether to clean the output directory before writing the new files.
+
+##### Default
+
+```ts
+true
 ```
 
 #### cookieName?
@@ -226,6 +238,10 @@ TODO documentation
 Defined in: [compiler-options.ts:3](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 ### Type declaration
+
+#### cleanOutdir
+
+> `readonly` **cleanOutdir**: `true` = `true`
 
 #### cookieName
 

--- a/inlang/packages/paraglide/paraglide-js/src/bundler-plugins/unplugin.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/bundler-plugins/unplugin.ts
@@ -21,6 +21,10 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 			previousCompilation = await compile({
 				fs: wrappedFs,
 				previousCompilation,
+				// webpack invokes the `buildStart` api in watch mode,
+				// to avoid cleaning the output directory in watch mode,
+				// we only clean the output directory if there was no previous compilation
+				cleanOutdir: previousCompilation === undefined,
 				...args,
 			});
 			logger.success("Compilation complete");
@@ -53,10 +57,11 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 			previousCompilation = await compile({
 				fs: wrappedFs,
 				previousCompilation,
+				cleanOutdir: false,
 				...args,
 			});
 
-			logger.success("Compilation complete");
+			logger.success("Re-compilation complete");
 
 			// Add any new files to watch
 			for (const filePath of Array.from(readFiles)) {
@@ -84,6 +89,7 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 				previousCompilation = await compile({
 					fs: wrappedFs,
 					previousCompilation,
+					cleanOutdir: true,
 					...args,
 				});
 				logger.success("Compilation complete");

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -106,7 +106,7 @@ test("saves the local account to app data if not exists", async () => {
 	expect(account).toHaveProperty("name");
 });
 
-test.skip("cleans the output directory", async () => {
+test("cleans the output directory", async () => {
 	const fs = memfs().fs as unknown as typeof import("node:fs");
 
 	const project = await loadProjectInMemory({
@@ -135,6 +135,38 @@ test.skip("cleans the output directory", async () => {
 
 	expect(outputDir).not.toContain("y.js");
 	expect(outputSubDir).toBe(false);
+});
+
+test("doesn't clean the output directory if option is set to false", async () => {
+	const fs = memfs().fs as unknown as typeof import("node:fs");
+
+	const project = await loadProjectInMemory({
+		blob: await newProject({}),
+	});
+
+	// save project to directory to test loading
+	await saveProjectToDirectory({
+		project,
+		path: "/project.inlang",
+		fs: fs.promises,
+	});
+
+	await fs.promises.mkdir("/output/subdir", { recursive: true });
+	await fs.promises.writeFile("/output/subdir/x.js", "console.log('hello')");
+	await fs.promises.writeFile("/output/y.js", "console.log('hello')");
+
+	await compile({
+		project: "/project.inlang",
+		outdir: "/output",
+		cleanOutdir: false,
+		fs: fs,
+	});
+
+	const outputDir = await fs.promises.readdir("/output");
+	const outputSubDir = fs.existsSync("/output/subdir");
+
+	expect(outputDir).toContain("y.js");
+	expect(outputSubDir).toBe(true);
 });
 
 test("multiple compile calls do not interfere with each other", async () => {

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile.ts
@@ -74,6 +74,7 @@ export async function compile(
 			const outputHashes = await writeOutput({
 				directory: absoluteOutdir,
 				output,
+				cleanDirectory: withDefaultOptions.cleanOutdir,
 				fs: fs.promises,
 				previousOutputHashes: options.previousCompilation?.outputHashes,
 			});
@@ -91,12 +92,10 @@ export async function compile(
 
 			return { outputHashes };
 		} catch (e) {
-			console.error(e);
-			return { outputHashes: undefined };
-		} finally {
-			// release the lock
+			// release the lock in case of an error
 			compilationInProgress = null;
-		}
+			throw e;
+		} 
 	})();
 
 	const result = structuredClone(await compilationInProgress);

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
@@ -5,6 +5,7 @@ export const defaultCompilerOptions = {
 	emitGitIgnore: true,
 	includeEslintDisableComment: true,
 	emitPrettierIgnore: true,
+	cleanOutdir: true,
 	strategy: ["cookie", "globalVariable", "baseLocale"],
 	cookieName: "PARAGLIDE_LOCALE",
 } as const satisfies Partial<CompilerOptions>;
@@ -167,6 +168,13 @@ export type CompilerOptions = {
 	 * @default "message-modules"
 	 */
 	outputStructure?: "locale-modules" | "message-modules";
+	/**
+	 * Whether to clean the output directory before writing the new files.
+	 *
+	 * @default true
+	 */
+	cleanOutdir?: boolean;
+
 	/**
 	 * The file system to use. Defaults to `await import('node:fs')`.
 	 *

--- a/inlang/packages/paraglide/paraglide-js/src/services/file-handling/write-output.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/services/file-handling/write-output.test.ts
@@ -1,12 +1,12 @@
 import memfs from "memfs";
 import type fs from "node:fs/promises";
-import { it, expect, vi, beforeEach } from "vitest";
+import { test, expect, vi, beforeEach } from "vitest";
 
 beforeEach(() => {
 	vi.resetModules();
 });
 
-it("should write the output to a non-existing directory", async () => {
+test("should write the output to a non-existing directory", async () => {
 	const { writeOutput } = await import("./write-output.js");
 	const fs = mockFs({});
 
@@ -20,7 +20,7 @@ it("should write the output to a non-existing directory", async () => {
 	);
 });
 
-it.skip("should clear & overwrite output that's already there", async () => {
+test("should clear & overwrite output that's already there", async () => {
 	const { writeOutput } = await import("./write-output.js");
 	const fs = mockFs({
 		"/output/test.txt": "old",
@@ -30,6 +30,7 @@ it.skip("should clear & overwrite output that's already there", async () => {
 	await writeOutput({
 		directory: "/output",
 		output: { "test.txt": "new" },
+		cleanDirectory: true,
 		fs,
 	});
 
@@ -41,7 +42,7 @@ it.skip("should clear & overwrite output that's already there", async () => {
 	).rejects.toBeDefined();
 });
 
-it("should create any missing directories", async () => {
+test("should create any missing directories", async () => {
 	const { writeOutput } = await import("./write-output.js");
 	const fs = mockFs({});
 
@@ -61,7 +62,7 @@ it("should create any missing directories", async () => {
 	).toBe("en");
 });
 
-it("should only write once if the output hasn't changed", async () => {
+test("should only write once if the output hasn't changed", async () => {
 	const { writeOutput } = await import("./write-output.js");
 	const fs = mockFs({});
 
@@ -86,7 +87,7 @@ it("should only write once if the output hasn't changed", async () => {
 	expect(fs.writeFile).toHaveBeenCalledTimes(1);
 });
 
-it("should write again if the output has changed", async () => {
+test("should write again if the output has changed", async () => {
 	const { writeOutput } = await import("./write-output.js");
 	const fs = mockFs({});
 
@@ -110,7 +111,7 @@ it("should write again if the output has changed", async () => {
 	expect(fs.writeFile).toHaveBeenCalledTimes(2);
 });
 
-it("should write files if output has partially changed", async () => {
+test("should write files if output has partially changed", async () => {
 	const { writeOutput } = await import("./write-output.js");
 	const fs = mockFs({});
 

--- a/inlang/packages/paraglide/paraglide-js/src/services/file-handling/write-output.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/services/file-handling/write-output.ts
@@ -5,6 +5,7 @@ import type nodeFs from "node:fs/promises";
 export async function writeOutput(args: {
 	directory: string;
 	output: Record<string, string>;
+	cleanDirectory?: boolean;
 	fs: typeof nodeFs;
 	previousOutputHashes?: Record<string, string>;
 }) {
@@ -23,10 +24,13 @@ export async function writeOutput(args: {
 		return currentOutputHashes;
 	}
 
+	// clear the output directory
+	//
 	// disabled because of https://github.com/opral/inlang-paraglide-js/issues/350
-	// // clear the output directory
-	// await args.fs.rm(args.outputDirectory, { recursive: true, force: true });
-
+	// and re-enabled because of https://github.com/opral/inlang-paraglide-js/issues/420
+	if (args.cleanDirectory) {
+		await args.fs.rm(args.directory, { recursive: true, force: true });
+	}
 	await args.fs.mkdir(args.directory, { recursive: true });
 
 	//Create missing directories inside the output directory


### PR DESCRIPTION
Closes https://github.com/opral/inlang-paraglide-js/issues/420

- cleans the outdir on start
- incrementally cleans message files as needed in watch mode