### PR TITLE
fix wrong locale on server routes

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 **Paraglide JS 2.0 GA release notes are [here](https://github.com/opral/monorepo/blob/main/inlang/packages/paraglide/paraglide-js/v2-release-notes.md)**
 
+## 2.0.0-beta.31
+
+- fix: `getLocale` returns correct value on SvelteKit server [#463](https://github.com/opral/inlang-paraglide-js/issues/463)
+  - Removes the `Sec-Fetch-Dest` check from URL locale extraction
+  - URL locale extraction now works for all request types, not just document requests
+  - Maintains the `Sec-Fetch-Dest` check for redirects only
+  - Eliminates inconsistencies between client-side and server-side locale detection
+
 ## 2.0.0-beta.30
 
 - improve: if no url pattern matches, `localizeUrl()` and `deLocalizeUrl()` will return the input url unchanged instead of throwing an error [#452](https://github.com/opral/inlang-paraglide-js/issues/452#issuecomment-2715761308)

--- a/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
+++ b/inlang/packages/paraglide/paraglide-js/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## 2.0.0-beta.31
 
-- fix: `getLocale` returns correct value on SvelteKit server [#463](https://github.com/opral/inlang-paraglide-js/issues/463)
+- fix: `getLocale` returns correct value on SvelteKit server [#461](https://github.com/opral/inlang-paraglide-js/issues/461)
+
   - Removes the `Sec-Fetch-Dest` check from URL locale extraction
   - URL locale extraction now works for all request types, not just document requests
   - Maintains the `Sec-Fetch-Dest` check for redirects only

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-request.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-request.js
@@ -38,10 +38,7 @@ export const extractLocaleFromRequest = (request) => {
 				?.split("=")[1];
 		} else if (
 			TREE_SHAKE_URL_STRATEGY_USED &&
-			strat === "url" &&
-			// only process url strategy if request is a document
-			// else it's api requests, etc.
-			request.headers.get("Sec-Fetch-Dest") === "document"
+			strat === "url"
 		) {
 			locale = extractLocaleFromUrl(request.url);
 		} else if (

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-request.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-request.test.ts
@@ -143,7 +143,7 @@ test("skips over localStorage strategy as it is not supported on the server", as
 	expect(runtime.extractLocaleFromRequest(request)).toBe("en");
 });
 
-test("does not resolve the locale from the url if request is not a document request", async () => {
+test("resolves the locale from the url for all request types", async () => {
 	const runtime = await createRuntimeForTesting({
 		baseLocale: "en",
 		locales: ["en", "fr"],
@@ -161,14 +161,14 @@ test("does not resolve the locale from the url if request is not a document requ
 		},
 	});
 
-	// Document request - should use URL strategy
+	// Non-document request should still use URL strategy
 	const request = new Request("https://example.com/fr/home", {
 		headers: {
 			"Sec-Fetch-Dest": "something",
 		},
 	});
 	const locale = runtime.extractLocaleFromRequest(request);
-	expect(locale).toBe("en");
+	expect(locale).toBe("fr");
 });
 
 // https://github.com/opral/inlang-paraglide-js/issues/436

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
@@ -6,12 +6,13 @@ import * as runtime from "./runtime.js";
  * This middleware performs several key functions:
  *
  * 1. Determines the locale for the incoming request using configured strategies
- * 2. Handles URL localization and redirects
+ * 2. Handles URL localization and redirects (only for document requests)
  * 3. Maintains locale state using AsyncLocalStorage to prevent request interference
  *
  * When URL strategy is used:
  *
- * - If URL doesn't match the determined locale, redirects to localized URL
+ * - The locale is extracted from the URL for all request types
+ * - If URL doesn't match the determined locale, redirects to localized URL (only for document requests)
  * - De-localizes URLs before passing to server (e.g., `/fr/about` → `/about`)
  *
  * @template T - The return type of the resolve function


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/461

- Removes the `Sec-Fetch-Dest` check from URL locale extraction

- URL locale extraction now works for all request types, not just document requests

- Maintains the `Sec-Fetch-Dest` check for redirects only

- Eliminates inconsistencies between client-side and server-side locale detection
