### PR TITLE
fix hydration error in paraglide react-router example

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/examples/react-router/app/entry.client.tsx
+++ b/inlang/packages/paraglide/paraglide-js/examples/react-router/app/entry.client.tsx
@@ -1,0 +1,12 @@
+import { startTransition, StrictMode } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { HydratedRouter } from "react-router/dom";
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <HydratedRouter />
+    </StrictMode>
+  );
+});

--- a/inlang/packages/paraglide/paraglide-js/examples/react-router/app/entry.server.tsx
+++ b/inlang/packages/paraglide/paraglide-js/examples/react-router/app/entry.server.tsx
@@ -1,0 +1,87 @@
+import { PassThrough } from "node:stream";
+
+import { createContext, useContext } from "react";
+import type { AppLoadContext, EntryContext } from "react-router";
+import { createReadableStreamFromReadable } from "@react-router/node";
+import { ServerRouter } from "react-router";
+import { isbot } from "isbot";
+import type { RenderToPipeableStreamOptions } from "react-dom/server";
+import { renderToPipeableStream } from "react-dom/server";
+import {
+  assertIsLocale,
+  baseLocale,
+  isLocale,
+  overwriteGetLocale,
+} from "./paraglide/runtime";
+
+export const streamTimeout = 5_000;
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _loadContext: AppLoadContext
+) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(request.url);
+    const pathSegment = url.pathname.split("/")[1];
+    const locale = isLocale(pathSegment) ? pathSegment : baseLocale;
+    const LocaleContextSSR = createContext(baseLocale);
+
+    if (import.meta.env.SSR) {
+      overwriteGetLocale(() => assertIsLocale(useContext(LocaleContextSSR)));
+    }
+
+    let shellRendered = false;
+    const userAgent = request.headers.get("user-agent");
+
+    // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
+    // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
+    const readyOption: keyof RenderToPipeableStreamOptions =
+      (userAgent && isbot(userAgent)) || routerContext.isSpaMode
+        ? "onAllReady"
+        : "onShellReady";
+
+    const { pipe, abort } = renderToPipeableStream(
+      <LocaleContextSSR.Provider value={locale}>
+        <ServerRouter context={routerContext} url={request.url} />
+      </LocaleContextSSR.Provider>,
+      {
+        [readyOption]() {
+          shellRendered = true;
+          const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set("Content-Type", "text/html");
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            })
+          );
+
+          pipe(body);
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      }
+    );
+
+    // Abort the rendering stream after the `streamTimeout` so it has time to
+    // flush down the rejected boundaries
+    setTimeout(abort, streamTimeout + 1000);
+  });
+}

--- a/inlang/packages/paraglide/paraglide-js/examples/react-router/app/root.tsx
+++ b/inlang/packages/paraglide/paraglide-js/examples/react-router/app/root.tsx
@@ -1,38 +1,9 @@
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
-import type { Route } from "./+types/root";
-import type React from "react";
-import { createContext, useContext } from "react";
-import {
-	assertIsLocale,
-	baseLocale,
-	getLocale,
-	isLocale,
-	overwriteGetLocale,
-} from "./paraglide/runtime";
+import { getLocale } from "./paraglide/runtime";
 
-export function loader(args: Route.LoaderArgs) {
-	return {
-		// detect the locale from the path. if no locale is found, the baseLocale is used.
-		// e.g. /de will set the locale to "de"
-		locale: isLocale(args.params.locale) ? args.params.locale : baseLocale,
-	};
-}
-
-// server-side rendering needs to be scoped to each request
-// react context is used to scope the locale to each request
-// and getLocale() is overwritten to read from the react context
-const LocaleContextSSR = createContext(baseLocale);
-if (import.meta.env.SSR) {
-	overwriteGetLocale(() => assertIsLocale(useContext(LocaleContextSSR)));
-}
-
-export default function App(props: Route.ComponentProps) {
+export default function App() {
 	return (
-		// use the locale
-		<LocaleContextSSR.Provider value={props.loaderData.locale}>
-			{/* @ts-ignore */}
-			<Outlet />
-		</LocaleContextSSR.Provider>
+		<Outlet />
 	);
 }
 

--- a/inlang/packages/paraglide/paraglide-js/examples/react-router/tsconfig.json
+++ b/inlang/packages/paraglide/paraglide-js/examples/react-router/tsconfig.json
@@ -19,6 +19,9 @@
 		"noEmit": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
-		"strict": true
+		"strict": true,
+		"paths": {
+			"react": [ "./node_modules/@types/react" ]
+		}
 	}
 }


### PR DESCRIPTION
* run: react-router reveal
* move context provider to app/entry.server.tsx
* fix ts error by adding @types/react to compilerOptions.paths (error appears when in monorepo)