### PR TITLE
correct jsdoc

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
@@ -49,10 +49,10 @@ export type CompilerOptions = {
 	 * fallback to the base locale.
 	 *
 	 * The default ensures that the browser takes a cookie approach,
-	 * server-side takes the variable (because cookie is unavailable),
+	 * server-side takes the globalVariable (because cookie is unavailable),
 	 * whereas both fallback to the base locale if not available.
 	 *
-	 * @default ["url", "cookie", "variable", "baseLocale"]
+	 * @default ["cookie", "globalVariable", "baseLocale"]
 	 */
 	strategy?: Runtime["strategy"];
 	/**


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/467. 

- the person likely had an old beta version 

- loop is not reproducible in beta 30

- updated jsdoc to have correct default strategy