### PR TITLE
fix: initially resolved locale is always used in disabled async local storage

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
     "@inlang/cli-example",
     "@inlang/fink",
     "@inlang/paraglide-js",
+    "@inlang/paraglide-js-benchmark",
     "@inlang/paraglide-js-example-cli",
     "@inlang/paraglide-js-example-vite",
     "@inlang/paraglide-js-example-react",

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
@@ -168,13 +168,12 @@ function createMockAsyncLocalStorage() {
 		getStore() {
 			return currentStore;
 		},
-		run(store, callback) {
-			const previousStore = currentStore;
+		async run(store, callback) {
 			currentStore = store;
 			try {
-				return callback();
+				return await callback();
 			} finally {
-				currentStore = previousStore;
+				currentStore = undefined;
 			}
 		},
 	};


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/446