### PR TITLE
fix: duplicate (case sensitive) message keys leading to compile error when using `output-structure: locale-modules`.

### DIFF
--- a/.changeset/chilly-moose-suffer.md
+++ b/.changeset/chilly-moose-suffer.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix: duplicate (case sensitive) message keys leading to compile error when using `output-structure: locale-modules`. closes https://github.com/opral/inlang-paraglide-js/issues/487

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.test.ts
@@ -755,6 +755,41 @@ describe.each([
 				runtime.setLocale("en-US");
 				expect(m.missing_in_en_US()).toBe("Fallback message.");
 			});
+
+			test("arbitrary module identifiers", async () => {
+				const project = await loadProjectInMemory({
+					blob: await newProject({
+						settings: { locales: ["en"], baseLocale: "en" },
+					}),
+				});
+
+				await insertBundleNested(
+					project.db,
+					createBundleNested({
+						id: "happy🍌",
+						messages: [
+							{
+								locale: "en",
+								variants: [{ pattern: [{ type: "text", value: "Hello" }] }],
+							},
+						],
+					})
+				);
+
+				const output = await compileProject({
+					project,
+					compilerOptions,
+				});
+
+				const code = await bundleCode(
+					output,
+					`export * as m from "./paraglide/messages.js"
+					export * as runtime from "./paraglide/runtime.js"`
+				);
+				const { m } = await importCode(code);
+
+				expect(m["happy🍌"]()).toBe("Hello");
+			});
 		});
 
 		test("case sensitivity handling for bundle IDs", async () => {

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.test.ts
@@ -970,6 +970,27 @@ const mockBundles: BundleNested[] = [
 			},
 		],
 	}),
