### PR TITLE
Fix typos

### DIFF
--- a/.changeset/honest-seahorses-buy.md
+++ b/.changeset/honest-seahorses-buy.md
@@ -1,0 +1,5 @@
+---
+"@inlang/cli": patch
+---
+
+Fix typo and inconsistent casing in CLI help output

--- a/inlang/packages/cli/README.md
+++ b/inlang/packages/cli/README.md
@@ -99,8 +99,8 @@ If one of the commands can't be found, you probably use an outdated CLI version.
 CLI for inlang.
 
 Options:
-  -V, --version         output the version number
-  -h, --help            display help for command
+  -V, --version         Output the version number
+  -h, --help            Display help for command
 
 Commands:
   project [command]  Commands for managing your inlang project
@@ -108,7 +108,7 @@ Commands:
   machine [command]  Commands for automating translations.
   open [command]     Commands for open parts of the inlang ecosystem.
   module [command]   Commands for build inlang modules.
-  help [command]     display help for command
+  help [command]     Display help for command
 ```
 
 The following commands are available with the inlang CLI:

--- a/inlang/packages/cli/src/commands/plugin/index.ts
+++ b/inlang/packages/cli/src/commands/plugin/index.ts
@@ -3,6 +3,6 @@ import { build } from "./build/command.js";
 
 export const plugin = new Command()
   .command("plugin")
-  .description("Commands for inlang pluginss.")
+  .description("Commands for inlang plugins.")
   .argument("[command]")
   .addCommand(build);


### PR DESCRIPTION
The help output for the CLI had a typo (`pluginss`) and the casing was a bit inconsistent:

<img width="277" alt="image" src="https://github.com/user-attachments/assets/f40fba78-0ea5-4659-9556-7cdbd663f90a" />
