### PR TITLE
improve: fallback to `typeof window` in vite

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
@@ -44,6 +44,10 @@ After
 }
 ```
 
+### other changes
+
+- improve: fallback to `typeof window` in vite [#445](https://github.com/opral/inlang-paraglide-js/issues/445)
+
 ## 2.0.0-beta.27
 
 - fix wrong matching in API requests [#427](https://github.com/opral/inlang-paraglide-js/issues/427)

--- a/inlang/packages/paraglide/paraglide-js/examples/sveltekit/messages/en.json
+++ b/inlang/packages/paraglide/paraglide-js/examples/sveltekit/messages/en.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"welcome": "Welcome to the SvelteKit Paraglide JS example.",
-	"about": "This is the /other page that only exists to illustrate routing with `localizeHref()`"
+	"about": "This is the /other page that only exists to illustrate routing with `localizeHref()`",
+	"unused": "This is an unused message to verify tree-shaking."
 }

--- a/inlang/packages/paraglide/paraglide-js/src/bundler-plugins/unplugin.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/bundler-plugins/unplugin.ts
@@ -84,7 +84,7 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 	vite: {
 		config: {
 			handler: () => {
-				isServer = "import.meta.env.SSR";
+				isServer = "import.meta.env?.SSR ?? typeof window === 'undefined'";
 			},
 		},
 	},


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/445