### PR TITLE
Parjs-321-remove-build-script-modification-in-init

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/docs/basics.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/basics.md
@@ -5,10 +5,23 @@ imports:
 
 # Basics
 
-## Adding and editing Messages
+## Adding and removing locales 
+
+To add a new locale, add it to the `locales` array in `<project0name>.inlang/settings.json` file.
+
+```diff
+// project.inlang/settings.json
+
+{
+  "baseLocale": "en",
++ "locales": ["en", "de"]
+}
+```
+
+## Adding and editing messages
 
 <doc-callout type="info">
-  This section assumes you use the inlang message format plugin that is setup by default in Paraglide JS. [Other file formats can be used as well.](./file-formats.md)
+  This section assumes you use the inlang message format plugin that is setup by default in Paraglide JS. 
 </doc-callout>
 
 Messages are stored in `messages/{locale}.json` as key-value pairs. You can add parameters with curly braces.

--- a/inlang/packages/paraglide/paraglide-js/src/cli/commands/compile/command.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/cli/commands/compile/command.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { resolve } from "node:path";
 import { Logger } from "../../../services/logger/index.js";
-import { DEFAULT_OUTDIR } from "../../defaults.js";
+import { DEFAULT_OUTDIR, DEFAULT_PROJECT_PATH } from "../../defaults.js";
 import { compile } from "../../../compiler/compile.js";
 import {
 	defaultCompilerOptions,
@@ -13,7 +13,8 @@ export const compileCommand = new Command()
 	.summary("Compiles inlang Paraglide-JS")
 	.requiredOption(
 		"--project <path>",
-		'The path to the inlang project. Example: "./project.inlang"'
+		'The path to the inlang project. Example: "./project.inlang"',
+		DEFAULT_PROJECT_PATH
 	)
 	.requiredOption(
 		"--outdir <path>",

--- a/inlang/packages/paraglide/paraglide-js/src/cli/commands/init/command.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/cli/commands/init/command.ts
@@ -64,7 +64,6 @@ export const initCommand = new Command()
 			`2. Run the build script (npm run build, or similar.)`,
 			`3. Visit https://inlang.com/m/gerre34r/library-inlang-paraglideJs/basics to get started.`,
 			"\n",
-			"\n",
 			`For questions and feedback, visit`,
 			`https://github.com/opral/inlang-paraglide-js/issues`,
 		].join("\n");

--- a/inlang/packages/paraglide/paraglide-js/src/cli/commands/init/command.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/cli/commands/init/command.ts
@@ -40,8 +40,6 @@ export const initCommand = new Command()
 
 		if (ctx6.bundler === "vite") {
 			await addVitePlugin(ctx6);
-		} else {
-			await addCompileStepToPackageJSON(ctx6);
 		}
 
 		const ctx7 = await maybeUpdateTsConfig(ctx6);
@@ -59,21 +57,12 @@ export const initCommand = new Command()
 			);
 		}
 
