### PR TITLE
fix: [2.0.8] Adds extra \*/ in generated .js files

### DIFF
--- a/.changeset/tender-jobs-cheer.md
+++ b/.changeset/tender-jobs-cheer.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix: [2.0.8] Adds extra \*/ in generated .js files https://github.com/opral/inlang-paraglide-js/issues/493

--- a/inlang/packages/paraglide/paraglide-js/examples/vite/package.json
+++ b/inlang/packages/paraglide/paraglide-js/examples/vite/package.json
@@ -5,9 +5,8 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build",
-		"clean": "rm -rf ./dist ./node_modules ./src/paraglide",
-		"test": "tsc --noEmit"
+		"build": "vite build && tsc --noEmit",
+		"clean": "rm -rf ./dist ./node_modules ./src/paraglide"
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "workspace:*",

--- a/inlang/packages/paraglide/paraglide-js/examples/vite/package.json
+++ b/inlang/packages/paraglide/paraglide-js/examples/vite/package.json
@@ -5,8 +5,9 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build && tsc --noEmit",
-		"clean": "rm -rf ./dist ./node_modules ./src/paraglide"
+		"build": "vite build",
+		"clean": "rm -rf ./dist ./node_modules ./src/paraglide",
+		"test": "tsc --noEmit"
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "workspace:*",

--- a/inlang/packages/paraglide/paraglide-js/examples/vite/vite.config.js
+++ b/inlang/packages/paraglide/paraglide-js/examples/vite/vite.config.js
@@ -6,6 +6,9 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: "./project.inlang",
 			outdir: "./src/paraglide",
+			// forcing locale modules to detect problems during CI/CD
+			// (all other projects use message-modules)
+			outputStructure: "locale-modules",
 		}),
 	],
 	build: {

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/output-structure/locale-modules.ts
@@ -47,7 +47,7 @@ export function generateOutput(
 					file += `\nexport { ${bundleModuleId} } from "./${fallbackLocale}.js"`;
 				} else {
 					// no fallback exists, render the bundleId
-					file += `\n/** @type {(inputs: ${inputsType(inputs)}) => string} */ */\nexport const ${bundleModuleId} = () => '${bundleId}'`;
+					file += `\n/** @type {(inputs: ${inputsType(inputs)}) => string} */\nexport const ${bundleModuleId} = () => '${bundleId}'`;
 				}
 				continue;
 			}


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/493