### PR TITLE
Clarify undefined value in cookieDomain documentation

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/docs-api/compiler-options.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/compiler-options.md
@@ -51,7 +51,7 @@ true
 > `optional` **cookieDomain**: `string`
 
 The host to which the cookie will be sent.
-If null, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
+If undefined, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
 Otherwise, subdomains are always included.
 
 ##### Default

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
@@ -106,7 +106,7 @@ export type CompilerOptions = {
 	cookieMaxAge?: number;
 	/**
 	 * The host to which the cookie will be sent.
-	 * If null, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
+	 * If undefined, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
 	 * Otherwise, subdomains are always included.
 	 *
 	 * @default window.location.hostname


### PR DESCRIPTION
Setting `cookieDomain` to `null` will throw `Type 'null' is not assignable to type 'string | undefined'.ts(2322)`. So it seems that the correct wording is to say `If undefined`