-		const absoluteSettingsPath = nodePath.resolve(
-			ctx8.projectPath,
-			"settings.json"
-		);
-		const relativeSettingsFilePath = absoluteSettingsPath.replace(
-			process.cwd(),
-			"."
-		);
-
 		const successMessage = [
 			`inlang Paraglide-JS has been set up sucessfully.`,
 			"\n",
 			`1. Run your install command (npm i, yarn install, etc)`,
 			`2. Run the build script (npm run build, or similar.)`,
-			`3. Define the locales in ${relativeSettingsFilePath}`,
+			`3. Visit https://inlang.com/m/gerre34r/library-inlang-paraglideJs/basics to get started.`,
 			"\n",
 			"\n",
 			`For questions and feedback, visit`,
@@ -134,14 +123,6 @@ export const addCompileStepToPackageJSON: CliStep<
 
 	ctx = await updatePackageJson({
 		scripts: async (scripts) => {
-			// add the compile command to the postinstall script
-			// this isn't super important, so we won't interrupt the user if it fails
-			if (!scripts.postinstall?.includes("paraglide-js compile")) {
-				scripts.postinstall =
-					`paraglide-js compile --project ${projectPath} --outdir ${outdir}` +
-					(scripts.postinstall ? " && " + scripts.postinstall : "");
-			}
-
 			if (scripts.build === undefined) {
 				scripts.build = `paraglide-js compile --project ${projectPath} --outdir ${outdir}`;
 			} else if (scripts.build.includes("paraglide-js compile") === false) {

--- a/inlang/packages/paraglide/paraglide-js/src/cli/defaults.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/cli/defaults.ts
@@ -9,8 +9,8 @@ const defaultProjectSettings = {
 	baseLocale: "en",
 	locales: ["en", "de"],
 	modules: [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@3/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@1/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2/dist/index.js",
 	],
 	"plugin.inlang.messageFormat": {
 		pathPattern: "./messages/{locale}.json",

--- a/inlang/packages/paraglide/paraglide-js/src/cli/steps/initialize-inlang-project.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/cli/steps/initialize-inlang-project.ts
@@ -207,10 +207,6 @@ export const createNewProjectFlow = async (ctx: {
 		})
 	);
 
-	ctx.logger.info(
-		`Creating a new inlang project in the current working directory.`
-	);
-
 	const projectPath = DEFAULT_PROJECT_PATH;
 
 	//create default project
@@ -235,15 +231,15 @@ export const createNewProjectFlow = async (ctx: {
 	});
 
 	if ((await project.errors.get()).length > 0) {
-		ctx.logger.warn(
-			"Failed to create a new inlang project.\n\nThis is likely an internal bug. Please file an issue at https://github.com/opral/monorepo."
+		ctx.logger.error(
+			"Failed to create a new inlang project.\n\nThis is likely an internal bug. Please file an issue at https://github.com/opral/inlang-paraglide-js."
 		);
 		for (const error of await project.errors.get()) {
 			ctx.logger.error(error);
 		}
 		return process.exit(1);
 	} else {
-		ctx.logger.success("Successfully created a new inlang project.");
+		ctx.logger.success("Created a new inlang project.");
 	}
 	return { project, projectPath };
 };

--- a/inlang/packages/paraglide/paraglide-js/src/cli/steps/update-ts-config.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/cli/steps/update-ts-config.ts
@@ -3,14 +3,15 @@ import type { Logger } from "../../services/logger/index.js";
 import { prompt } from "../utils.js";
 import JSON5 from "json5";
 import { pathExists } from "../../services/file-handling/exists.js";
-import nodePath from "node:path";
+// import nodePath from "node:path";
 
 export const maybeUpdateTsConfig: CliStep<
 	{ fs: typeof import("node:fs/promises"); logger: Logger },
 	unknown
 > = async (ctx) => {
 	const ctx1 = await maybeUpdateTsConfigAllowJs(ctx);
-	return await maybeUpdateTsConfigModuleResolution(ctx1);
+	return ctx1;
+	// return await maybeUpdateTsConfigModuleResolution(ctx1);
 };
 
 /**
@@ -80,106 +81,106 @@ export const maybeUpdateTsConfigAllowJs: CliStep<
 	return ctx;
 };
 
-/**
- * Ensures that the moduleResolution compiler option is set to "bundler" or similar in the tsconfig.json.
- *
- * Otherwise, types defined in `package.exports` are not resolved by TypeScript. Leading to type
- * errors with Paraglide-JS.
- */
-const maybeUpdateTsConfigModuleResolution: CliStep<
-	{ fs: typeof import("node:fs/promises"); logger: Logger },
-	unknown
-> = async (ctx) => {
-	if ((await pathExists("./tsconfig.json", ctx.fs)) === false) {
-		return ctx;
-	}
-	const file = await ctx.fs.readFile("./tsconfig.json", {
-		encoding: "utf-8",
-	});
-	// tsconfig allows comments ... FML
-	let tsconfig = JSON5.parse(file);
+// /**
+//  * Ensures that the moduleResolution compiler option is set to "bundler" or similar in the tsconfig.json.
+//  *
+//  * Otherwise, types defined in `package.exports` are not resolved by TypeScript. Leading to type
+//  * errors with Paraglide-JS.
+//  */
+// const maybeUpdateTsConfigModuleResolution: CliStep<
+// 	{ fs: typeof import("node:fs/promises"); logger: Logger },
+// 	unknown
+// > = async (ctx) => {
+// 	if ((await pathExists("./tsconfig.json", ctx.fs)) === false) {
+// 		return ctx;
+// 	}
+// 	const file = await ctx.fs.readFile("./tsconfig.json", {
+// 		encoding: "utf-8",
+// 	});
+// 	// tsconfig allows comments ... FML
+// 	let tsconfig = JSON5.parse(file);
 
-	let parentTsConfig: any | undefined;
+// 	let parentTsConfig: any | undefined;
 
-	if (tsconfig.extends) {
-		try {
-			const parentTsConfigPath = nodePath.resolve(
-				process.cwd(),
-				tsconfig.extends
-			);
-			const parentTsConfigFile = await ctx.fs.readFile(parentTsConfigPath, {
-				encoding: "utf-8",
-			});
-			parentTsConfig = JSON5.parse(parentTsConfigFile);
-		} catch {
-			ctx.logger.warn(
-				`The tsconfig.json is extended from a tsconfig that couldn't be read. Maybe the file doesn't exist yet or is a NPM package. Continuing without taking the extended from tsconfig into consideration.`
-			);
-		}
-	}
+// 	if (tsconfig.extends) {
+// 		try {
+// 			const parentTsConfigPath = nodePath.resolve(
+// 				process.cwd(),
+// 				tsconfig.extends
+// 			);
+// 			const parentTsConfigFile = await ctx.fs.readFile(parentTsConfigPath, {
+// 				encoding: "utf-8",
+// 			});
+// 			parentTsConfig = JSON5.parse(parentTsConfigFile);
+// 		} catch {
+// 			ctx.logger.warn(
+// 				`The tsconfig.json is extended from a tsconfig that couldn't be read. Maybe the file doesn't exist yet or is a NPM package. Continuing without taking the extended from tsconfig into consideration.`
+// 			);
+// 		}
+// 	}
 
-	// options that don't support package.exports
-	const invalidOptions = ["classic", "node", "node10"];
-	const moduleResolution =
-		tsconfig.compilerOptions?.moduleResolution ??
-		parentTsConfig?.compilerOptions?.moduleResolution;
+// 	// options that don't support package.exports
+// 	const invalidOptions = ["classic", "node", "node10"];
+// 	const moduleResolution =
+// 		tsconfig.compilerOptions?.moduleResolution ??
+// 		parentTsConfig?.compilerOptions?.moduleResolution;
 
-	if (
-		moduleResolution &&
-		invalidOptions.includes(moduleResolution.toLowerCase()) === false
-	) {
-		// the moduleResolution is already set to bundler or similar
-		return ctx;
-	}
+// 	if (
+// 		moduleResolution &&
+// 		invalidOptions.includes(moduleResolution.toLowerCase()) === false
+// 	) {
+// 		// the moduleResolution is already set to bundler or similar
+// 		return ctx;
+// 	}
 
-	ctx.logger.info(
-		`The \`compilerOptions.moduleResolution\` options must be set to "Bundler" in the \`tsconfig.json\` file:
+// 	ctx.logger.info(
+// 		`The \`compilerOptions.moduleResolution\` options must be set to "Bundler" in the \`tsconfig.json\` file:
 
-\`{
- "compilerOptions": {
-   "moduleResolution": "Bundler"
- }
-}\``
-	);
-	let isValid = false;
-	while (isValid === false) {
-		const response = await prompt(
-			`Is \`compilerOptions.moduleResolution\` set to "Bundler"?`,
-			{
-				type: "confirm",
-				initial: true,
-			}
-		);
-		if (response === false) {
-			ctx.logger.warn(
-				"Continuing without adjusting the tsconfig.json. This may lead to type errors."
-			);
-			return ctx;
-		}
+// \`{
+//  "compilerOptions": {
+//    "moduleResolution": "Bundler"
+//  }
+// }\``
+// 	);
+// 	let isValid = false;
+// 	while (isValid === false) {
+// 		const response = await prompt(
+// 			`Is \`compilerOptions.moduleResolution\` set to "Bundler"?`,
+// 			{
+// 				type: "confirm",
+// 				initial: true,
+// 			}
+// 		);
+// 		if (response === false) {
+// 			ctx.logger.warn(
+// 				"Continuing without adjusting the tsconfig.json. This may lead to type errors."
+// 			);
+// 			return ctx;
+// 		}
 
-		// don't re-ask the question if there is an `extends` present in the tsconfig
-		// just trust that it's correct.
-		if (tsconfig.extends) {
-			isValid = true;
-			return ctx;
-		}
+// 		// don't re-ask the question if there is an `extends` present in the tsconfig
+// 		// just trust that it's correct.
+// 		if (tsconfig.extends) {
+// 			isValid = true;
+// 			return ctx;
+// 		}
 
-		const file = await ctx.fs.readFile("./tsconfig.json", {
-			encoding: "utf-8",
-		});
-		tsconfig = JSON5.parse(file);
-		if (
-			tsconfig?.compilerOptions?.moduleResolution &&
-			tsconfig.compilerOptions.moduleResolution.toLowerCase() === "bundler"
-		) {
-			isValid = true;
-			return ctx;
-		} else {
-			ctx.logger.error(
-				"The compiler options have not been adjusted. Please set the `compilerOptions.moduleResolution` to `Bundler`."
-			);
-		}
-	}
+// 		const file = await ctx.fs.readFile("./tsconfig.json", {
+// 			encoding: "utf-8",
+// 		});
+// 		tsconfig = JSON5.parse(file);
+// 		if (
+// 			tsconfig?.compilerOptions?.moduleResolution &&
+// 			tsconfig.compilerOptions.moduleResolution.toLowerCase() === "bundler"
+// 		) {
+// 			isValid = true;
+// 			return ctx;
+// 		} else {
+// 			ctx.logger.error(
+// 				"The compiler options have not been adjusted. Please set the `compilerOptions.moduleResolution` to `Bundler`."
+// 			);
+// 		}
+// 	}
 
-	return ctx;
-};
+// 	return ctx;
+// };

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile.ts
@@ -95,7 +95,7 @@ export async function compile(
 			// release the lock in case of an error
 			compilationInProgress = null;
 			throw e;
-		} 
+		}
 	})();
 
 	const result = structuredClone(await compilationInProgress);

--- a/inlang/packages/paraglide/paraglide-js/src/services/file-handling/write-output.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/services/file-handling/write-output.test.ts
@@ -144,42 +144,52 @@ test("should delete files that have been removed from the output", async () => {
 		output: {
 			"file1.txt": "content1",
 			"file2.txt": "content2",
-			"subdir/file3.txt": "content3"
+			"subdir/file3.txt": "content3",
 		},
 		fs,
 	});
 
 	// Verify all files were written
-	expect(await fs.readFile("/output/file1.txt", { encoding: "utf-8" })).toBe("content1");
-	expect(await fs.readFile("/output/file2.txt", { encoding: "utf-8" })).toBe("content2");
-	expect(await fs.readFile("/output/subdir/file3.txt", { encoding: "utf-8" })).toBe("content3");
+	expect(await fs.readFile("/output/file1.txt", { encoding: "utf-8" })).toBe(
+		"content1"
+	);
+	expect(await fs.readFile("/output/file2.txt", { encoding: "utf-8" })).toBe(
+		"content2"
+	);
+	expect(
+		await fs.readFile("/output/subdir/file3.txt", { encoding: "utf-8" })
+	).toBe("content3");
 
 	// Second write with file2.txt removed
 	await writeOutput({
 		directory: "/output",
 		output: {
 			"file1.txt": "content1",
-			"subdir/file3.txt": "content3updated"
+			"subdir/file3.txt": "content3updated",
 		},
 		fs,
 		previousOutputHashes: hashes,
 	});
 
 	// Verify file1.txt still exists
-	expect(await fs.readFile("/output/file1.txt", { encoding: "utf-8" })).toBe("content1");
+	expect(await fs.readFile("/output/file1.txt", { encoding: "utf-8" })).toBe(
+		"content1"
+	);
 	// Verify file2.txt has been deleted
 	await expect(
 		async () => await fs.readFile("/output/file2.txt", { encoding: "utf-8" })
 	).rejects.toBeDefined();
 	// Verify file3.txt was updated
-	expect(await fs.readFile("/output/subdir/file3.txt", { encoding: "utf-8" })).toBe("content3updated");
+	expect(
+		await fs.readFile("/output/subdir/file3.txt", { encoding: "utf-8" })
+	).toBe("content3updated");
 
 	// Get the new hashes
 	const newHashes = await writeOutput({
 		directory: "/output",
 		output: {
 			"file1.txt": "content1",
-			"subdir/file3.txt": "content3updated"
+			"subdir/file3.txt": "content3updated",
 		},
 		fs,
 		previousOutputHashes: hashes,
@@ -189,17 +199,20 @@ test("should delete files that have been removed from the output", async () => {
 	await writeOutput({
 		directory: "/output",
 		output: {
-			"file1.txt": "content1"
+			"file1.txt": "content1",
 		},
 		fs,
 		previousOutputHashes: newHashes,
 	});
 
 	// Verify file1.txt still exists
-	expect(await fs.readFile("/output/file1.txt", { encoding: "utf-8" })).toBe("content1");
+	expect(await fs.readFile("/output/file1.txt", { encoding: "utf-8" })).toBe(
+		"content1"
+	);
 	// Verify subdir/file3.txt has been deleted
 	await expect(
-		async () => await fs.readFile("/output/subdir/file3.txt", { encoding: "utf-8" })
+		async () =>
+			await fs.readFile("/output/subdir/file3.txt", { encoding: "utf-8" })
 	).rejects.toBeDefined();
 	// Verify the subdir directory has also been removed
 	await expect(


### PR DESCRIPTION
Closes https://github.com/opral/inlang-paraglide-js/issues/318 and https://github.com/opral/inlang-paraglide-js/issues/419

- leaves build script modification in if vite is not used
- updates message format version to v4