### PR TITLE
Parjs-481-translations-with-placeholder-generate-jsdocs-with-incorrect

### DIFF
--- a/.changeset/gold-squids-stare.md
+++ b/.changeset/gold-squids-stare.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+improve: handle duplicate inputs https://github.com/opral/inlang-paraglide-js/issues/479

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-bundle.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-bundle.test.ts
@@ -108,3 +108,65 @@ test("compiles bundles with arbitrary module identifiers", async () => {
 		`export { ${toSafeModuleId("$p@44🍌")} as "$p@44🍌" }`
 	);
 });
+
+test("handles message pattern with duplicate variable references", async () => {
+	const mockBundle: BundleNested = {
+		id: "date_last_days",
+		declarations: [
+			{ type: "input-variable", name: "days" },
+			{ type: "input-variable", name: "days" },
+		],
+		messages: [
+			{
+				id: "date_last_days",
+				bundleId: "date_last_days",
+				locale: "en",
+				selectors: [],
+				variants: [
+					{
+						id: "1",
+						messageId: "date_last_days",
+						matches: [],
+						pattern: [
+							{ type: "text", value: "Last " },
+							{
+								type: "expression",
+								arg: { type: "variable-reference", name: "days" },
+							},
+							{ type: "text", value: " days, showing " },
+							{
+								type: "expression",
+								arg: { type: "variable-reference", name: "days" },
+							},
+							{ type: "text", value: " items" },
+						],
+					},
+				],
+			},
+		],
+	};
+
+	const result = compileBundle({
+		fallbackMap: {
+			en: "en",
+		},
+		bundle: mockBundle,
+		messageReferenceExpression: (locale) =>
+			`${toSafeModuleId(locale)}.date_last_days`,
+	});
+
+	// The JSDoc should not have duplicate parameters
+	expect(result.bundle.code).toContain(
+		"@param {{ days: NonNullable<unknown> }} inputs"
+	);
+	expect(result.bundle.code).not.toContain(
+		"days: NonNullable<unknown>, days: NonNullable<unknown>"
+	);
+
+	// Check that the pattern is compiled correctly
+	const enMessage = result.messages?.en;
+	expect(enMessage).toBeDefined();
+	expect(enMessage?.code).toContain(
+		"Last ${i.days} days, showing ${i.days} items"
+	);
+});

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-message.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-message.test.ts
@@ -82,7 +82,7 @@ test("compiles a message with variants", async () => {
 
 	const { some_message } = await import(
 		"data:text/javascript;base64," +
-			btoa("export const some_message =" + compiled.code)
+			btoa("export const some_message = " + compiled.code)
 	);
 
 	expect(some_message({ fistInput: 1, secondInput: 2 })).toBe(

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/jsdoc-types.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/jsdoc-types.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "vitest";
+import { inputsType, jsDocBundleFunctionTypes } from "./jsdoc-types.js";
+import type { InputVariable } from "@inlang/sdk";
+
+test("inputsType generates unique parameter types even when the same input appears multiple times", () => {
+	// Simulate a case where the same input appears multiple times (like in a translation with placeholders)
+	const inputs: InputVariable[] = [
+		{ name: "days", type: "input-variable" },
+		{ name: "days", type: "input-variable" }, // Duplicated input
+	];
+
+	// The generated input type should only include each parameter once
+	const result = inputsType(inputs);
+	expect(result).toBe("{ days: NonNullable<unknown> }");
+
+	// It should not generate a duplicate parameter
+	expect(result).not.toBe(
+		"{ days: NonNullable<unknown>, days: NonNullable<unknown> }"
+	);
+});
+
+test("jsDocBundleFunctionTypes correctly handles messages with duplicate inputs", () => {
+	const inputs: InputVariable[] = [
+		{ name: "days", type: "input-variable" },
+		{ name: "days", type: "input-variable" }, // Duplicated input
+	];
+
+	const locales = ["en-us", "de-de"];
+
+	const result = jsDocBundleFunctionTypes({ inputs, locales });
+
+	// The JSDoc should only include each parameter once
+	expect(result).toContain("@param {{ days: NonNullable<unknown> }} inputs");
+
+	// It should not contain duplicated parameters
+	expect(result).not.toContain(
+		"@param {{ days: NonNullable<unknown>, days: NonNullable<unknown> }} inputs"
+	);
+});

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/jsdoc-types.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/jsdoc-types.ts
@@ -24,7 +24,17 @@ export function inputsType(inputs: InputVariable[]): string {
 	if (inputs.length === 0) {
 		return "{}";
 	}
-	const inputParams = inputs
+
+	// Deduplicate inputs by name to avoid TypeScript errors with duplicate properties in JSDoc
+	const uniqueInputMap = new Map<string, InputVariable>();
+
+	for (const input of inputs) {
+		uniqueInputMap.set(input.name, input);
+	}
+
+	const uniqueInputs = Array.from(uniqueInputMap.values());
+
+	const inputParams = uniqueInputs
 		.map((input) => {
 			return `${input.name}: NonNullable<unknown>`;
 		})


### PR DESCRIPTION
Closes https://github.com/opral/inlang-paraglide-js/issues/479