### PR TITLE
Fix sveltekit example

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/examples/sveltekit/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/sveltekit/README.md
@@ -70,7 +70,7 @@ const paraglideHandle: Handle = ({ event, resolve }) =>
 		event.request = localizedRequest;
 		return resolve(event, {
 			transformPageChunk: ({ html }) => {
-				return html.replace('lang%', locale);
+				return html.replace('%lang%', locale);
 			}
 		});
 	});

--- a/inlang/packages/paraglide/paraglide-js/examples/sveltekit/src/hooks.server.ts
+++ b/inlang/packages/paraglide/paraglide-js/examples/sveltekit/src/hooks.server.ts
@@ -6,7 +6,7 @@ const paraglideHandle: Handle = ({ event, resolve }) =>
 		event.request = localizedRequest;
 		return resolve(event, {
 			transformPageChunk: ({ html }) => {
-				return html.replace('lang%', locale);
+				return html.replace('%lang%', locale);
 			}
 		});
 	});


### PR DESCRIPTION
- Fix missing first `%` to replace `lang` attribute