+	createBundleNested({
+		id: "Sad_penguin_bundle",
+		messages: [
+			{
+				locale: "en",
+				variants: [
+					{ pattern: [{ type: "text", value: "Capital Sad penguin" }] },
+				],
+			},
+			{
+				locale: "de",
+				variants: [
+					{
+						pattern: [
+							{ type: "text", value: "Grossgeschriebenes Sad penguin" },
+						],
+					},
+				],
+			},
+		],
+	}),
 	{
 		id: "depressed_dog",
 		declarations: [

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.test.ts
@@ -74,3 +74,53 @@ test("the files should include files for each locale, even if there are no messa
 	expect(output).toHaveProperty("messages/de.js");
 	expect(output).toHaveProperty("messages/fr.js");
 });
+
+test("should handle case sensitivity in message IDs correctly", () => {
+	const bundles: CompiledBundleWithMessages[] = [
+		{
+			bundle: {
+				code: 'console.log("bundle code");',
+				node: {
+					id: "sad_penguin_bundle",
+				} as unknown as Bundle,
+			},
+			messages: {
+				en: {
+					code: 'console.log("sad_penguin_bundle");',
+					node: {} as unknown as Message,
+				},
+			},
+		},
+		{
+			bundle: {
+				code: 'console.log("bundle code");',
+				node: {
+					id: "Sad_penguin_bundle",
+				} as unknown as Bundle,
+			},
+			messages: {
+				en: {
+					code: 'console.log("Sad_penguin_bundle");',
+					node: {} as unknown as Message,
+				},
+			},
+		},
+	];
+
+	const settings: Pick<ProjectSettings, "locales" | "baseLocale"> = {
+		locales: ["en"],
+		baseLocale: "en",
+	};
+
+	const fallbackMap: Record<string, string | undefined> = {};
+
+	const output = generateOutput(bundles, settings, fallbackMap);
+	
+	// Check that the output exists
+	expect(output).toHaveProperty("messages/en.js");
+	
+	// The exported constants should not conflict
+	const content = output["messages/en.js"];
+	expect(content).toContain("export const sad_penguin_bundle");
+	expect(content).toContain("export const sad_penguin_bundle1"); // or some other unique name
+});

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.ts
@@ -3,8 +3,27 @@ import type { CompiledBundleWithMessages } from "../compile-bundle.js";
 import { toSafeModuleId } from "../safe-module-id.js";
 import { inputsType } from "../jsdoc-types.js";
 
+// Helper function to escape special characters in a string for use in a regular expression
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// This map will be used to track which bundle IDs have been renamed to which unique IDs
+// It will be populated during the generateOutput function and used in messageReferenceExpression
+const bundleIdToUniqueIdMap = new Map<string, string>();
+
 export function messageReferenceExpression(locale: string, bundleId: string) {
-	return `${toSafeModuleId(locale)}.${toSafeModuleId(bundleId)}`;
+	// First convert to safe module ID
+	const safeModuleId = toSafeModuleId(bundleId);
+	
+	// Check if this bundleId has been mapped to a unique identifier
+	const uniqueId = bundleIdToUniqueIdMap.get(bundleId);
+	if (uniqueId) {
+		return `${toSafeModuleId(locale)}.${uniqueId}`;
+	}
+	
+	// Otherwise, return the default safe module ID
+	return `${toSafeModuleId(locale)}.${safeModuleId}`;
 }
 
 export function generateOutput(
@@ -12,6 +31,57 @@ export function generateOutput(
 	settings: Pick<ProjectSettings, "locales" | "baseLocale">,
 	fallbackMap: Record<string, string | undefined>
 ): Record<string, string> {
+	// Create a map to track module IDs in the index file to avoid duplicates
+	const indexModuleIdMap = new Map<string, string>();
+	
+	// Process the bundles to ensure no duplicate bundle IDs
+	// Generate unique moduleIds for duplicate IDs
+	const processedBundleCodes = compiledBundles.map(({ bundle }) => {
+		const bundleId = bundle.node.id;
+		const bundleModuleId = toSafeModuleId(bundleId);
+		
+		// Check if this safe module ID has been used before
+		if (indexModuleIdMap.has(bundleModuleId)) {
+			// Create a unique identifier by adding a counter
+			let counter = 1;
+			let uniqueModuleId = `${bundleModuleId}${counter}`;
+			
+			while (indexModuleIdMap.has(uniqueModuleId)) {
+				counter++;
+				uniqueModuleId = `${bundleModuleId}${counter}`;
+			}
+			
+			// Modify the code to use the unique identifier
+			const modifiedCode = bundle.code.replace(
+				new RegExp(`const ${bundleModuleId} =`, 'g'),
+				`const ${uniqueModuleId} =`
+			).replace(
+				new RegExp(`export const ${bundleModuleId} =`, 'g'),
+				`export const ${uniqueModuleId} =`
+			).replace(
+				new RegExp(`export { ${bundleModuleId}`, 'g'),
+				`export { ${uniqueModuleId}`
+			).replace(
+				// Also update the trackMessageCall to use the new identifier
+				new RegExp(`trackMessageCall\\("${escapeRegExp(bundleId)}"`, 'g'),
+				`trackMessageCall("${bundleId}"`
+			);
+			
+			// Store the unique ID mapping
+			indexModuleIdMap.set(uniqueModuleId, bundleId);
+			
+			// Also store in the global map for messageReferenceExpression to use
+			bundleIdToUniqueIdMap.set(bundleId, uniqueModuleId);
+			
+			return modifiedCode;
+		}
+		
+		// Store the mapping
+		indexModuleIdMap.set(bundleModuleId, bundleId);
+		
+		return bundle.code;
+	}).join("\n");
+	
 	const indexFile = [
 		`import { getLocale, trackMessageCall, experimentalMiddlewareLocaleSplitting, isServer } from "../runtime.js"`,
 		settings.locales
@@ -20,7 +90,7 @@ export function generateOutput(
 					`import * as ${toSafeModuleId(locale)} from "./${locale}.js"`
 			)
 			.join("\n"),
-		compiledBundles.map(({ bundle }) => bundle.code).join("\n"),
+		processedBundleCodes,
 	].join("\n");
 
 	const output: Record<string, string> = {
@@ -31,11 +101,30 @@ export function generateOutput(
 	for (const locale of settings.locales) {
 		const filename = `messages/${locale}.js`;
 		let file = "";
+		
+		// Keep track of module IDs to avoid duplicates
+		const moduleIdMap = new Map<string, string>();
 
 		for (const compiledBundle of compiledBundles) {
 			const compiledMessage = compiledBundle.messages[locale];
-			const bundleModuleId = toSafeModuleId(compiledBundle.bundle.node.id);
 			const bundleId = compiledBundle.bundle.node.id;
+			const bundleModuleId = toSafeModuleId(compiledBundle.bundle.node.id);
+			
+			// Check if this module ID has already been used
+			let uniqueModuleId = bundleModuleId;
+			if (moduleIdMap.has(bundleModuleId)) {
+				// If it has, create a unique ID by adding an index
+				let counter = 1;
+				uniqueModuleId = `${bundleModuleId}${counter}`;
+				while (moduleIdMap.has(uniqueModuleId)) {
+					counter++;
+					uniqueModuleId = `${bundleModuleId}${counter}`;
+				}
+			}
+			
+			// Store this module ID
+			moduleIdMap.set(uniqueModuleId, bundleId);
+			
 			const inputs =
 				compiledBundle.bundle.node.declarations?.filter(
 					(decl) => decl.type === "input-variable"
@@ -44,15 +133,15 @@ export function generateOutput(
 				const fallbackLocale = fallbackMap[locale];
 				if (fallbackLocale) {
 					// use the fall back locale e.g. render the message in English if the German message is missing
-					file += `\nexport { ${bundleModuleId} } from "./${fallbackLocale}.js"`;
+					file += `\nexport { ${uniqueModuleId} } from "./${fallbackLocale}.js"`;
 				} else {
 					// no fallback exists, render the bundleId
-					file += `\n/** @type {(inputs: ${inputsType(inputs)}) => string} */ */\nexport const ${bundleModuleId} = () => '${bundleId}'`;
+					file += `\n/** @type {(inputs: ${inputsType(inputs)}) => string} */\nexport const ${uniqueModuleId} = () => '${bundleId}'`;
 				}
 				continue;
 			}
 
-			file += `\n\nexport const ${bundleModuleId} = ${compiledMessage.code}`;
+			file += `\n\nexport const ${uniqueModuleId} = ${compiledMessage.code}`;
 		}
 
 		// add import if used


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/487