### PR TITLE
fix wrong matching in API requests

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## 2.0.0-beta.27
 
+- fix wrong matching in API requests [#427](https://github.com/opral/inlang-paraglide-js/issues/427)
+
+Paraglide JS is no longer extracting the locale from API requests for the `url` strategy because that can lead to unwanted re-directs. To get the right locale in API requests, at least add the `baseLocale` strategy to your options. 
+
+```diff
+-strategy: ["url"]
++strategy: ["url", "cookie", "baseLocale"]
+```
+
 - `experimentalMiddlewareLocaleSplitting` option https://github.com/opral/inlang-paraglide-js/issues/425#issuecomment-2692351073
 
 - fix [setLocale() triggers re-loads if the same locale is set](https://github.com/opral/inlang-paraglide-js/issues/430) 

--- a/inlang/packages/paraglide/paraglide-js/docs/errors.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/errors.md
@@ -11,9 +11,9 @@ Paraglide JS was not able to resolve a locale. This can happen if:
 +strategy: ["cookie", "baseLocale"]
 ```
 
+  
 2. You are using `overwriteGetLocale()` and `overwriteSetLocale()` but forgot to call them at the root/entrypoint of your app.
 
-If you use an empty strategy array `[]`, and overwrite the locale getter and setter, make sure to call `overwriteGetLocale()` and `overwriteSetLocale()` at the root/entrypoint of your app.
 
 ```tsx
 import { overwriteGetLocale, overwriteSetLocale } from "./paraglide/runtime.js";
@@ -32,6 +32,7 @@ export default function App() {
 }
 ```
 
+  
 3. You are using the `url` strategy but call messages outside of a request context. 
 
 ```
@@ -63,4 +64,16 @@ app.use(paraglideMiddleware)
 app.get("/", (req, res) => {
 	console.log(m.hello());
 });
+```
+
+   
+4. You make API requests and only have `strategy: ["url"]` set. 
+
+Paraglide JS will only extract the locale from a URL if the request is a document request, indicated by [Sec-Fetch-Dest: document](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest) to distinguish it from API requests. 
+
+Add `cookie` or `baseLocale` to your strategy array to ensure that the locale is always resolved in API requests as well.
+
+```diff
+-strategy: ["url"]
++strategy: ["url", "cookie", "baseLocale"]
 ```

--- a/inlang/packages/paraglide/paraglide-js/docs/strategy.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/strategy.md
@@ -117,6 +117,7 @@ For example, the pattern `https://:domain(.*)/:locale(de|en)?/:path*` matches UR
 
 <doc-callout type="tip">Use https://urlpattern.com/ to test your URL patterns.</doc-callout>
 
+<doc-callout type="info">On the server, the URL strategy will only trigger for requests with the `Sec-Fetch-Dest: "document"` header. This helps distinguish between document requests (browser page loads) and API requests, preventing unnecessary redirects for API calls.</doc-callout>
 
 #### Pathname-based url localization example
 

--- a/inlang/packages/paraglide/paraglide-js/examples/next-js-ssg/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/next-js-ssg/README.md
@@ -47,7 +47,7 @@ export default {
 +			paraglideWebpackPlugin({
 +				outdir: "./src/paraglide",
 +				project: "./project.inlang",
-+       strategy: ["url"],
++       strategy: ["url", "cookie", "baseLocale"],
 +				urlPatterns: [
 +					{
 +						pattern:

--- a/inlang/packages/paraglide/paraglide-js/examples/next-js-ssg/next.config.mjs
+++ b/inlang/packages/paraglide/paraglide-js/examples/next-js-ssg/next.config.mjs
@@ -9,7 +9,7 @@ export default {
 			paraglideWebpackPlugin({
 				outdir: "./src/paraglide",
 				project: "./project.inlang",
-				strategy: ["url"],
+				strategy: ["url", "cookie", "baseLocale"],
 				urlPatterns: [
 					{
 						pattern:

--- a/inlang/packages/paraglide/paraglide-js/examples/next-js-ssr/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/next-js-ssr/README.md
@@ -47,7 +47,7 @@ export default {
 +			paraglideWebpackPlugin({
 +				outdir: "./src/paraglide",
 +				project: "./project.inlang",
-+       strategy: ["url"],
++       strategy: ["url", "cookie", "baseLocale"],
 +			})
 +		);
 +		return config;

--- a/inlang/packages/paraglide/paraglide-js/examples/next-js-ssr/next.config.mjs
+++ b/inlang/packages/paraglide/paraglide-js/examples/next-js-ssr/next.config.mjs
@@ -9,7 +9,7 @@ export default {
 			paraglideWebpackPlugin({
 				outdir: "./src/paraglide",
 				project: "./project.inlang",
-				strategy: ["url", "baseLocale"],
+				strategy: ["url", "cookie", "baseLocale"],
 			})
 		);
 

--- a/inlang/packages/paraglide/paraglide-js/examples/sveltekit/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/sveltekit/README.md
@@ -25,6 +25,10 @@ npx @inlang/paraglide-js@beta init
 
 ### Add the `paraglideVitePlugin()` to `vite.config.js`.
 
+<doc-callout type="info">
+	You can define strategy however you need. 
+</doc-callout>
+
 ```diff
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
@@ -36,7 +40,7 @@ export default defineConfig({
 +		paraglideVitePlugin({
 +			project: './project.inlang',
 +			outdir: './src/lib/paraglide',
-+			strategy: ['url']
++			strategy: ['url', 'cookie', 'baseLocale'],
 +		})
 	]
 });

--- a/inlang/packages/paraglide/paraglide-js/examples/sveltekit/messages/de.json
+++ b/inlang/packages/paraglide/paraglide-js/examples/sveltekit/messages/de.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"welcome": "Willkommen zum SvelteKit Paraglide Adapter Beispiel.",
+	"welcome": "Willkommen zum SvelteKit Paraglide JS Beispiel.",
 	"about": "Dies ist die /other Seite die nur existiert um Navigation mit `localizeHref()` zu demonstrieren."
 }

--- a/inlang/packages/paraglide/paraglide-js/examples/sveltekit/vite.config.ts
+++ b/inlang/packages/paraglide/paraglide-js/examples/sveltekit/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: './project.inlang',
 			outdir: './src/lib/paraglide',
-			strategy: ['url']
+			strategy: ['cookie', 'url', 'baseLocale']
 		})
 	]
 });

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-request.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-request.js
@@ -36,7 +36,13 @@ export const extractLocaleFromRequest = (request) => {
 				?.split("; ")
 				.find((c) => c.startsWith(cookieName + "="))
 				?.split("=")[1];
-		} else if (TREE_SHAKE_URL_STRATEGY_USED && strat === "url") {
+		} else if (
+			TREE_SHAKE_URL_STRATEGY_USED &&
+			strat === "url" &&
+			// only process url strategy if request is a document
+			// else it's api requests, etc.
+			request.headers.get("Sec-Fetch-Dest") === "document"
+		) {
 			locale = extractLocaleFromUrl(request.url);
 		} else if (
 			TREE_SHAKE_PREFERRED_LANGUAGE_STRATEGY_USED &&
@@ -52,8 +58,6 @@ export const extractLocaleFromRequest = (request) => {
 			return baseLocale;
 		} else if (strat === "localStorage") {
 			continue;
-		} else {
-			throw new Error(`Unsupported strategy: ${strat}`);
 		}
 		if (locale !== undefined) {
 			if (!isLocale(locale)) {
@@ -64,7 +68,7 @@ export const extractLocaleFromRequest = (request) => {
 		}
 	}
 	throw new Error(
-		"No locale found. There is an error in your strategy. Try adding 'baseLocale' as the very last strategy."
+		"No locale found. There is an error in your strategy. Try adding 'baseLocale' as the very last strategy. Read more here https://inlang.com/m/gerre34r/library-inlang-paraglideJs/errors#no-locale-found"
 	);
 };
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
@@ -81,7 +81,10 @@ export async function paraglideMiddleware(request, resolve, options = {}) {
 
 	// if the client makes a request to a URL that doesn't match
 	// the localizedUrl, redirect the client to the localized URL
-	if (runtime.strategy.includes("url")) {
+	if (
+		request.headers.get("Sec-Fetch-Dest") === "document" &&
+		runtime.strategy.includes("url")
+	) {
 		const localizedUrl = runtime.localizeUrl(request.url, { locale });
 		if (localizedUrl.href !== request.url) {
 			return Response.redirect(localizedUrl, 307);


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/427

Paraglide JS is no longer extracting the locale from API requests for the `url` strategy because that can lead to unwanted re-directs. To get the right locale in API requests, at least add the `baseLocale` strategy to your options. 

```diff
-strategy: ["url"]
+strategy: ["url", "cookie", "baseLocale"]
```