### PR TITLE
Memoize extractLocaleFromUrl

### DIFF
--- a/.changeset/spicy-rats-greet.md
+++ b/.changeset/spicy-rats-greet.md
@@ -1,0 +1,7 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+`extractLocaleFromUrl()` now uses a cache for the last value.
+
+Useful on the client-side where the same URL is being extracted many times for each message on a given page.

--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/type/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/type/-internal-.md
@@ -203,7 +203,7 @@ If the input is not a locale.
 
 > **deLocalizeHref**(`href`): `string`
 
-Defined in: [runtime/localize-href.js:104](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js)
+Defined in: [runtime/localize-href.js:105](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js)
 
 High-level URL de-localization function optimized for client-side UI usage.
 
@@ -369,7 +369,7 @@ const locale = extractLocaleFromRequest(request);
 
 > **extractLocaleFromUrl**(`url`): `any`
 
-Defined in: [runtime/extract-locale-from-url.js:15](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-url.js)
+Defined in: [runtime/extract-locale-from-url.js:26](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-url.js)
 
 Extracts the locale from a given URL using native URLPattern.
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-url.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/extract-locale-from-url.js
@@ -25,11 +25,11 @@ let cachedLocale;
  */
 export function extractLocaleFromUrl(url) {
 	const urlString = typeof url === "string" ? url : url.href;
-	
+
 	if (cachedUrl === urlString) {
 		return cachedLocale;
 	}
-	
+
 	let result;
 	if (TREE_SHAKE_DEFAULT_URL_PATTERN_USED) {
 		result = defaultUrlPatternExtractLocale(url);
@@ -56,7 +56,7 @@ export function extractLocaleFromUrl(url) {
 			if (result) break;
 		}
 	}
-	
+
 	cachedUrl = urlString;
 	cachedLocale = result;
 	return result;

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/localize-href.js
@@ -41,17 +41,18 @@ import { deLocalizeUrl, localizeUrl } from "./localize-url.js";
  * @returns {string} The localized href, relative if input was relative
  */
 export function localizeHref(href, options) {
-	const locale = options?.locale ?? getLocale();
+	const currentLocale = getLocale();
+	const locale = options?.locale ?? currentLocale;
 	const url = new URL(href, getUrlOrigin());
 
-	const localized = localizeUrl(url, options);
+	const localized = localizeUrl(url, { locale });
 
 	// if the origin is identical and the href is relative,
 	// return the relative path
 	if (href.startsWith("/") && url.origin === localized.origin) {
 		// check for cross origin localization in which case an absolute URL must be returned.
-		if (locale !== getLocale()) {
-			const localizedCurrentLocale = localizeUrl(url, { locale: getLocale() });
+		if (locale !== currentLocale) {
+			const localizedCurrentLocale = localizeUrl(url, { locale: currentLocale });
 			if (localizedCurrentLocale.origin !== localized.origin) {
 				return localized.href;
 			}


### PR DESCRIPTION
As reported on [Discord](https://discord.com/channels/897438559458430986/1366763869464301672), I have a performance issue when navigating to a page with about 200 `localizeHref` calls. This comes from the repeated calls to `extractLocaleFromUrl` even if the URL and the extract locale is constant on a given page.

This PR adds a cache to memoize this function.