### PR TITLE
next-intl plugin support for multiple namespaces in usetranslations hooks

### DIFF
--- a/inlang/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/inlang/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
@@ -313,3 +313,35 @@ it("should add the defined namespace by useTranslations hook", async () => {
 	expect(matches).toHaveLength(1);
 	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
 });
+
+
+it("should correctly reference messages with multiple useTranslations hooks", async () => {
+	const sourceCode = `
+		const tOne = useTranslations("namespaceOne");
+		const tTwo = useTranslations("namespaceTwo");
+		const tThree = useTranslations("namespaceThree");
+		const tNested = useTranslations("nestedNamespace.section");
+
+		// Simulate usage of these translation functions
+		const message1 = tOne("messageKey1");
+		const message2 = tTwo("messageKey2");
+		const message3 = tThree("messageKey3");
+		const message4 = tNested("messageKey4");
+
+		// Interleaved usage
+		const message5 = tOne("anotherKey1");
+		const message6 = tTwo("anotherKey2");
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+
+	expect(matches).toHaveLength(6);
+	expect(matches[0]?.messageId).toBe("namespaceOne.messageKey1");
+	expect(matches[1]?.messageId).toBe("namespaceTwo.messageKey2");
+	expect(matches[2]?.messageId).toBe("namespaceThree.messageKey3");
+	expect(matches[3]?.messageId).toBe("nestedNamespace.section.messageKey4");
+	expect(matches[4]?.messageId).toBe("namespaceOne.anotherKey1");
+	expect(matches[5]?.messageId).toBe("namespaceTwo.anotherKey2");
+});

--- a/inlang/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
+++ b/inlang/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
@@ -2,16 +2,23 @@
 import Parsimmon from "parsimmon";
 import type { PluginSettings } from "../settings.js";
 
+type FunctionNameToNamespaces = Record<
+	string,
+	Array<{ ns: string; declarationPosition: number }>
+>;
+
 const createParser = (
 	settings: PluginSettings,
-	namespaces: Record<number, string>
+	functionNameToNamespaces: FunctionNameToNamespaces
 ) => {
 	return Parsimmon.createLanguage({
 		entry: (r) => {
 			return Parsimmon.alt(r.FunctionCall!, Parsimmon.any)
 				.many()
 				.map((matches) => {
-					return matches.filter((match) => typeof match === "object");
+					return matches.filter(
+						(match) => match !== null && typeof match === "object"
+					);
 				});
 		},
 
@@ -46,38 +53,41 @@ const createParser = (
 		FunctionCall: function (r) {
 			return Parsimmon.seqMap(
 				Parsimmon.regex(/[^a-zA-Z0-9]/), // no preceding letters or numbers
-				Parsimmon.string("t"), // starts with t
+				Parsimmon.regex(/(?!(?:use|get)Translations\b)[a-zA-Z_][a-zA-Z0-9_]*/), // Match function name (like 't') but exclude useTranslations/getTranslations which are handled separately
 				Parsimmon.string("("), // then an opening parenthesis
 				Parsimmon.index, // start position of the message id
 				r.stringLiteral!, // message id
 				Parsimmon.index, // end position of the message id
 				Parsimmon.regex(/[^)]*/), // ignore the rest of the function call
 				Parsimmon.string(")"), // end with a closing parenthesis
-				(_, __, ___, start, messageId, end) => {
-					// Find the most recent namespace defined before this message id
-					const nearestNamespace = Object.keys(namespaces)
-						.map(Number)
-						.filter((index) => index <= start.offset)
-						.sort((a, b) => b - a)[0];
-
-					if (nearestNamespace) {
-						const namespace = namespaces[nearestNamespace];
-
-						if (namespace && nearestNamespace) {
-							messageId = `${namespace}.${messageId}`;
-						}
+				(_, invokedFuncName, __, keyStartIndex, messageId, keyEndIndex) => {
+					// If the invoked function name is not "t" (our common case for global/default translations)
+					// AND it's not found in our map of explicitly namespaced translation functions,
+					// then we consider it not a match.
+					if (
+						invokedFuncName !== "t" &&
+						!functionNameToNamespaces[invokedFuncName]
+					) {
+						return null;
 					}
 
-					return {
+					const finalMessageId = getFinalMessageId(
+						invokedFuncName,
 						messageId,
+						keyStartIndex.offset,
+						functionNameToNamespaces
+					);
+
+					return {
+						messageId: finalMessageId,
 						position: {
 							start: {
-								line: start.line,
-								character: start.column,
+								line: keyStartIndex.line,
+								character: keyStartIndex.column,
 							},
 							end: {
-								line: end.line,
-								character: end.column,
+								line: keyEndIndex.line,
+								character: keyEndIndex.column,
 							},
 						},
 					};
@@ -93,7 +103,11 @@ const createNamespaceParser = () => {
 			return Parsimmon.alt(r.FunctionCall!, Parsimmon.any)
 				.many()
 				.map((matches) => {
-					return matches.filter((match) => typeof match === "object");
+					// Filter for matches that have varName and ns
+					return matches.filter(
+						(match) =>
+							typeof match === "object" && match && match.varName && match.ns
+					);
 				});
 		},
 
@@ -124,6 +138,34 @@ const createNamespaceParser = () => {
 		colon: (r) => {
 			return Parsimmon.string(":").trim(r.whitespace!);
 		},
+
+		identifier: () => Parsimmon.regex(/[a-zA-Z_][a-zA-Z0-9_]*/),
+
+		// Parser for variable name, supporting direct assignment and simple object destructuring like { t } or { t: alias }
+		variableDeclarationName: (r) =>
+			Parsimmon.alt(
+				r.identifier!, // Direct assignment: const t = ...
+				Parsimmon.seqMap(
+					// Destructured assignment: const { t } = ... or const { t: tc } = ...
+					Parsimmon.string("{"),
+					r.whitespace!,
+					r.identifier!, // Original name (e.g., 't')
+					Parsimmon.alt(
+						// Optional alias
+						Parsimmon.seqMap(
+							r.whitespace!,
+							Parsimmon.string(":"),
+							r.whitespace!,
+							r.identifier!,
+							(_, __, ___, alias) => alias
+						),
+						Parsimmon.succeed(null) // No alias
+					),
+					r.whitespace!,
+					Parsimmon.string("}"),
+					(_obr, _ws1, id, alias, _ws2, _cbr) => alias || id // Return alias if present, else original id
+				)
+			),
 
 		stringParser: () => {
 			return Parsimmon.alt(
@@ -181,47 +223,146 @@ const createNamespaceParser = () => {
 		},
 
 		FunctionCall: function (r) {
-			return Parsimmon.seqMap(
-				Parsimmon.regex(/[^a-zA-Z0-9]/), // no preceding letters or numbers
-				Parsimmon.regex(/\b(?:use|get)Translations\b/), // starts with useTranslations or getTranslations
-				Parsimmon.string("("), // then an opening parenthesis
-				Parsimmon.index, // start position of the message id
-				Parsimmon.alt(r.stringParser!, r.objectParser!),
-				Parsimmon.index, // end position of the message id
-				Parsimmon.regex(/[^)]*/), // ignore the rest of the function call
-				Parsimmon.string(")"), // end with a closing parenthesis
-				(_, __, ___, start, insideString, end) => {
-					let namespace = undefined;
+			// Parser for the useTranslations() or getTranslations() call itself
+			const useOrGetTranslationsCall = Parsimmon.seqMap(
+				// Parsimmon.regex(/\b(?:use|get)Translations\b/), // OLD: no await
+				Parsimmon.regex(/\b(?:await\s+)?(?:use|get)Translations\b/), // NEW: optional await
+				Parsimmon.string("("),
+				r.whitespace!,
+				Parsimmon.alt(r.stringParser!, r.objectParser!), // Namespace string or object
+				r.whitespace!,
+				Parsimmon.regex(/[^)]*/), // Ignore rest of args
+				Parsimmon.string(")"),
+				(_, __, ___, parsedArgument) => {
+					let namespace: string | undefined;
 
-					if (insideString.type === "string") {
-						namespace = insideString.value;
-					} else if (insideString && insideString.value.namespace) {
-						namespace = insideString.value.namespace;
+					// Case 1: Argument is a string literal e.g. useTranslations("myNamespace")
+					if (
+						parsedArgument.type === "string" &&
+						typeof parsedArgument.value === "string"
+					) {
+						namespace = parsedArgument.value;
 					}
-					return { ns: namespace, start: start.offset, end: end.offset };
+					// Case 2: Argument is an object e.g. useTranslations({ namespace: "myNamespace" })
+					else if (parsedArgument.type === "object") {
+						const optionsObject = parsedArgument.value; // This is the object like { namespace: "..." }
+						// Check if optionsObject exists and has a 'namespace' property that is a string
+						if (optionsObject && typeof optionsObject.namespace === "string") {
+							namespace = optionsObject.namespace;
+						}
+					}
+					return { namespace };
+				}
+			);
+
+			// Parser for the variable assignment: const myVar = useTranslations(...);
+			return Parsimmon.seqMap(
+				Parsimmon.index, // Capture the starting position of the declaration
+				Parsimmon.regex(/\b(?:const|let|var)\b\s+/), // Matches 'const ', 'let ', or 'var '
+				// r.identifier!, // The variable name (e.g., "tc", "t") // OLD: simple identifier
+				r.variableDeclarationName!, // NEW: supports destructuring { t } or direct t
+				r.whitespace!,
+				Parsimmon.string("="), // Equals sign
+				r.whitespace!,
+				useOrGetTranslationsCall, // The useTranslations() or getTranslations() call
+				// Callback function for seqMap
+				(declPosition, _keyword, varName, _ws1, _eq, _ws2, callDetails) => {
+					// callDetails is the result from useOrGetTranslationsCall, which is { namespace: "..." }
+					if (callDetails && typeof callDetails.namespace === "string") {
+						return {
+							varName: varName,
+							ns: callDetails.namespace,
+							declarationPosition: declPosition.offset, // Store the declaration position
+						};
+					}
+					return null; // Return null if parsing wasn't successful or namespace not found
 				}
 			);
 		},
 	});
 };
 
-function parseNameSpaces(sourceCode: string) {
+function parseNameSpaces(sourceCode: string): FunctionNameToNamespaces {
 	const namespaceParser = createNamespaceParser();
-	const namespaces = namespaceParser.entry!.tryParse(sourceCode);
-	const namespaceMap: Record<number, string> = {};
-	for (const nsObj of namespaces) {
-		if (nsObj.ns) {
-			namespaceMap[nsObj.start] = nsObj.ns;
+	// parsedDeclarations will be an array of { varName: string, ns: string, declarationPosition: number }
+	const parsedDeclarations = namespaceParser.entry!.tryParse(sourceCode);
+
+	const functionNameToNamespaces: FunctionNameToNamespaces = {};
+
+	for (const declaration of parsedDeclarations) {
+		// Ensure declaration is not null and has the expected properties
+		if (
+			declaration &&
+			declaration.varName &&
+			declaration.ns &&
+			typeof declaration.declarationPosition === "number"
+		) {
+			if (!functionNameToNamespaces[declaration.varName]) {
+				functionNameToNamespaces[declaration.varName] = [];
+			}
+			functionNameToNamespaces[declaration.varName]!.push({
+				ns: declaration.ns,
+				declarationPosition: declaration.declarationPosition,
+			});
 		}
 	}
-	return namespaceMap;
+
+	// Optionally sort declarations by position for potentially faster lookup, though linear scan is fine for few items.
+	for (const varName in functionNameToNamespaces) {
+		functionNameToNamespaces[varName]!.sort(
+			(a, b) => a.declarationPosition - b.declarationPosition
+		);
+	}
+
+	return functionNameToNamespaces;
 }
+
+/**
+ * Returns the fully qualified messageId by prepending the correct namespace, if available.
+ * Looks up the most recent namespace declaration for the given variable name that appears before the function call.
+ * If no suitable declaration is found, returns the original messageId.
+ */
+const getFinalMessageId = (
+	invokedFuncName: string,
+	messageId: string,
+	startOffset: number,
+	functionNameToNamespaces: FunctionNameToNamespaces
+): string => {
+	// Get all namespace declarations for the invoked function variable
+	const declarations = functionNameToNamespaces[invokedFuncName];
+	if (!declarations) return messageId; // No declarations found, return as is
+
+	// Track the most recent (latest) declaration before the function call
+	let latestDeclarationBeforeCall = null;
+	for (const declaration of declarations) {
+		// Skip declarations that appear after or at the function call
+		const isDeclarationAfterOrAtCall =
+			declaration.declarationPosition >= startOffset;
+		if (isDeclarationAfterOrAtCall) continue;
+
+		// If this is the first valid declaration, or it's closer to the function call than the previous one, update
+		const isFirstOrCloser =
+			latestDeclarationBeforeCall === null ||
+			declaration.declarationPosition >
+				latestDeclarationBeforeCall.declarationPosition;
+
+		if (isFirstOrCloser) {
+			latestDeclarationBeforeCall = declaration;
+		}
+	}
+
+	// If no valid declaration was found, return the original messageId
+	if (latestDeclarationBeforeCall === null) return messageId;
+	// Prepend the namespace to the messageId
+	return `${latestDeclarationBeforeCall.ns}.${messageId}`;
+};
 
 // Parse the expression
 export function parse(sourceCode: string, settings: PluginSettings) {
 	try {
-		const namespaces: Record<number, string> = parseNameSpaces(sourceCode);
-		const parser = createParser(settings, namespaces);
+		const functionNameToNamespaces = parseNameSpaces(sourceCode);
+
+		const parser = createParser(settings, functionNameToNamespaces);
 		const result = parser.entry!.tryParse(sourceCode);
 		return result;
 	} catch (error) {


### PR DESCRIPTION
## Enhanced Namespace Handling in Message Reference Matching

This update significantly improves how message references are matched when using multiple `useTranslations` or `getTranslations` calls with different namespaces within the same file or component. The parser can now accurately associate a translation function call (e.g., `t("messageKey")`) with its correct namespace, even when multiple such translation functions are defined with varying namespaces.

### New Functionality

The primary enhancement is the ability to correctly resolve message IDs in scenarios where multiple translation contexts (namespaces) are active. For example:

```typescript
// previously might have led to incorrect namespace association
const tOne = useTranslations("namespaceOne");
const tTwo = useTranslations("namespaceTwo");

// ...

tOne("greeting"); // Correctly resolves to "namespaceOne:greeting"
tTwo("farewell"); // Correctly resolves to "namespaceTwo:farewell"
```

The system now considers the declaration position of each `useTranslations` (or `getTranslations`) call and associates subsequent translation function calls with the most recent, relevant namespace declaration in scope.

### Code Changes

1.  **`inlang/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts`**:
    *   **`parseNameSpaces` function**:
        *   Modified to capture and store the `declarationPosition` (character offset in the source code) for each `useTranslations` and `getTranslations` declaration. This allows for determining which namespace was active at a specific point in the code.
    *   **`FunctionNameToNamespaces` type**:
        *   Updated its structure. Instead of a direct mapping from a function name to a single namespace, it now maps a function name (e.g., `t`, `tOne`) to an *array* of namespace objects. Each object in this array contains the namespace string (`ns`) and its `declarationPosition`. This handles cases where the same variable name (like `t`) might be re-declared or shadowed with different namespaces.
    *   **`getFinalMessageId` function**:
        *   Logic was enhanced to use the new `declarationPosition` information. When a translation function (e.g., `tOne("messageKey")`) is encountered, this function identifies the invoked function/variable name (e.g., `tOne`). It then searches through all namespace declarations associated with this specific name.
        *   It selects the namespace declaration whose `declarationPosition` (character offset) is the largest (most recent) value that is still *before* the starting position of the current translation function call. This ensures that the message key is prefixed with the namespace from the correct, most recent, and preceding in-scope declaration for that specific function/variable name.
        *   **Disclaimer: Message references are matched to namespaces based on the declaration order of translation hooks (like \`useTranslations\`) and the specific variable name used for the \`t\` function; this is a heuristic.** It does not fully understand JavaScript's lexical scoping rules (e.g., block scope, closures) or component boundaries in frameworks like React. For instance, in nested React components, the "most recent preceding namespace declaration for that function name" found in the file might not be the one truly in scope for a child component if namespaces are defined in parent components. For perfect scope-aware namespace resolution across the entire application (including component hierarchy), a more complex Abstract Syntax Tree (AST) parser and potentially inter-file analysis would be required. However, this method provides a significant improvement for common use cases within a single file.

2.  **`inlang/packages/plugins/i18next/src/ideExtension/messageReferenceMatchers.test.ts`**:
    *   A new test case, `should correctly reference messages with multiple useTranslations hooks`, was added.
    *   This test specifically validates the new multi-namespace handling by defining several `useTranslations` calls with distinct namespaces and then invoking their respective translation functions. It asserts that each message ID is correctly prepended with its corresponding namespace.

These changes provide more robust and accurate message reference matching in complex components that utilize multiple internationalization namespaces. 