### PR TITLE
fix: compiling message bundles with case sensitive ids for the locale module output 

### DIFF
--- a/.changeset/curly-actors-dress.md
+++ b/.changeset/curly-actors-dress.md
@@ -1,0 +1,16 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix: compiling message bundles with case sensitive ids for the locale module output https://github.com/opral/inlang-paraglide-js/issues/490
+
+Case sensitive ids led to duplicate exports in the locale module output. This has been fixed by adjusting the `toSafeModuleId()` used by the compiler internally to append a number of uppercase characters to de-duplicate the ids.
+
+```diff
+toSafeModuleId("helloworld")
+ "helloworld"
+
+toSafeModuleId("helloWorld")
+- "helloworld"
++ "helloworld1"
+```

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-bundle.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-bundle.test.ts
@@ -62,7 +62,7 @@ export const blue_moon_bottle = (inputs, options = {}) => {
 	const locale = options.locale ?? getLocale()
 	trackMessageCall("blue_moon_bottle", locale)
 	if (locale === "en") return en.blue_moon_bottle(inputs)
-	if (locale === "en-US") return en_us.blue_moon_bottle(inputs)
+	if (locale === "en-US") return en_us2.blue_moon_bottle(inputs)
 	return "blue_moon_bottle"
 };"`
 	);

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.test.ts
@@ -354,6 +354,8 @@ describe.each([
 			test("should return the correct message for the current locale", async () => {
 				const { m, runtime } = await importCode(code);
 
+				console.log(m);
+
 				runtime.setLocale("en");
 
 				expect(m.sad_penguin_bundle()).toBe("A simple message.");
@@ -480,7 +482,6 @@ describe.each([
 					`export * as m from "./paraglide/messages.js"
 					export * as runtime from "./paraglide/runtime.js"`
 				);
-
 				const { m, runtime } = await importCode(code);
 
 				runtime.setLocale("de");
@@ -793,10 +794,6 @@ describe.each([
 		});
 
 		test("case sensitivity handling for bundle IDs", async () => {
-			// skip local modules for now because the option might get removed in the future
-			if (compilerOptions.outputStructure === "locale-modules") {
-				return;
-			}
 			const project = await loadProjectInMemory({
 				blob: await newProject({
 					settings: { locales: ["en"], baseLocale: "en" },

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.test.ts
@@ -117,6 +117,7 @@ test("should handle case sensitivity in message IDs correctly", () => {
 	const output = generateOutput(bundles, settings, fallbackMap);
 
 	// Check that the output exists
+	expect(output).toHaveProperty("messages/_index.js");
 	expect(output).toHaveProperty("messages/en.js");
 
 	// The exported constants should not conflict

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.ts
@@ -3,27 +3,8 @@ import type { CompiledBundleWithMessages } from "../compile-bundle.js";
 import { toSafeModuleId } from "../safe-module-id.js";
 import { inputsType } from "../jsdoc-types.js";
 
-// Helper function to escape special characters in a string for use in a regular expression
-function escapeRegExp(string: string) {
-	return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-// This map will be used to track which bundle IDs have been renamed to which unique IDs
-// It will be populated during the generateOutput function and used in messageReferenceExpression
-const bundleIdToUniqueIdMap = new Map<string, string>();
-
 export function messageReferenceExpression(locale: string, bundleId: string) {
-	// First convert to safe module ID
-	const safeModuleId = toSafeModuleId(bundleId);
-
-	// Check if this bundleId has been mapped to a unique identifier
-	const uniqueId = bundleIdToUniqueIdMap.get(bundleId);
-	if (uniqueId) {
-		return `${toSafeModuleId(locale)}.${uniqueId}`;
-	}
-
-	// Otherwise, return the default safe module ID
-	return `${toSafeModuleId(locale)}.${safeModuleId}`;
+	return `${toSafeModuleId(locale)}.${toSafeModuleId(bundleId)}`;
 }
 
 export function generateOutput(
@@ -31,63 +12,6 @@ export function generateOutput(
 	settings: Pick<ProjectSettings, "locales" | "baseLocale">,
 	fallbackMap: Record<string, string | undefined>
 ): Record<string, string> {
-	// Create a map to track module IDs in the index file to avoid duplicates
-	const indexModuleIdMap = new Map<string, string>();
-
-	// Process the bundles to ensure no duplicate bundle IDs
-	// Generate unique moduleIds for duplicate IDs
-	const processedBundleCodes = compiledBundles
-		.map(({ bundle }) => {
-			const bundleId = bundle.node.id;
-			const bundleModuleId = toSafeModuleId(bundleId);
-
-			// Check if this safe module ID has been used before
-			if (indexModuleIdMap.has(bundleModuleId)) {
-				// Create a unique identifier by adding a counter
-				let counter = 1;
-				let uniqueModuleId = `${bundleModuleId}${counter}`;
-
-				while (indexModuleIdMap.has(uniqueModuleId)) {
-					counter++;
-					uniqueModuleId = `${bundleModuleId}${counter}`;
-				}
-
-				// Modify the code to use the unique identifier
-				const modifiedCode = bundle.code
-					.replace(
-						new RegExp(`const ${bundleModuleId} =`, "g"),
-						`const ${uniqueModuleId} =`
-					)
-					.replace(
-						new RegExp(`export const ${bundleModuleId} =`, "g"),
-						`export const ${uniqueModuleId} =`
-					)
-					.replace(
-						new RegExp(`export { ${bundleModuleId}`, "g"),
-						`export { ${uniqueModuleId}`
-					)
-					.replace(
-						// Also update the trackMessageCall to use the new identifier
-						new RegExp(`trackMessageCall\\("${escapeRegExp(bundleId)}"`, "g"),
-						`trackMessageCall("${bundleId}"`
-					);
-
-				// Store the unique ID mapping
-				indexModuleIdMap.set(uniqueModuleId, bundleId);
-
-				// Also store in the global map for messageReferenceExpression to use
-				bundleIdToUniqueIdMap.set(bundleId, uniqueModuleId);
-
-				return modifiedCode;
-			}
-
-			// Store the mapping
-			indexModuleIdMap.set(bundleModuleId, bundleId);
-
-			return bundle.code;
-		})
-		.join("\n");
-
 	const indexFile = [
 		`import { getLocale, trackMessageCall, experimentalMiddlewareLocaleSplitting, isServer } from "../runtime.js"`,
 		settings.locales
@@ -96,7 +20,7 @@ export function generateOutput(
 					`import * as ${toSafeModuleId(locale)} from "./${locale}.js"`
 			)
 			.join("\n"),
-		processedBundleCodes,
+		compiledBundles.map(({ bundle }) => bundle.code).join("\n"),
 	].join("\n");
 
 	const output: Record<string, string> = {
@@ -108,29 +32,10 @@ export function generateOutput(
 		const filename = `messages/${locale}.js`;
 		let file = "";
 
-		// Keep track of module IDs to avoid duplicates
-		const moduleIdMap = new Map<string, string>();
-
 		for (const compiledBundle of compiledBundles) {
 			const compiledMessage = compiledBundle.messages[locale];
-			const bundleId = compiledBundle.bundle.node.id;
 			const bundleModuleId = toSafeModuleId(compiledBundle.bundle.node.id);
-
-			// Check if this module ID has already been used
-			let uniqueModuleId = bundleModuleId;
-			if (moduleIdMap.has(bundleModuleId)) {
-				// If it has, create a unique ID by adding an index
-				let counter = 1;
-				uniqueModuleId = `${bundleModuleId}${counter}`;
-				while (moduleIdMap.has(uniqueModuleId)) {
-					counter++;
-					uniqueModuleId = `${bundleModuleId}${counter}`;
-				}
-			}
-
-			// Store this module ID
-			moduleIdMap.set(uniqueModuleId, bundleId);
-
+			const bundleId = compiledBundle.bundle.node.id;
 			const inputs =
 				compiledBundle.bundle.node.declarations?.filter(
 					(decl) => decl.type === "input-variable"
@@ -139,15 +44,15 @@ export function generateOutput(
 				const fallbackLocale = fallbackMap[locale];
 				if (fallbackLocale) {
 					// use the fall back locale e.g. render the message in English if the German message is missing
-					file += `\nexport { ${uniqueModuleId} } from "./${fallbackLocale}.js"`;
+					file += `\nexport { ${bundleModuleId} } from "./${fallbackLocale}.js"`;
 				} else {
 					// no fallback exists, render the bundleId
-					file += `\n/** @type {(inputs: ${inputsType(inputs)}) => string} */\nexport const ${uniqueModuleId} = () => '${bundleId}'`;
+					file += `\n/** @type {(inputs: ${inputsType(inputs)}) => string} */ */\nexport const ${bundleModuleId} = () => '${bundleId}'`;
 				}
 				continue;
 			}
 
-			file += `\n\nexport const ${uniqueModuleId} = ${compiledMessage.code}`;
+			file += `\n\nexport const ${bundleModuleId} = ${compiledMessage.code}`;
 		}
 
 		// add import if used

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/message-modules.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/message-modules.test.ts
@@ -81,6 +81,6 @@ test("handles case senstivity by creating directories and files only in lowercas
 
 	// expecting only lowercase directories and files
 	expect(output).toHaveProperty("messages/happyelephant.js");
-	expect(output).toHaveProperty("messages/happyelephant1.js");
+	expect(output).toHaveProperty("messages/happyelephant2.js");
 	expect(output).not.toHaveProperty("messages/HappyElephant.js");
 });

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/message-modules.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/message-modules.ts
@@ -19,23 +19,16 @@ export function generateOutput(
 
 	for (const compiledBundle of compiledBundles) {
 		const bundleId = compiledBundle.bundle.node.id;
-		const safeBundleId = toSafeModuleId(compiledBundle.bundle.node.id);
+		const safeModuleId = toSafeModuleId(compiledBundle.bundle.node.id);
 		const inputs =
 			compiledBundle.bundle.node.declarations?.filter(
 				(decl) => decl.type === "input-variable"
 			) ?? [];
 
 		// bundle file
-		let filename = `messages/${safeBundleId}.js`;
+		const filename = `messages/${safeModuleId}.js`;
 
-		let counter = 0;
-		while (output[filename]) {
-			// bundle file already exists, need to append to it
-			counter += 1;
-			filename = `messages/${safeBundleId}${counter}.js`;
-		}
-
-		moduleFilenames.add(`${safeBundleId}${counter ? counter : ""}.js`);
+		moduleFilenames.add(`${safeModuleId}.js`);
 
 		// create fresh bundle file
 		output[filename] = compiledBundle.bundle.code;
@@ -53,7 +46,7 @@ export function generateOutput(
 				needsFallback.push(locale);
 			} else {
 				messages.push(
-					`const ${safeLocale}_${safeBundleId} = ${compiledMessage.code}`
+					`const ${safeLocale}_${safeModuleId} = ${compiledMessage.code}`
 				);
 			}
 		}
@@ -68,12 +61,12 @@ export function generateOutput(
 				const safeFallbackLocale = toSafeModuleId(fallbackLocale);
 				// take the fallback locale
 				messages.push(
-					`/** @type {(inputs: ${inputsType(inputs)}) => string} */\nconst ${safeLocale}_${safeBundleId} = ${safeFallbackLocale}_${safeBundleId};`
+					`/** @type {(inputs: ${inputsType(inputs)}) => string} */\nconst ${safeLocale}_${safeModuleId} = ${safeFallbackLocale}_${safeModuleId};`
 				);
 			} else {
 				// fallback to just the bundle id
 				messages.push(
-					`/** @type {(inputs: ${inputsType(inputs)}) => string} */\nconst ${safeLocale}_${safeBundleId} = () => '${escapeForSingleQuoteString(
+					`/** @type {(inputs: ${inputsType(inputs)}) => string} */\nconst ${safeLocale}_${safeModuleId} = () => '${escapeForSingleQuoteString(
 						bundleId
 					)}'`
 				);

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/safe-module-id.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/safe-module-id.test.ts
@@ -2,16 +2,16 @@ import { test, expect } from "vitest";
 import { toSafeModuleId } from "./safe-module-id.js";
 
 test("handles emojis (because why not)", () => {
-	expect(toSafeModuleId("helloWorld🍌")).toBe("helloworld__");
+	expect(toSafeModuleId("helloWorld🍌")).toBe("helloworld__1");
 });
 
 // https://github.com/opral/inlang-paraglide-js/issues/395
 test("makes everything lowercase", () => {
-	expect(toSafeModuleId("HelloWorld")).toBe("helloworld");
+	expect(toSafeModuleId("HelloWorld")).toBe("helloworld2");
 });
 
 test('escapes "-" to "_"', () => {
-	expect(toSafeModuleId("de-DE-bavaria")).toBe("de_de_bavaria");
+	expect(toSafeModuleId("de-DE-bavaria")).toBe("de_de_bavaria2");
 });
 
 test("prefixes with _ if it starts with a number", () => {
@@ -35,4 +35,10 @@ test("transforms js reserved keywords", async () => {
 	expect(toSafeModuleId("let")).toBe("_let");
 	// https://github.com/opral/inlang-paraglide-js/issues/331
 	expect(toSafeModuleId("then")).toBe("_then");
+});
+
+test("adds an uppercase counter for de-duplication", async () => {
+	expect(toSafeModuleId("helloworld")).toBe("helloworld");
+	expect(toSafeModuleId("helloWorld")).toBe("helloworld1");
+	expect(toSafeModuleId("HelloWorld")).toBe("helloworld2");
 });

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/safe-module-id.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/safe-module-id.ts
@@ -14,7 +14,14 @@ export function toSafeModuleId(id: string): string {
 		return "_" + result;
 	}
 
-	return result;
+	let numUppercase = 0;
+	for (const char of id) {
+		if (char.match(/[A-Z]/)) {
+			numUppercase++;
+		}
+	}
+
+	return result + (numUppercase > 0 ? `${numUppercase}` : "");
 }
 
 export function isSafeModuleId(id: string): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1857,6 +1857,8 @@ importers:
         specifier: 2.1.8
         version: 2.1.8(@types/node@20.5.9)(@vitest/browser@2.1.8)(jsdom@25.0.1)(lightningcss@1.29.1)(msw@2.7.0(@types/node@20.5.9)(typescript@5.7.2))(terser@5.36.0)
 
+  inlang/packages/website/dist/server: {}
+
   inlang/packages/website/tailwind-color-plugin:
     dependencies:
       '@ctrl/tinycolor':


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/490

Case sensitive ids led to duplicate exports in the locale module output. This has been fixed by adjusting the `toSafeModuleId()` used by the compiler internally to append a number of uppercase characters to de-duplicate the ids.

```diff
toSafeModuleId("helloworld")
 "helloworld"

toSafeModuleId("helloWorld")
- "helloworld"
+ "helloworld1"
```