### PR TITLE
fix: serverMiddleware() throws when cookie contains invalid locale

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - fix [setLocale() triggers re-loads if the same locale is set](https://github.com/opral/inlang-paraglide-js/issues/430) 
 
+- fix [serverMiddleware() throws when cookie contains invalid locale](https://github.com/opral/inlang-paraglide-js/issues/442)
+
 ## 2.0.0-beta.26
 
 - replace `node:crypto` with the Web Crypto API https://github.com/opral/inlang-paraglide-js/issues/424

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-request.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-request.js
@@ -17,7 +17,8 @@ import { isLocale } from "./is-locale.js";
  * from a request.
  *
  * The function goes through the strategies in the order
- * they are defined.
+ * they are defined. If a strategy returns an invalid locale,
+ * it will fall back to the next strategy.
  *
  * @example
  *   const locale = extractLocaleFromRequest(request);
@@ -53,7 +54,11 @@ export const extractLocaleFromRequest = (request) => {
 			throw new Error(`Unsupported strategy: ${strat}`);
 		}
 		if (locale !== undefined) {
-			return assertIsLocale(locale);
+			if (!isLocale(locale)) {
+				locale = undefined;
+			} else {
+				return assertIsLocale(locale);
+			}
 		}
 	}
 	throw new Error(


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/442