### PR TITLE
fix README.md typing error on paraglide name

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/examples/astro/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/astro/README.md
@@ -51,7 +51,7 @@ export default defineConfig({
 ### 3. Create or add the paraglide js server middleware to the `src/middleware.ts` file:
 
 ```diff
-import { paraglideMiddleware } from "./paralide/server.js";
+import { paraglideMiddleware } from "./paraglide/server.js";
 
 export const onRequest = defineMiddleware((context, next) => {
 +	return paraglideMiddleware(context.request, () => next());


### PR DESCRIPTION
fix a typo on paraglide import in the astro middleware