### PR TITLE
chore: reduce the minmum node version to v18 to unblock adoption

### DIFF
--- a/.changeset/poor-masks-refuse.md
+++ b/.changeset/poor-masks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@lix-js/sdk": patch
+---
+
+chore: reduce the minmum node version to v18 to unblock adoption https://github.com/opral/lix-sdk/issues/277

--- a/packages/lix-sdk/package.json
+++ b/packages/lix-sdk/package.json
@@ -26,7 +26,7 @@
 	"_comment": "Required for tree-shaking https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free",
 	"sideEffects": false,
 	"engines": {
-		"node": ">=21"
+		"node": ">=18"
 	},
 	"dependencies": {
 		"@lix-js/server-api-schema": "workspace:*",


### PR DESCRIPTION
closes https://github.com/opral/lix-sdk/issues/277