### PR TITLE
feat: add domain property to cookie options

### DIFF
--- a/.changeset/seven-ways-kiss.md
+++ b/.changeset/seven-ways-kiss.md
@@ -1,0 +1,13 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Add domain property to cookie options.
+
+```diff
+paraglideVitePlugin({
+  project: './project.inlang',
+  outdir: "./src/paraglide",
++ cookieDomain: 'example.com'
+}),
+```

--- a/inlang/packages/paraglide/paraglide-js/docs-api/compiler-options.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/compiler-options.md
@@ -2,7 +2,7 @@
 
 > **CompilerOptions**: `object`
 
-Defined in: [compiler-options.ts:18](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:19](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 ### Type declaration
 
@@ -44,6 +44,20 @@ Whether to clean the output directory before writing the new files.
 
 ```ts
 true
+```
+
+#### cookieDomain?
+
+> `optional` **cookieDomain**: `string`
+
+The host to which the cookie will be sent.
+If null, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
+Otherwise, subdomains are always included.
+
+##### Default
+
+```ts
+window.location.hostname
 ```
 
 #### cookieMaxAge?
@@ -327,6 +341,10 @@ Defined in: [compiler-options.ts:3](https://github.com/opral/monorepo/tree/main/
 #### cleanOutdir
 
 > `readonly` **cleanOutdir**: `true` = `true`
+
+#### cookieDomain
+
+> `readonly` **cookieDomain**: `""` = `""`
 
 #### cookieMaxAge
 

--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
@@ -10,7 +10,7 @@ Defined in: [runtime/ambient.d.ts:10](https://github.com/opral/monorepo/tree/mai
 
 > **ParaglideAsyncLocalStorage**\<\>: `object`
 
-Defined in: [runtime/variables.js:51](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:54](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
 
 ### Type Parameters
 
@@ -90,7 +90,7 @@ Defined in: [runtime/variables.js:22](https://github.com/opral/monorepo/tree/mai
 
 > `const` **disableAsyncLocalStorage**: `false` = `false`
 
-Defined in: [runtime/variables.js:64](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:67](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
 
 ***
 
@@ -98,7 +98,7 @@ Defined in: [runtime/variables.js:64](https://github.com/opral/monorepo/tree/mai
 
 > `const` **experimentalMiddlewareLocaleSplitting**: `false` = `false`
 
-Defined in: [runtime/variables.js:66](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:69](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
 
 ***
 
@@ -106,7 +106,7 @@ Defined in: [runtime/variables.js:66](https://github.com/opral/monorepo/tree/mai
 
 > `const` **isServer**: `boolean`
 
-Defined in: [runtime/variables.js:68](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:71](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
 
 ***
 
@@ -132,7 +132,7 @@ if (locales.includes(userSelectedLocale) === false) {
 
 > **serverAsyncLocalStorage**: `undefined` \| [`ParaglideAsyncLocalStorage`](-internal-.md#paraglideasynclocalstorage) = `undefined`
 
-Defined in: [runtime/variables.js:62](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:65](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
 
 Server side async local storage that is set by `serverMiddleware()`.
 
@@ -145,7 +145,7 @@ rendering context without effecting other requests.
 
 > `const` **strategy**: (`"cookie"` \| `"baseLocale"` \| `"globalVariable"` \| `"url"` \| `"preferredLanguage"` \| `"localStorage"`)[]
 
-Defined in: [runtime/variables.js:33](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:36](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
 
 ***
 
@@ -153,7 +153,7 @@ Defined in: [runtime/variables.js:33](https://github.com/opral/monorepo/tree/mai
 
 > `const` **urlPatterns**: `object`[] = `[]`
 
-Defined in: [runtime/variables.js:40](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:43](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
 
 The used URL patterns.
 
@@ -693,7 +693,7 @@ define how the URL origin is resolved.
 
 > **overwriteServerAsyncLocalStorage**(`value`): `void`
 
-Defined in: [runtime/variables.js:80](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
+Defined in: [runtime/variables.js:83](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js)
 
 Sets the server side async local storage.
 
@@ -718,7 +718,7 @@ avoid a circular import between `runtime.js` and
 
 > **overwriteSetLocale**(`fn`): `void`
 
-Defined in: [runtime/set-locale.js:120](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:124](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
 
 Overwrite the `setLocale()` function.
 
@@ -750,7 +750,7 @@ overwriteSetLocale((newLocale) => {
 
 > **setLocale**(`newLocale`, `options`?): `void`
 
-Defined in: [runtime/set-locale.js:31](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:32](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
 
 Set the locale.
 

--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/-internal-.md
@@ -718,7 +718,7 @@ avoid a circular import between `runtime.js` and
 
 > **overwriteSetLocale**(`fn`): `void`
 
-Defined in: [runtime/set-locale.js:124](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:128](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js)
 
 Overwrite the `setLocale()` function.
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
@@ -13,6 +13,7 @@ export const defaultCompilerOptions = {
 	strategy: ["cookie", "globalVariable", "baseLocale"],
 	cookieName: "PARAGLIDE_LOCALE",
 	cookieMaxAge: 60 * 60 * 24 * 400,
+	cookieDomain: "",
 } as const satisfies Partial<CompilerOptions>;
 
 export type CompilerOptions = {
@@ -103,6 +104,14 @@ export type CompilerOptions = {
 	 * @default 60 * 60 * 24 * 400
 	 */
 	cookieMaxAge?: number;
+	/**
+	 * The host to which the cookie will be sent.
+	 * If null, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
+	 * Otherwise, subdomains are always included.
+	 *
+	 * @default window.location.hostname
+	 */
+	cookieDomain?: string;
 	/**
 	 * The `additionalFiles` option is an array of paths to additional files that should be copied to the output directory.
 	 *

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/create-runtime.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/create-runtime.ts
@@ -11,6 +11,7 @@ export function createRuntimeFile(args: {
 		strategy: NonNullable<CompilerOptions["strategy"]>;
 		cookieName: NonNullable<CompilerOptions["cookieName"]>;
 		cookieMaxAge: NonNullable<CompilerOptions["cookieMaxAge"]>;
+		cookieDomain: CompilerOptions["cookieDomain"];
 		urlPatterns?: CompilerOptions["urlPatterns"];
 		experimentalMiddlewareLocaleSplitting: CompilerOptions["experimentalMiddlewareLocaleSplitting"];
 		isServer: CompilerOptions["isServer"];
@@ -63,6 +64,7 @@ ${injectCode("./variables.js")
 	)
 	.replace(`<cookie-name>`, `${args.compilerOptions.cookieName}`)
 	.replace(`60 * 60 * 24 * 400`, `${args.compilerOptions.cookieMaxAge}`)
+	.replace(`<cookie-domain>`, `${args.compilerOptions.cookieDomain}`)
 	.replace(
 		`export const TREE_SHAKE_COOKIE_STRATEGY_USED = false;`,
 		`const TREE_SHAKE_COOKIE_STRATEGY_USED = ${args.compilerOptions.strategy.includes("cookie")};`

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/get-locale.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/get-locale.test.ts
@@ -214,6 +214,7 @@ test("initially sets the locale after resolving it for the first time", async ()
 	globalThis.window = {
 		// @ts-expect-error - global variable definition
 		location: {
+			hostname: "example.com",
 			href: "https://example.com/de/page",
 		},
 	};
@@ -227,7 +228,7 @@ test("initially sets the locale after resolving it for the first time", async ()
 	expect(runtime.getLocale()).toBe("de");
 	// Cookie should be set, proving that the locale was initially set
 	expect(globalThis.document.cookie).toBe(
-		"PARAGLIDE_LOCALE=de; path=/; max-age=34560000"
+		"PARAGLIDE_LOCALE=de; path=/; max-age=34560000; domain=example.com"
 	);
 	expect(globalThis.window.location.href).toBe("https://example.com/de/page");
 });

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js
@@ -53,7 +53,11 @@ export let setLocale = (newLocale, options) => {
 			// is likely overwritten by `defineSetLocale()`
 			_locale = newLocale;
 		} else if (TREE_SHAKE_COOKIE_STRATEGY_USED && strat === "cookie") {
-			if (isServer || typeof document === "undefined") {
+			if (
+				isServer ||
+				typeof document === "undefined" ||
+				typeof window === "undefined"
+			) {
 				continue;
 			}
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js
@@ -3,6 +3,7 @@ import { localizeUrl } from "./localize-url.js";
 import {
 	cookieMaxAge,
 	cookieName,
+	cookieDomain,
 	isServer,
 	localStorageKey,
 	strategy,
@@ -55,8 +56,11 @@ export let setLocale = (newLocale, options) => {
 			if (isServer || typeof document === "undefined") {
 				continue;
 			}
+
+			const domain = cookieDomain || window.location.hostname;
+
 			// set the cookie
-			document.cookie = `${cookieName}=${newLocale}; path=/; max-age=${cookieMaxAge}`;
+			document.cookie = `${cookieName}=${newLocale}; path=/; max-age=${cookieMaxAge}; domain=${domain}`;
 		} else if (strat === "baseLocale") {
 			// nothing to be set here. baseLocale is only a fallback
 			continue;

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.test.ts
@@ -8,7 +8,7 @@ test("sets the cookie to a different locale", async () => {
 	// @ts-expect-error - global variable definition
 	globalThis.window = {};
 	// @ts-expect-error - global variable definition
-	globalThis.window.location = {};
+	globalThis.window.location = { hostname: "example.com" };
 	globalThis.window.location.reload = vi.fn();
 
 	const runtime = await createParaglide({
@@ -30,7 +30,77 @@ test("sets the cookie to a different locale", async () => {
 
 	// set the locale
 	expect(globalThis.document.cookie).toBe(
-		"PARAGLIDE_LOCALE=de; path=/; max-age=34560000"
+		"PARAGLIDE_LOCALE=de; path=/; max-age=34560000; domain=example.com"
+	);
+	// reloads the site if window is available
+	expect(globalThis.window.location.reload).toBeCalled();
+});
+
+test("sets the cookie with explicit domain to a different locale navigating subdomain", async () => {
+	// @ts-expect-error - global variable definition
+	globalThis.document = {};
+	// @ts-expect-error - global variable definition
+	globalThis.window = {};
+	// @ts-expect-error - global variable definition
+	globalThis.window.location = { hostname: "web.example.com" };
+	globalThis.window.location.reload = vi.fn();
+
+	const runtime = await createParaglide({
+		project: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		compilerOptions: {
+			strategy: ["cookie"],
+			cookieName: "PARAGLIDE_LOCALE",
+			cookieDomain: "example.com",
+		},
+	});
+
+	globalThis.document.cookie = "PARAGLIDE_LOCALE=en";
+
+	runtime.setLocale("de");
+
+	// set the locale
+	expect(globalThis.document.cookie).toBe(
+		"PARAGLIDE_LOCALE=de; path=/; max-age=34560000; domain=example.com"
+	);
+	// reloads the site if window is available
+	expect(globalThis.window.location.reload).toBeCalled();
+});
+
+test("sets the cookie with explicit domain to a different locale navigating domain", async () => {
+	// @ts-expect-error - global variable definition
+	globalThis.document = {};
+	// @ts-expect-error - global variable definition
+	globalThis.window = {};
+	// @ts-expect-error - global variable definition
+	globalThis.window.location = { hostname: "example.com" };
+	globalThis.window.location.reload = vi.fn();
+
+	const runtime = await createParaglide({
+		project: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		compilerOptions: {
+			strategy: ["cookie"],
+			cookieName: "PARAGLIDE_LOCALE",
+			cookieDomain: "example.com",
+		},
+	});
+
+	globalThis.document.cookie = "PARAGLIDE_LOCALE=en";
+
+	runtime.setLocale("de");
+
+	// set the locale
+	expect(globalThis.document.cookie).toBe(
+		"PARAGLIDE_LOCALE=de; path=/; max-age=34560000; domain=example.com"
 	);
 	// reloads the site if window is available
 	expect(globalThis.window.location.reload).toBeCalled();
@@ -92,7 +162,7 @@ test("sets the cookie when it's an empty string", async () => {
 	runtime.setLocale("en");
 
 	expect(globalThis.document.cookie).toBe(
-		"PARAGLIDE_LOCALE=en; path=/; max-age=34560000"
+		"PARAGLIDE_LOCALE=en; path=/; max-age=34560000; domain=example.com"
 	);
 });
 
@@ -132,7 +202,7 @@ test("when strategy precedes URL, it should set the locale and re-direct to the 
 	runtime.setLocale("en");
 
 	expect(globalThis.document.cookie).toBe(
-		"PARAGLIDE_LOCALE=en; path=/; max-age=34560000"
+		"PARAGLIDE_LOCALE=en; path=/; max-age=34560000; domain=example.com"
 	);
 	expect(globalThis.window.location.href).toBe(
 		"https://example.com/en/some-path"
@@ -146,7 +216,7 @@ test("should not reload when setting locale to current locale", async () => {
 	// @ts-expect-error - global variable definition
 	globalThis.window = {};
 	// @ts-expect-error - global variable definition
-	globalThis.window.location = {};
+	globalThis.window.location = { hostname: "example.com" };
 	globalThis.window.location.reload = vi.fn();
 
 	const runtime = await createParaglide({
@@ -169,7 +239,7 @@ test("should not reload when setting locale to current locale", async () => {
 
 	// Cookie should remain unchanged
 	expect(globalThis.document.cookie).toBe(
-		"PARAGLIDE_LOCALE=en; path=/; max-age=34560000"
+		"PARAGLIDE_LOCALE=en; path=/; max-age=34560000; domain=example.com"
 	);
 	// Should not trigger a reload
 	expect(globalThis.window.location.reload).not.toBeCalled();
@@ -177,7 +247,7 @@ test("should not reload when setting locale to current locale", async () => {
 	// Setting to a different locale should still work
 	runtime.setLocale("de");
 	expect(globalThis.document.cookie).toBe(
-		"PARAGLIDE_LOCALE=de; path=/; max-age=34560000"
+		"PARAGLIDE_LOCALE=de; path=/; max-age=34560000; domain=example.com"
 	);
 	expect(globalThis.window.location.reload).toBeCalled();
 });
@@ -264,6 +334,6 @@ test("should set locale in all configured storage mechanisms regardless of which
 		"fr"
 	);
 	expect(globalThis.document.cookie).toBe(
-		"PARAGLIDE_LOCALE=fr; path=/; max-age=34560000"
+		"PARAGLIDE_LOCALE=fr; path=/; max-age=34560000; domain=example.com"
 	);
 });

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/variables.js
@@ -25,6 +25,9 @@ export const cookieName = "<cookie-name>";
 export const cookieMaxAge = 60 * 60 * 24 * 400;
 
 /** @type {string} */
+export const cookieDomain = "<cookie-domain>";
+
+/** @type {string} */
 export const localStorageKey = "PARAGLIDE_LOCALE";
 
 /**


### PR DESCRIPTION
Add domain property to cookie options.

```diff
paraglideVitePlugin({
  project: './project.inlang',
  outdir: "./src/paraglide",
+ cookieDomain: 'example.com'
}),
```
