### PR TITLE
Add callbacks object to middleware

### DIFF
--- a/.changeset/eighty-chairs-agree.md
+++ b/.changeset/eighty-chairs-agree.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Add support for callbacks in server middleware

--- a/inlang/packages/paraglide/paraglide-js/docs-api/server/type/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/server/type/-internal-.md
@@ -42,9 +42,7 @@ Function to handle the request
 
 #### callbacks
 
-```ts
-{ onRedirect: (response: Response) => void }
-```
+{ `onRedirect`: (`response`: `Response`) => `void` }
 
 Callbacks to handle events from middleware
 - `onRedirect` calls when it's redirecting to a new url

--- a/inlang/packages/paraglide/paraglide-js/docs-api/server/type/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/server/type/-internal-.md
@@ -40,6 +40,15 @@ The incoming request object
 
 Function to handle the request
 
+#### callbacks
+
+```ts
+{ onRedirect: (response: Response) => void }
+```
+
+Callbacks to handle events from middleware
+- `onRedirect` calls when it's redirecting to a new url
+
 ### Returns
 
 `Promise`\<`Response`\>

--- a/inlang/packages/paraglide/paraglide-js/examples/react-router/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/react-router/README.md
@@ -39,6 +39,7 @@ Run the app and start translating. See the [basics documentation](/m/gerre34r/li
 
 ## Server side rendering using middleware
 
+In your middleware file:
 ```ts
 import { paraglideMiddleware } from "~/paraglide/server";
 import type { Route } from "../+types/root";
@@ -55,6 +56,13 @@ const localeMiddleware: Route.unstable_MiddlewareFunction = async (
 export { localeMiddleware };
 
 ```
+
+In `root.tsx`:
+```ts
+export const unstable_middleware = [localeMiddleware];
+```
+
+Now you can use `getLocale` function anywhere in your project.
 
 ## Server side rendering without middleware
 

--- a/inlang/packages/paraglide/paraglide-js/examples/react-router/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/react-router/README.md
@@ -37,12 +37,28 @@ export default defineConfig({
 
 Run the app and start translating. See the [basics documentation](/m/gerre34r/library-inlang-paraglideJs/basics) for information on how to use Paraglide's messages, parameters, and locale management.
 
-## Server side rendering
+## Server side rendering using middleware
 
+```ts
+import { paraglideMiddleware } from "~/paraglide/server";
+import type { Route } from "../+types/root";
+
+const localeMiddleware: Route.unstable_MiddlewareFunction = async (
+  { request },
+  next,
+) => {
+  return await paraglideMiddleware(request, () => {
+    return next();
+  }, { onRedirect: (response) => throw response });
+};
+
+export { localeMiddleware };
+
+```
+
+## Server side rendering without middleware
 
 If you use React Router v7 with SSR you will need to add the following code:
-
-<doc-callout type="info">The setup will be even easier when React Router receives middlewares which is expected to arrive in early 2025 https://github.com/remix-run/react-router/issues/12695</doc-callout>
 
 In `root.tsx`:
 

--- a/inlang/packages/paraglide/paraglide-js/examples/react-router/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/react-router/README.md
@@ -62,6 +62,31 @@ In `root.tsx`:
 export const unstable_middleware = [localeMiddleware];
 ```
 
+In `routes.ts`: 
+
+```diff
+import {
+	type RouteConfig,
+	index,
+	prefix,
+	route,
+} from "@react-router/dev/routes";
+
+export default [
+	// prefixing each path with an optional :locale
+	// optional to match a path with no locale `/page`
+	// or with a locale `/en/page`
+	//
+	// * make sure that the pattern you define here matches
+	// * with the urlPatterns of paraglide JS if you use
+	// * the `url` strategy
++	...prefix(":locale?", [
+		index("routes/home.tsx"),
+		route("about", "routes/about.tsx"),
++	]),
+] satisfies RouteConfig;
+```
+
 Now you can use `getLocale` function anywhere in your project.
 
 ## Server side rendering without middleware

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
@@ -1,6 +1,4 @@
-import * as runtime from "./runtime.js";
-
-/**
+import * as runtime from "./runtime.js"; /**
  * Server middleware that handles locale-based routing and request processing.
  *
  * This middleware performs several key functions:
@@ -19,7 +17,7 @@ import * as runtime from "./runtime.js";
  *
  * @param {Request} request - The incoming request object
  * @param {(args: { request: Request, locale: import("./runtime.js").Locale }) => T | Promise<T>} resolve - Function to handle the request
- *
+ * @param {{ onRedirect:(response: Response) => void }} [callbacks] - Callbacks to handle events from middleware
  * @returns {Promise<Response>}
  *
  * @example
@@ -61,7 +59,7 @@ import * as runtime from "./runtime.js";
  * };
  * ```
  */
-export async function paraglideMiddleware(request, resolve) {
+export async function paraglideMiddleware(request, resolve, callbacks) {
 	if (!runtime.disableAsyncLocalStorage && !runtime.serverAsyncLocalStorage) {
 		const { AsyncLocalStorage } = await import("async_hooks");
 		runtime.overwriteServerAsyncLocalStorage(new AsyncLocalStorage());
@@ -80,7 +78,9 @@ export async function paraglideMiddleware(request, resolve) {
 	) {
 		const localizedUrl = runtime.localizeUrl(request.url, { locale });
 		if (normalizeURL(localizedUrl.href) !== normalizeURL(request.url)) {
-			return Response.redirect(localizedUrl, 307);
+			const response = Response.redirect(localizedUrl, 307);
+			callbacks?.onRedirect(response);
+			return response;
 		}
 	}
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
@@ -1,4 +1,6 @@
-import * as runtime from "./runtime.js"; /**
+import * as runtime from "./runtime.js";
+
+/**
  * Server middleware that handles locale-based routing and request processing.
  *
  * This middleware performs several key functions:

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.test.ts
@@ -134,6 +134,104 @@ test("redirects to localized URL when non-URL strategy determines locale", async
 	);
 });
 
+test("call onRedirect callback when redirecting to new url", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "fr"],
+			},
+		}),
+		strategy: ["cookie", "url"],
+		cookieName: "PARAGLIDE_LOCALE",
+		urlPatterns: [
+			{
+				pattern: "https://example.com/:path(.*)?",
+				localized: [
+					["en", "https://example.com/en/:path(.*)?"],
+					["fr", "https://example.com/fr/:path(.*)?"],
+				],
+			},
+		],
+	});
+
+	// Request to URL in en with cookie specifying French
+	const request = new Request("https://example.com/en/some-path", {
+		headers: {
+			cookie: `PARAGLIDE_LOCALE=fr`,
+			"Sec-Fetch-Dest": "document",
+		},
+	});
+
+	let response: any;
+
+	await runtime.paraglideMiddleware(
+		request,
+		() => {
+			// This shouldn't be called since we should redirect
+			throw new Error("Should not reach here");
+		},
+		{
+			onRedirect: (res: Response) => {
+				response = res;
+			},
+		}
+	);
+
+	expect(response instanceof Response).toBe(true);
+	// needs to be 307 status code https://github.com/opral/inlang-paraglide-js/issues/416
+	expect(response.status).toBe(307); // Redirect status code
+	expect(response.headers.get("Location")).toBe(
+		"https://example.com/fr/some-path"
+	);
+});
+
+test("does not call onRedirect callback when there is no redirecting", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "fr"],
+			},
+		}),
+		strategy: ["cookie", "url"],
+		cookieName: "PARAGLIDE_LOCALE",
+		urlPatterns: [
+			{
+				pattern: "https://example.com/:path(.*)?",
+				localized: [
+					["en", "https://example.com/en/:path(.*)?"],
+					["fr", "https://example.com/fr/:path(.*)?"],
+				],
+			},
+		],
+	});
+
+	// Request to URL in en with cookie specifying French
+	const request = new Request("https://example.com/en/some-path", {
+		headers: {
+			cookie: `PARAGLIDE_LOCALE=en`,
+			"Sec-Fetch-Dest": "document",
+		},
+	});
+
+	let response: any = null;
+
+	await runtime.paraglideMiddleware(
+		request,
+		() => {
+			return new Response("Hello World");
+		},
+		{
+			onRedirect: (res: Response) => {
+				response = res;
+			},
+		}
+	);
+
+	expect(response).toBe(null);
+});
+
 test("does not redirect if URL already matches determined locale", async () => {
 	const runtime = await createParaglide({
 		blob: await newProject({

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.test.ts
@@ -208,9 +208,9 @@ test("does not call onRedirect callback when there is no redirecting", async () 
 	});
 
 	// Request to URL in en with cookie specifying French
-	const request = new Request("https://example.com/en/some-path", {
+	const request = new Request("https://example.com/fr/some-path", {
 		headers: {
-			cookie: `PARAGLIDE_LOCALE=en`,
+			cookie: `PARAGLIDE_LOCALE=fr`,
 			"Sec-Fetch-Dest": "document",
 		},
 	});


### PR DESCRIPTION
Add a new optional callbacks object to middleware input to be able to handle custom onRedirect event. Resolved issue #449.
