### PR TITLE
fix there is no plugin configured

### DIFF
--- a/.changeset/tender-turtles-promise.md
+++ b/.changeset/tender-turtles-promise.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+fix: save the inlang project after message extraction

--- a/.changeset/wet-cups-learn.md
+++ b/.changeset/wet-cups-learn.md
@@ -1,0 +1,7 @@
+---
+"@inlang/plugin-m-function-matcher": patch
+"@inlang/plugin-t-function-matcher": patch
+"@inlang/plugin-i18next": patch
+---
+
+fix: key name of sherlock extension

--- a/inlang/packages/plugins/i18next/src/plugin.ts
+++ b/inlang/packages/plugins/i18next/src/plugin.ts
@@ -24,6 +24,6 @@ export const plugin: InlangPlugin<{
 	exportFiles,
 	toBeImportedFiles,
 	meta: {
-		"app.inlang.ide-extension": config,
+		"app.inlang.ideExtension": config,
 	},
 };

--- a/inlang/packages/plugins/m-function-matcher/src/plugin.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/plugin.ts
@@ -14,6 +14,6 @@ export const plugin: InlangPlugin<{
 		"A plugin for the inlang SDK that uses a JSON file per language tag to store translations.",
 	key,
 	meta: {
-		"app.inlang.ide-extension": config,
+		"app.inlang.ideExtension": config,
 	},
 };

--- a/inlang/packages/plugins/t-function-matcher/src/plugin.ts
+++ b/inlang/packages/plugins/t-function-matcher/src/plugin.ts
@@ -14,6 +14,6 @@ export const plugin: InlangPlugin<{
 		"A plugin for the inlang SDK that uses a JSON file per language tag to store translations.",
 	key,
 	meta: {
-		"app.inlang.ide-extension": config,
+		"app.inlang.ideExtension": config,
 	},
 };

--- a/inlang/packages/sherlock/src/commands/extractMessage.test.ts
+++ b/inlang/packages/sherlock/src/commands/extractMessage.test.ts
@@ -13,16 +13,29 @@ vi.mock("../utilities/state", () => ({
 	state: vi.fn(),
 }))
 
-vi.mock("vscode", () => ({
-	window: {
-		showInputBox: vi.fn(),
-		showQuickPick: vi.fn(),
-		showErrorMessage: vi.fn(),
-	},
-	commands: {
-		registerTextEditorCommand: vi.fn(),
-	},
-}))
+vi.mock("vscode", async () => {
+	return {
+		window: {
+			showInputBox: vi.fn(),
+			showQuickPick: vi.fn(),
+			showErrorMessage: vi.fn(),
+		},
+		commands: {
+			registerTextEditorCommand: vi.fn(),
+		},
+		CodeActionKind: {
+			QuickFix: "quickfix",
+			Refactor: "refactor",
+		},
+		CodeAction: vi.fn().mockImplementation(function (title, kind) {
+			return {
+				title,
+				kind,
+				command: undefined,
+			}
+		}),
+	}
+})
 
 vi.mock("../utilities/messages/msg", () => ({
 	msg: vi.fn(),

--- a/inlang/packages/sherlock/src/commands/extractMessage.ts
+++ b/inlang/packages/sherlock/src/commands/extractMessage.ts
@@ -12,6 +12,7 @@ import {
 	type NewBundleNested,
 } from "@inlang/sdk"
 import { v4 as uuidv4 } from "uuid"
+import { saveProject } from "../main.js"
 
 /**
  * Helps the user to extract messages from the active text editor.
@@ -143,6 +144,8 @@ export const extractMessageCommand = {
 			})
 
 			CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.fire()
+
+			await saveProject()
 
 			capture({
 				event: "IDE-EXTENSION command executed: Extract Message",


### PR DESCRIPTION
fixes https://github.com/opral/inlang-sherlock/issues/152#issuecomment-2694630596

> There is no plugin configuration for the Visual Studio Code extension (Sherlock). One of the modules should expose a plugin which has customApi containing app.inlang.ideExtension