### PR TITLE
Fix dependency path from async_hooks to node:async_hooks

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe, vi, beforeEach } from "vitest";
-import { AsyncLocalStorage } from "async_hooks";
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
 	createProject as typescriptProject,
 	ts,
@@ -911,7 +911,7 @@ async function bundleCode(output: Record<string, string>, file: string) {
 		'import "@inlang/paraglide-js/urlpattern-polyfill";',
 		"/** @type {any} */const URLPattern = {};"
 	).replace(
-		'const { AsyncLocalStorage } = await import("async_hooks");',
+		'const { AsyncLocalStorage } = await import("node:async_hooks");',
 		"const AsyncLocalStorage = class {};"
 	);
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
@@ -63,7 +63,7 @@ import * as runtime from "./runtime.js";
  */
 export async function paraglideMiddleware(request, resolve) {
 	if (!runtime.disableAsyncLocalStorage && !runtime.serverAsyncLocalStorage) {
-		const { AsyncLocalStorage } = await import("async_hooks");
+		const { AsyncLocalStorage } = await import("node:async_hooks");
 		runtime.overwriteServerAsyncLocalStorage(new AsyncLocalStorage());
 	} else if (!runtime.serverAsyncLocalStorage) {
 		runtime.overwriteServerAsyncLocalStorage(createMockAsyncLocalStorage());


### PR DESCRIPTION
Without this fix the generated middleware would break deno.