### PR TITLE
make `setLocale()` set all strategies

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
@@ -48,6 +48,8 @@ After
 
 - improve: fallback to `typeof window` in vite [#445](https://github.com/opral/inlang-paraglide-js/issues/445)
 
+- make `setLocale()` set all strategies. Setting all strategies aligns with user expectations and ensures that server APIs can receive the cookie of the client, for example. [#439](https://github.com/opral/inlang-paraglide-js/issues/439)
+
 ## 2.0.0-beta.27
 
 - fix wrong matching in API requests [#427](https://github.com/opral/inlang-paraglide-js/issues/427)

--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
@@ -375,7 +375,7 @@ The extracted locale, or undefined if no locale is found.
 
 > **getLocale**(): `any`
 
-Defined in: [runtime/get-locale.js:41](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/get-locale.js)
+Defined in: [runtime/get-locale.js:44](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/get-locale.js)
 
 Get the current locale.
 
@@ -580,7 +580,7 @@ localizeUrl(url, { locale: "de" });
 
 > **overwriteGetLocale**(`fn`): `void`
 
-Defined in: [runtime/get-locale.js:136](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/get-locale.js)
+Defined in: [runtime/get-locale.js:141](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/get-locale.js)
 
 Overwrite the `getLocale()` function.
 
@@ -661,7 +661,7 @@ avoid a circular import between `runtime.js` and
 
 > **overwriteSetLocale**(`fn`): `void`
 
-Defined in: [runtime/set-locale.js:108](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:119](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
 
 Overwrite the `setLocale()` function.
 
@@ -691,11 +691,16 @@ overwriteSetLocale((newLocale) => {
 
 ## setLocale()
 
-> **setLocale**(`newLocale`): `void`
+> **setLocale**(`newLocale`, `options`?): `void`
 
-Defined in: [runtime/set-locale.js:22](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:30](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
 
 Set the locale.
+
+Set locale reloads the site by default on the client. Reloading
+can be disabled by passing `reload: false` as an option. If
+reloading is disbaled, you need to ensure that the UI is updated
+to reflect the new locale.
 
 ### Parameters
 
@@ -703,14 +708,24 @@ Set the locale.
 
 `any`
 
+#### options?
+
+##### reload?
+
+`boolean`
+
 ### Returns
 
 `void`
 
-### Example
+### Examples
 
 ```ts
 setLocale('en');
+```
+
+```ts
+setLocale('en', { reload: false });
 ```
 
 ***

--- a/inlang/packages/paraglide/paraglide-js/examples/sveltekit/vite.config.ts
+++ b/inlang/packages/paraglide/paraglide-js/examples/sveltekit/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: './project.inlang',
 			outdir: './src/lib/paraglide',
-			strategy: ['cookie', 'url', 'baseLocale']
+			strategy: ['url', 'cookie', 'baseLocale']
 		})
 	]
 });

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.test.ts
@@ -130,6 +130,7 @@ test("default url patterns to improve out of the box experience", async () => {
 		baseLocale: "en",
 		locales: ["en", "de", "fr"],
 		compilerOptions: {
+			isServer: "false",
 			strategy: ["url"],
 			urlPatterns: undefined,
 		},


### PR DESCRIPTION
Setting all strategies aligns with user expectations and ensures that server APIs can receive the cookie of the client, for example.

closes https://github.com/opral/inlang-paraglide-js/issues/439