### PR TITLE
fix: add crypto polyfill for environments without crypto

### DIFF
--- a/.changeset/lemon-boats-drop.md
+++ b/.changeset/lemon-boats-drop.md
@@ -1,0 +1,5 @@
+---
+"@lix-js/sdk": patch
+---
+
+Add polyfill for crypto.getRandomValues to ensure nanoid works in environments without crypto support (like older versions of Node in Stackblitz). Fixes https://github.com/opral/lix-sdk/issues/258

--- a/packages/lix-sdk/CHANGELOG.md
+++ b/packages/lix-sdk/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @lix-js/sdk
 
-## 0.4.2
-
-### Patch Changes
-
-- Add polyfill for crypto.getRandomValues to ensure nanoid works in environments without crypto support (like older versions of Node in Stackblitz). Fixes https://github.com/opral/lix-sdk/issues/258
-
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/lix-sdk/CHANGELOG.md
+++ b/packages/lix-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @lix-js/sdk
 
+## 0.4.2
+
+### Patch Changes
+
+- Add polyfill for crypto.getRandomValues to ensure nanoid works in environments without crypto support (like older versions of Node in Stackblitz). Fixes https://github.com/opral/lix-sdk/issues/258
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/lix-sdk/src/database/nano-id.test.ts
+++ b/packages/lix-sdk/src/database/nano-id.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { _nanoIdAlphabet, nanoid } from "./nano-id.js";
 
 test("length is obeyed", () => {
@@ -12,4 +12,31 @@ test("the alphabet does not contain underscores `_` because they are not URL saf
 
 test("the alphabet does not contain dashes `-` because they break selecting the ID from the URL in the browser", () => {
 	expect(_nanoIdAlphabet).not.toContain("-");
+});
+
+/**
+ * Test the crypto polyfill that was added to fix environments without crypto support
+ * like older versions of Node in Stackblitz.
+ * 
+ * See: https://github.com/opral/lix-sdk/issues/258
+ */
+test("polyfill works when crypto is not available", () => {
+	// Store original crypto
+	const originalCrypto = global.crypto;
+
+	// Mock crypto as undefined to test the polyfill
+	vi.stubGlobal("crypto", undefined);
+
+	try {
+		const id = nanoid(10);
+		expect(id.length).toBe(10);
+		expect(typeof id).toBe("string");
+		// Check that it only contains characters from our alphabet
+		for (let i = 0; i < id.length; i++) {
+			expect(_nanoIdAlphabet).toContain(id[i]);
+		}
+	} finally {
+		// Restore original crypto
+		vi.stubGlobal("crypto", originalCrypto);
+	}
 });

--- a/packages/lix-sdk/src/database/nano-id.ts
+++ b/packages/lix-sdk/src/database/nano-id.ts
@@ -4,7 +4,32 @@
  *
  */
 
-const random = (bytes: any) => crypto.getRandomValues(new Uint8Array(bytes));
+/**
+ * Polyfill for crypto.getRandomValues in environments that don't have it,
+ * such as older versions of Node in Stackblitz.
+ * 
+ * This implementation is not cryptographically secure, but is sufficient for ID generation
+ * in these environments. In environments with proper crypto support, we'll use the native implementation.
+ * 
+ * See: https://github.com/opral/lix-sdk/issues/258
+ */
+const insecureRandom = (array: Uint8Array) => {
+  for (let i = 0; i < array.length; i++) {
+    array[i] = Math.floor(Math.random() * 256);
+  }
+  return array;
+};
+
+// Use crypto.getRandomValues if available, otherwise use our polyfill
+const random = (bytes: any) => {
+  const array = new Uint8Array(bytes);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    return crypto.getRandomValues(array);
+  }
+  
+  // Fallback to insecure random number generator if crypto is not available
+  return insecureRandom(array);
+};
 
 const customRandom = (
 	alphabet: string,


### PR DESCRIPTION
This polyfill ensures nanoid works in environments that don't have crypto support,
like older versions of Node.js in Stackblitz.

Fixes https://github.com/opral/lix-sdk/issues/258