### PR TITLE
Re-enables `variableReferencePattern` settings for the v6 `importFiles` and `exportFiles` APIs.

### DIFF
--- a/.changeset/stale-students-thank.md
+++ b/.changeset/stale-students-thank.md
@@ -1,0 +1,7 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Re-enables `variableReferencePattern` settings for the v6 `importFiles` and `exportFiles` APIs.
+
+https://github.com/opral/inlang-paraglide-js/issues/513

--- a/inlang/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/inlang/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -8,151 +8,157 @@ import type {
 } from "@inlang/sdk";
 import { type plugin } from "../plugin.js";
 import { unflatten } from "flat";
+import type { PluginSettings } from "../settings.js";
 
 export const exportFiles: NonNullable<(typeof plugin)["exportFiles"]> = async ({
-  bundles,
-  messages,
-  variants,
+	bundles,
+	messages,
+	variants,
+	settings,
 }) => {
-  const result: Record<string, Record<string, any>> = {};
-  const resultNamespaces: Record<
-    string,
-    Record<string, Record<string, any>>
-  > = {};
+	const result: Record<string, Record<string, any>> = {};
+	const resultNamespaces: Record<
+		string,
+		Record<string, Record<string, any>>
+	> = {};
 
-  for (const message of messages) {
-    const serializedMessages = serializeMessage(
-      bundles.find((b) => b.id === message.bundleId)!,
-      message,
-      variants.filter((v) => v.messageId === message.id),
-    );
+	for (const message of messages) {
+		const serializedMessages = serializeMessage(
+			bundles.find((b) => b.id === message.bundleId)!,
+			message,
+			variants.filter((v) => v.messageId === message.id),
+			settings?.["plugin.inlang.i18next"]
+		);
 
-    for (const message of serializedMessages) {
-      // no namespace
-      if (message.key.includes(":") === false) {
-        if (result[message.locale] === undefined) {
-          result[message.locale] = {};
-        }
-        result[message.locale]![message.key] = message.value;
-      }
-      // namespaces
-      else {
-        const [namespace, key] = message.key.split(":");
-        if (resultNamespaces[namespace!] === undefined) {
-          resultNamespaces[namespace!] = {};
-        }
-        if (resultNamespaces[namespace!]?.[message.locale] === undefined) {
-          resultNamespaces[namespace!]![message.locale] = {};
-        }
-        resultNamespaces[namespace!]![message.locale]![key!] = message.value;
-      }
-    }
-  }
+		for (const message of serializedMessages) {
+			// no namespace
+			if (message.key.includes(":") === false) {
+				if (result[message.locale] === undefined) {
+					result[message.locale] = {};
+				}
+				result[message.locale]![message.key] = message.value;
+			}
+			// namespaces
+			else {
+				const [namespace, key] = message.key.split(":");
+				if (resultNamespaces[namespace!] === undefined) {
+					resultNamespaces[namespace!] = {};
+				}
+				if (resultNamespaces[namespace!]?.[message.locale] === undefined) {
+					resultNamespaces[namespace!]![message.locale] = {};
+				}
+				resultNamespaces[namespace!]![message.locale]![key!] = message.value;
+			}
+		}
+	}
 
-  const withoutNamespace = Object.entries(result).map(([locale, messages]) => ({
-    locale,
-    content: new TextEncoder().encode(
-      JSON.stringify(unflatten(messages), undefined, "\t") + "\n",
-    ),
-    name: `${locale}.json`,
-  }));
-  const withNamespace = Object.entries(resultNamespaces).flatMap(
-    ([namespace, locales]) =>
-      Object.entries(locales).map(([locale, messages]) => ({
-        locale,
-        content: new TextEncoder().encode(
-          JSON.stringify(unflatten(messages), undefined, "\t") + "\n",
-        ),
-        name: `${namespace}-${locale}.json`,
-      })),
-  );
-  return [...withoutNamespace, ...withNamespace];
+	const withoutNamespace = Object.entries(result).map(([locale, messages]) => ({
+		locale,
+		content: new TextEncoder().encode(
+			JSON.stringify(unflatten(messages), undefined, "\t") + "\n"
+		),
+		name: `${locale}.json`,
+	}));
+	const withNamespace = Object.entries(resultNamespaces).flatMap(
+		([namespace, locales]) =>
+			Object.entries(locales).map(([locale, messages]) => ({
+				locale,
+				content: new TextEncoder().encode(
+					JSON.stringify(unflatten(messages), undefined, "\t") + "\n"
+				),
+				name: `${namespace}-${locale}.json`,
+			}))
+	);
+	return [...withoutNamespace, ...withNamespace];
 };
 
 function serializeMessage(
-  bundle: Bundle,
-  message: Message,
-  variants: Variant[],
+	bundle: Bundle,
+	message: Message,
+	variants: Variant[],
+	settings?: PluginSettings
 ): Array<{ key: string; value: string; locale: string }> {
-  const result = [];
+	const result = [];
 
-  const hasContext = bundle.declarations.some(
-    (declaration) =>
-      declaration.type === "input-variable" && declaration.name === "context",
-  );
+	const hasContext = bundle.declarations.some(
+		(declaration) =>
+			declaration.type === "input-variable" && declaration.name === "context"
+	);
 
-  const hasPlurals = bundle.declarations.some(
-    (declaration) =>
-      declaration.type === "local-variable" &&
-      declaration.value.annotation?.type === "function-reference" &&
-      declaration.value.annotation?.name === "plural",
-  );
+	const hasPlurals = bundle.declarations.some(
+		(declaration) =>
+			declaration.type === "local-variable" &&
+			declaration.value.annotation?.type === "function-reference" &&
+			declaration.value.annotation?.name === "plural"
+	);
 
-  for (const variant of variants) {
-    const pattern = serializePattern(variant.pattern);
-    const contextMatch = variant.matches.find(
-      (match) => match.type === "literal-match" && match.key === "context",
-    ) as LiteralMatch | undefined;
-    const pluralMatch = variant.matches.find(
-      (match) => match.type === "literal-match" && match.key === "countPlural",
-    ) as LiteralMatch | undefined;
+	for (const variant of variants) {
+		const pattern = serializePattern(variant.pattern, settings);
+		const contextMatch = variant.matches.find(
+			(match) => match.type === "literal-match" && match.key === "context"
+		) as LiteralMatch | undefined;
+		const pluralMatch = variant.matches.find(
+			(match) => match.type === "literal-match" && match.key === "countPlural"
+		) as LiteralMatch | undefined;
 
-    const isCatchAll = variant.matches.some(
-      (match) => match.type === "catchall-match",
-    );
+		const isCatchAll = variant.matches.some(
+			(match) => match.type === "catchall-match"
+		);
 
-    if (hasContext && contextMatch === undefined) {
-      throw new Error("The variant does not have a context match");
-    }
-    if (hasPlurals && pluralMatch === undefined) {
-      throw new Error("The variant does not have a plural match");
-    }
-    // matches need to be appended
-    // 'keyContext' -> 'keyContext_match'
-    let key: string;
-    if (hasContext && hasPlurals && isCatchAll) {
-      key = `${bundle.id}_${contextMatch?.value}`;
-    } else if (hasContext && hasPlurals && isCatchAll === false) {
-      key = `${bundle.id}_${contextMatch?.value}_${pluralMatch?.value}`;
-    } else if (hasContext === false && hasPlurals) {
-      key = `${bundle.id}_${pluralMatch?.value}`;
-    } else if (hasContext && hasPlurals === false) {
-      key = `${bundle.id}_${contextMatch?.value}`;
-    } else {
-      key = bundle.id;
-    }
-    const value = pattern;
-    result.push({ key, value, locale: message.locale });
-  }
+		if (hasContext && contextMatch === undefined) {
+			throw new Error("The variant does not have a context match");
+		}
+		if (hasPlurals && pluralMatch === undefined) {
+			throw new Error("The variant does not have a plural match");
+		}
+		// matches need to be appended
+		// 'keyContext' -> 'keyContext_match'
+		let key: string;
+		if (hasContext && hasPlurals && isCatchAll) {
+			key = `${bundle.id}_${contextMatch?.value}`;
+		} else if (hasContext && hasPlurals && isCatchAll === false) {
+			key = `${bundle.id}_${contextMatch?.value}_${pluralMatch?.value}`;
+		} else if (hasContext === false && hasPlurals) {
+			key = `${bundle.id}_${pluralMatch?.value}`;
+		} else if (hasContext && hasPlurals === false) {
+			key = `${bundle.id}_${contextMatch?.value}`;
+		} else {
+			key = bundle.id;
+		}
+		const value = pattern;
+		result.push({ key, value, locale: message.locale });
+	}
 
-  return result;
+	return result;
 }
 
-function serializePattern(pattern: Pattern): string {
-  let result = "";
+function serializePattern(pattern: Pattern, settings?: PluginSettings): string {
+	let result = "";
 
-  for (const part of pattern) {
-    if (part.type === "text") {
-      result += part.value;
-    } else if (
-      part.arg.type === "variable-reference" &&
-      part.annotation === undefined
-    ) {
-      result += `{{${part.arg.name}}}`;
-    } else if (
-      part.arg.type === "variable-reference" &&
-      part.annotation !== undefined &&
-      part.annotation.options.length === 0
-    ) {
-      result += `{{${part.arg.name}, ${part.annotation.name}}}`;
-    } else if (
-      part.arg.type === "variable-reference" &&
-      part.annotation !== undefined &&
-      part.annotation.options.length > 0
-    ) {
-      throw new Error("Not implemented");
-    }
-  }
+	const variableRefPattern = settings?.variableReferencePattern ?? ["{{", "}}"];
 
-  return result;
+	for (const part of pattern) {
+		if (part.type === "text") {
+			result += part.value;
+		} else if (
+			part.arg.type === "variable-reference" &&
+			part.annotation === undefined
+		) {
+			result += `${variableRefPattern[0]}${part.arg.name}${variableRefPattern[1]}`;
+		} else if (
+			part.arg.type === "variable-reference" &&
+			part.annotation !== undefined &&
+			part.annotation.options.length === 0
+		) {
+			result += `${variableRefPattern[0]}${part.arg.name}, ${part.annotation.name}${variableRefPattern[1]}`;
+		} else if (
+			part.arg.type === "variable-reference" &&
+			part.annotation !== undefined &&
+			part.annotation.options.length > 0
+		) {
+			throw new Error("Not implemented");
+		}
+	}
+
+	return result;
 }

--- a/inlang/packages/plugins/i18next/src/import-export/importFiles.ts
+++ b/inlang/packages/plugins/i18next/src/import-export/importFiles.ts
@@ -3,308 +3,325 @@ import type { Bundle, Pattern, VariableReference, Variant } from "@inlang/sdk";
 import { type plugin } from "../plugin.js";
 import { flatten } from "flat";
 import type { BundleImport, MessageImport, VariantImport } from "@inlang/sdk";
+import type { PluginSettings } from "../settings.js";
 
 export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
-  files,
+	files,
+	settings,
 }) => {
-  const bundles: BundleImport[] = [];
-  const messages: MessageImport[] = [];
-  const variants: VariantImport[] = [];
+	const bundles: BundleImport[] = [];
+	const messages: MessageImport[] = [];
+	const variants: VariantImport[] = [];
 
-  for (const file of files) {
-    const namespace = file.toBeImportedFilesMetadata?.namespace;
-    const result = parseFile({
-      namespace,
-      locale: file.locale,
-      content: file.content,
-    });
-    bundles.push(...result.bundles);
-    messages.push(...result.messages);
-    variants.push(...result.variants);
-  }
+	for (const file of files) {
+		const namespace = file.toBeImportedFilesMetadata?.namespace;
+		const result = parseFile({
+			namespace,
+			locale: file.locale,
+			content: file.content,
+			settings: settings?.["plugin.inlang.i18next"],
+		});
+		bundles.push(...result.bundles);
+		messages.push(...result.messages);
+		variants.push(...result.variants);
+	}
 
-  // merge the bundle declarations
-  const uniqueBundleIds = [...new Set(bundles.map((bundle) => bundle.id))];
-  const uniqueBundles: BundleImport[] = uniqueBundleIds.map((id) => {
-    const _bundles = bundles.filter((bundle) => bundle.id === id);
-    const declarations = removeDuplicates(
-      _bundles.flatMap((bundle) => bundle.declarations),
-    );
-    return { id, declarations };
-  });
+	// merge the bundle declarations
+	const uniqueBundleIds = [...new Set(bundles.map((bundle) => bundle.id))];
+	const uniqueBundles: BundleImport[] = uniqueBundleIds.map((id) => {
+		const _bundles = bundles.filter((bundle) => bundle.id === id);
+		const declarations = removeDuplicates(
+			_bundles.flatMap((bundle) => bundle.declarations)
+		);
+		return { id, declarations };
+	});
 
-  return { bundles: uniqueBundles, messages, variants };
+	return { bundles: uniqueBundles, messages, variants };
 };
 
 function parseFile(args: {
-  namespace?: string;
-  locale: string;
-  content: ArrayBuffer;
+	namespace?: string;
+	locale: string;
+	content: ArrayBuffer;
+	settings?: PluginSettings;
 }): {
-  bundles: BundleImport[];
-  messages: MessageImport[];
-  variants: VariantImport[];
+	bundles: BundleImport[];
+	messages: MessageImport[];
+	variants: VariantImport[];
 } {
-  const resource: Record<string, string> = flatten(
-    JSON.parse(new TextDecoder().decode(args.content)),
-  );
+	const resource: Record<string, string> = flatten(
+		JSON.parse(new TextDecoder().decode(args.content))
+	);
 
-  const bundles: BundleImport[] = [];
-  const messages: MessageImport[] = [];
-  const variants: VariantImport[] = [];
+	const bundles: BundleImport[] = [];
+	const messages: MessageImport[] = [];
+	const variants: VariantImport[] = [];
 
-  for (const key in resource) {
-    const value = resource[key]!;
-    const { bundle, message, variant } = parseMessage({
-      namespace: args.namespace,
-      key,
-      value,
-      locale: args.locale,
-      resource,
-    });
-    bundles.push(bundle);
-    messages.push(message);
-    variants.push(variant);
-  }
-  return { bundles, messages, variants };
+	for (const key in resource) {
+		const value = resource[key]!;
+		const { bundle, message, variant } = parseMessage({
+			namespace: args.namespace,
+			key,
+			value,
+			locale: args.locale,
+			resource,
+			settings: args.settings,
+		});
+		bundles.push(bundle);
+		messages.push(message);
+		variants.push(variant);
+	}
+	return { bundles, messages, variants };
 }
 
 function parseMessage(args: {
-  namespace?: string;
-  key: string;
-  value: string;
-  locale: string;
-  resource: Record<string, any>;
+	namespace?: string;
+	key: string;
+	value: string;
+	locale: string;
+	resource: Record<string, any>;
+	settings?: PluginSettings;
 }): { bundle: BundleImport; message: MessageImport; variant: VariantImport } {
-  const pattern = parsePattern(args.value);
+	const pattern = parsePattern(args.value, args.settings);
 
-  // i18next suffixes keys with context or plurals
-  // "friend_female_one" -> "friend"
-  let bundleId = args.key.split("_")[0]!;
-  if (args.namespace) {
-    // following i18next's convention
-    // https://www.i18next.com/principles/namespaces#sample
-    bundleId = `${args.namespace}:${bundleId}`;
-  }
+	// i18next suffixes keys with context or plurals
+	// "friend_female_one" -> "friend"
+	let bundleId = args.key.split("_")[0]!;
+	if (args.namespace) {
+		// following i18next's convention
+		// https://www.i18next.com/principles/namespaces#sample
+		bundleId = `${args.namespace}:${bundleId}`;
+	}
 
-  const bundle: Bundle = {
-    id: bundleId,
-    declarations: pattern.variableReferences.map((variableReference) => ({
-      type: "input-variable",
-      name: variableReference.name,
-    })),
-  };
+	const bundle: Bundle = {
+		id: bundleId,
+		declarations: pattern.variableReferences.map((variableReference) => ({
+			type: "input-variable",
+			name: variableReference.name,
+		})),
+	};
 
-  const message: MessageImport = {
-    bundleId: bundleId,
-    selectors: [],
-    locale: args.locale,
-  };
+	const message: MessageImport = {
+		bundleId: bundleId,
+		selectors: [],
+		locale: args.locale,
+	};
 
-  const variant: VariantImport = {
-    messageBundleId: bundleId,
-    messageLocale: args.locale,
-    matches: [],
-    pattern: pattern.result,
-  };
+	const variant: VariantImport = {
+		messageBundleId: bundleId,
+		messageLocale: args.locale,
+		matches: [],
+		pattern: pattern.result,
+	};
 
-  // plurals, see https://www.i18next.com/misc/json-format#i18next-json-v4
-  const hasPlurals = testForPlurals(args.key);
-  // context is used see https://www.i18next.com/translation-function/context
-  const hasContext = hasPlurals
-    ? args.key.split("_").length === 3
-    : args.key.split("_").length === 2;
+	// plurals, see https://www.i18next.com/misc/json-format#i18next-json-v4
+	const hasPlurals = testForPlurals(args.key);
+	// context is used see https://www.i18next.com/translation-function/context
+	const hasContext = hasPlurals
+		? args.key.split("_").length === 3
+		: args.key.split("_").length === 2;
 
-  // the key itself has no plurals, but the resource has plurals
-  // hence, it must be the catch all variant
-  // https://www.i18next.com/translation-function/context#combining-with-plurals
-  const isCatchAll =
-    testForPlurals(args.key) === false &&
-    Object.keys(args.resource).some(
-      // the first part of the key is identical e.g.
-      // ["friend"] -> ["friend", "one"]
-      (key) =>
-        args.key.split("_")[0] === key.split("_")[0] && testForPlurals(key),
-    );
+	// the key itself has no plurals, but the resource has plurals
+	// hence, it must be the catch all variant
+	// https://www.i18next.com/translation-function/context#combining-with-plurals
+	const isCatchAll =
+		testForPlurals(args.key) === false &&
+		Object.keys(args.resource).some(
+			// the first part of the key is identical e.g.
+			// ["friend"] -> ["friend", "one"]
+			(key) =>
+				args.key.split("_")[0] === key.split("_")[0] && testForPlurals(key)
+		);
 
-  if (hasContext && hasPlurals === false && isCatchAll === false) {
-    // "friend_male" -> ["friend", "male"]
-    const [, context] = args.key.split("_");
-    bundle.declarations.push({
-      type: "input-variable",
-      name: "context",
-    });
-    message.selectors = [
-      {
-        type: "variable-reference",
-        name: "context",
-      },
-    ];
-    variant.matches = [
-      {
-        type: "literal-match",
-        // i18next always uses "context" as the key
-        key: "context",
-        value: context!,
-      },
-    ];
-  } else if (hasContext && hasPlurals && isCatchAll === false) {
-    // "friend_female_one": "A girlfriend" -> ["friend", "female", "one"]
-    const [, context, plural] = args.key.split("_");
-    bundle.declarations.push({
-      type: "input-variable",
-      name: "context",
-    });
-    bundle.declarations.push({
-      type: "input-variable",
-      name: "count",
-    });
-    bundle.declarations.push({
-      type: "local-variable",
-      name: "countPlural",
-      value: {
-        type: "expression",
-        arg: {
-          type: "variable-reference",
-          name: "count",
-        },
-        annotation: {
-          type: "function-reference",
-          name: "plural",
-          options: [],
-        },
-      },
-    });
-    message.selectors = [
-      {
-        type: "variable-reference",
-        name: "context",
-      },
-      {
-        type: "variable-reference",
-        name: "countPlural",
-      },
-    ];
-    variant.matches = [
-      {
-        type: "literal-match",
-        key: "context",
-        value: context!,
-      },
-      {
-        type: "literal-match",
-        // i18next only allows matching against a count variable.
-        // suffixing plural here because the inlang sdk v2 purposefully
-        // did not allow using a variable with a function like `plural`
-        // without declaring a new variable
-        key: "countPlural",
-        value: plural!,
-      },
-    ];
-  } else if (hasPlurals && isCatchAll === false) {
-    variant.matches = [
-      {
-        // i18next only allows matching against a count variable
-        // suffixing plural because the inlang sdk v2 purposefully
-        // did not allow using a variable with a function like `plural`
-        // without declaring a new variable to reduce complexity
-        type: "literal-match",
-        key: "countPlural",
-        value: args.key.split("_").at(-1)!,
-      },
-    ];
-    message.selectors = [
-      {
-        type: "variable-reference",
-        name: "countPlural",
-      },
-    ];
-    bundle.declarations.push({
-      type: "input-variable",
-      name: "count",
-    });
-    bundle.declarations.push({
-      type: "local-variable",
-      name: "countPlural",
-      value: {
-        type: "expression",
-        arg: {
-          type: "variable-reference",
-          name: "count",
-        },
-        annotation: {
-          type: "function-reference",
-          name: "plural",
-          options: [],
-        },
-      },
-    });
-  } else if (isCatchAll) {
-    variant.matches = [
-      {
-        type: "catchall-match",
-        key: "context",
-      },
-    ];
-  }
+	if (hasContext && hasPlurals === false && isCatchAll === false) {
+		// "friend_male" -> ["friend", "male"]
+		const [, context] = args.key.split("_");
+		bundle.declarations.push({
+			type: "input-variable",
+			name: "context",
+		});
+		message.selectors = [
+			{
+				type: "variable-reference",
+				name: "context",
+			},
+		];
+		variant.matches = [
+			{
+				type: "literal-match",
+				// i18next always uses "context" as the key
+				key: "context",
+				value: context!,
+			},
+		];
+	} else if (hasContext && hasPlurals && isCatchAll === false) {
+		// "friend_female_one": "A girlfriend" -> ["friend", "female", "one"]
+		const [, context, plural] = args.key.split("_");
+		bundle.declarations.push({
+			type: "input-variable",
+			name: "context",
+		});
+		bundle.declarations.push({
+			type: "input-variable",
+			name: "count",
+		});
+		bundle.declarations.push({
+			type: "local-variable",
+			name: "countPlural",
+			value: {
+				type: "expression",
+				arg: {
+					type: "variable-reference",
+					name: "count",
+				},
+				annotation: {
+					type: "function-reference",
+					name: "plural",
+					options: [],
+				},
+			},
+		});
+		message.selectors = [
+			{
+				type: "variable-reference",
+				name: "context",
+			},
+			{
+				type: "variable-reference",
+				name: "countPlural",
+			},
+		];
+		variant.matches = [
+			{
+				type: "literal-match",
+				key: "context",
+				value: context!,
+			},
+			{
+				type: "literal-match",
+				// i18next only allows matching against a count variable.
+				// suffixing plural here because the inlang sdk v2 purposefully
+				// did not allow using a variable with a function like `plural`
+				// without declaring a new variable
+				key: "countPlural",
+				value: plural!,
+			},
+		];
+	} else if (hasPlurals && isCatchAll === false) {
+		variant.matches = [
+			{
+				// i18next only allows matching against a count variable
+				// suffixing plural because the inlang sdk v2 purposefully
+				// did not allow using a variable with a function like `plural`
+				// without declaring a new variable to reduce complexity
+				type: "literal-match",
+				key: "countPlural",
+				value: args.key.split("_").at(-1)!,
+			},
+		];
+		message.selectors = [
+			{
+				type: "variable-reference",
+				name: "countPlural",
+			},
+		];
+		bundle.declarations.push({
+			type: "input-variable",
+			name: "count",
+		});
+		bundle.declarations.push({
+			type: "local-variable",
+			name: "countPlural",
+			value: {
+				type: "expression",
+				arg: {
+					type: "variable-reference",
+					name: "count",
+				},
+				annotation: {
+					type: "function-reference",
+					name: "plural",
+					options: [],
+				},
+			},
+		});
+	} else if (isCatchAll) {
+		variant.matches = [
+			{
+				type: "catchall-match",
+				key: "context",
+			},
+		];
+	}
 
-  bundle.declarations = removeDuplicates(bundle.declarations);
+	bundle.declarations = removeDuplicates(bundle.declarations);
 
-  return { bundle, message, variant };
+	return { bundle, message, variant };
 }
 
-function parsePattern(value: string): {
-  variableReferences: VariableReference[];
-  result: Pattern;
+function parsePattern(
+	value: string,
+	settings?: PluginSettings
+): {
+	variableReferences: VariableReference[];
+	result: Pattern;
 } {
-  const result: Variant["pattern"] = [];
-  const variableReferences: VariableReference[] = [];
+	const result: Variant["pattern"] = [];
+	const variableReferences: VariableReference[] = [];
 
-  // splits a pattern like "Hello {{name}}!" into an array of parts
-  // "hello {{name}}, how are you?" -> ["hello ", "{{name}}", ", how are you?"]
-  const parts = value.split(/({{.*?}})/).filter((part) => part !== "");
+	const pattern = settings?.variableReferencePattern ?? ["{{", "}}"];
 
-  for (const part of parts) {
-    // it's text
-    if ((part.startsWith("{{") && part.endsWith("}}")) === false) {
-      result.push({ type: "text", value: part });
-    }
-    // it's an expression
-    else {
-      // i18next allows for annotations like `{{name, uppercase}}`
-      const subparts = part.slice(2, -2).split(",");
+	// splits a pattern like "Hello {{name}}!" into an array of parts
+	// "hello {{name}}, how are you?" -> ["hello ", "{{name}}", ", how are you?"]
+	const parts = value
+		.split(new RegExp(`(${pattern[0]}.*?${pattern[1]})`))
+		.filter((part) => part !== "");
 
-      const arg = subparts[0]?.trim();
-      const annotation = subparts[1]?.trim();
+	for (const part of parts) {
+		// it's text
+		if (
+			(part.startsWith(pattern[0]!) && part.endsWith(pattern[1]!)) === false
+		) {
+			result.push({ type: "text", value: part });
+		}
+		// it's an expression
+		else {
+			// i18next allows for annotations like `{{name, uppercase}}`
+			const subparts = part
+				.slice(pattern[0]!.length, -pattern[1]!.length)
+				.split(",");
 
-      if (arg === undefined) {
-        throw new Error(
-          "Expected an argument in the expression but received undefined.",
-        );
-      }
+			const arg = subparts[0]?.trim();
+			const annotation = subparts[1]?.trim();
 
-      const variableReference: VariableReference = {
-        type: "variable-reference",
-        name: arg,
-      };
+			if (arg === undefined) {
+				throw new Error(
+					"Expected an argument in the expression but received undefined."
+				);
+			}
 
-      variableReferences.push(variableReference);
+			const variableReference: VariableReference = {
+				type: "variable-reference",
+				name: arg,
+			};
 
-      result.push({
-        type: "expression",
-        arg: variableReference,
-        ...(annotation && {
-          annotation: {
-            type: "function-reference",
-            name: annotation,
-            options: [],
-          },
-        }),
-      });
-    }
-  }
+			variableReferences.push(variableReference);
 
-  return { variableReferences, result };
+			result.push({
+				type: "expression",
+				arg: variableReference,
+				...(annotation && {
+					annotation: {
+						type: "function-reference",
+						name: annotation,
+						options: [],
+					},
+				}),
+			});
+		}
+	}
+
+	return { variableReferences, result };
 }
 const removeDuplicates = <T extends any[]>(arr: T) =>
   [...new Set(arr.map((item) => JSON.stringify(item)))].map((item) =>

--- a/inlang/packages/plugins/i18next/src/import-export/roundtrip.test.ts
+++ b/inlang/packages/plugins/i18next/src/import-export/roundtrip.test.ts
@@ -8,586 +8,618 @@ import {
   type Variant,
 } from "@inlang/sdk";
 import { exportFiles } from "./exportFiles.js";
+import type { PluginSettings } from "../settings.js";
 
 test("single key value", async () => {
-  const imported = await runImportFiles({
-    key: "value",
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    key: "value",
-  });
+	const imported = await runImportFiles({
+		key: "value",
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		key: "value",
+	});
 
-  expect(imported.bundles).lengthOf(1);
-  expect(imported.messages).lengthOf(1);
-  expect(imported.variants).lengthOf(1);
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.messages).lengthOf(1);
+	expect(imported.variants).lengthOf(1);
 
-  expect(imported.bundles[0]?.id).toStrictEqual("key");
-  expect(imported.bundles[0]?.declarations).toStrictEqual([]);
-  expect(imported.messages[0]?.selectors).toStrictEqual([]);
-  expect(imported.variants[0]?.matches).toStrictEqual([]);
-  expect(imported.variants[0]?.pattern).toStrictEqual([
-    { type: "text", value: "value" },
-  ]);
+	expect(imported.bundles[0]?.id).toStrictEqual("key");
+	expect(imported.bundles[0]?.declarations).toStrictEqual([]);
+	expect(imported.messages[0]?.selectors).toStrictEqual([]);
+	expect(imported.variants[0]?.matches).toStrictEqual([]);
+	expect(imported.variants[0]?.pattern).toStrictEqual([
+		{ type: "text", value: "value" },
+	]);
 });
 
 test("key deep", async () => {
-  const imported = await runImportFiles({
-    keyDeep: { inner: "value" },
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyDeep: { inner: "value" },
-  });
+	const imported = await runImportFiles({
+		keyDeep: { inner: "value" },
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyDeep: { inner: "value" },
+	});
 
-  expect(imported.bundles).lengthOf(1);
-  expect(imported.messages).lengthOf(1);
-  expect(imported.variants).lengthOf(1);
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.messages).lengthOf(1);
+	expect(imported.variants).lengthOf(1);
 
-  expect(imported.bundles[0]?.id).toStrictEqual("keyDeep.inner");
-  expect(imported.variants[0]?.pattern).toStrictEqual([
-    { type: "text", value: "value" },
-  ]);
+	expect(imported.bundles[0]?.id).toStrictEqual("keyDeep.inner");
+	expect(imported.variants[0]?.pattern).toStrictEqual([
+		{ type: "text", value: "value" },
+	]);
 });
 
 test("keyInterpolate", async () => {
-  const imported = await runImportFiles({
-    keyInterpolate: "replace this {{value}}",
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyInterpolate: "replace this {{value}}",
-  });
+	const imported = await runImportFiles({
+		keyInterpolate: "replace this {{value}}",
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyInterpolate: "replace this {{value}}",
+	});
 
-  expect(imported.bundles).lengthOf(1);
-  expect(imported.messages).lengthOf(1);
-  expect(imported.variants).lengthOf(1);
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.messages).lengthOf(1);
+	expect(imported.variants).lengthOf(1);
 
-  expect(imported.bundles[0]?.declarations).toStrictEqual([
-    { type: "input-variable", name: "value" },
-  ]);
+	expect(imported.bundles[0]?.declarations).toStrictEqual([
+		{ type: "input-variable", name: "value" },
+	]);
 
-  expect(imported.variants[0]?.pattern).toStrictEqual([
-    { type: "text", value: "replace this " },
-    { type: "expression", arg: { type: "variable-reference", name: "value" } },
-  ] satisfies Pattern);
+	expect(imported.variants[0]?.pattern).toStrictEqual([
+		{ type: "text", value: "replace this " },
+		{ type: "expression", arg: { type: "variable-reference", name: "value" } },
+	] satisfies Pattern);
 });
 
 test("keyInterpolateUnescaped", async () => {
-  const imported = await runImportFiles({
-    keyInterpolateUnescaped: "replace this {{- value}}",
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyInterpolateUnescaped: "replace this {{- value}}",
-  });
+	const imported = await runImportFiles({
+		keyInterpolateUnescaped: "replace this {{- value}}",
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyInterpolateUnescaped: "replace this {{- value}}",
+	});
 
-  expect(imported.bundles[0]?.id).toStrictEqual("keyInterpolateUnescaped");
-  expect(imported.bundles[0]?.declarations).toStrictEqual([
-    { type: "input-variable", name: "- value" },
-  ]);
-  expect(imported.variants[0]?.pattern).toStrictEqual([
-    { type: "text", value: "replace this " },
-    {
-      type: "expression",
-      arg: { type: "variable-reference", name: "- value" },
-    },
-  ] satisfies Pattern);
+	expect(imported.bundles[0]?.id).toStrictEqual("keyInterpolateUnescaped");
+	expect(imported.bundles[0]?.declarations).toStrictEqual([
+		{ type: "input-variable", name: "- value" },
+	]);
+	expect(imported.variants[0]?.pattern).toStrictEqual([
+		{ type: "text", value: "replace this " },
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "- value" },
+		},
+	] satisfies Pattern);
 });
 
 test("keyInterpolateWithFormatting", async () => {
-  const imported = await runImportFiles({
-    keyInterpolateWithFormatting: "replace this {{value, format}}",
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyInterpolateWithFormatting: "replace this {{value, format}}",
-  });
+	const imported = await runImportFiles({
+		keyInterpolateWithFormatting: "replace this {{value, format}}",
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyInterpolateWithFormatting: "replace this {{value, format}}",
+	});
 
-  expect(imported.bundles[0]?.id).toStrictEqual("keyInterpolateWithFormatting");
-  expect(imported.variants[0]?.pattern).toStrictEqual([
-    { type: "text", value: "replace this " },
-    {
-      type: "expression",
-      arg: { type: "variable-reference", name: "value" },
-      annotation: { type: "function-reference", name: "format", options: [] },
-    },
-  ] satisfies Pattern);
+	expect(imported.bundles[0]?.id).toStrictEqual("keyInterpolateWithFormatting");
+	expect(imported.variants[0]?.pattern).toStrictEqual([
+		{ type: "text", value: "replace this " },
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "value" },
+			annotation: { type: "function-reference", name: "format", options: [] },
+		},
+	] satisfies Pattern);
 });
 
 test.todo("keyContext", async () => {
-  const imported = await runImportFiles({
-    // catch all
-    keyContext: "the variant",
-    // context: male
-    keyContext_male: "the male variant",
-    // context: female
-    keyContext_female: "the female variant",
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyContext: "the variant",
-    keyContext_male: "the male variant",
-    keyContext_female: "the female variant",
-  });
+	const imported = await runImportFiles({
+		// catch all
+		keyContext: "the variant",
+		// context: male
+		keyContext_male: "the male variant",
+		// context: female
+		keyContext_female: "the female variant",
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyContext: "the variant",
+		keyContext_male: "the male variant",
+		keyContext_female: "the female variant",
+	});
 
-  expect(imported.bundles).lengthOf(1);
-  expect(imported.messages).lengthOf(1);
-  expect(imported.variants).lengthOf(3);
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.messages).lengthOf(1);
+	expect(imported.variants).lengthOf(3);
 
-  expect(imported.bundles[0]?.id).toStrictEqual("keyContext");
-  expect(imported.bundles[0]?.declarations).toStrictEqual([
-    { type: "input-variable", name: "context" },
-  ]);
-  expect(imported?.messages[0]?.selectors).toStrictEqual([
-    { type: "variable-reference", name: "context" },
-  ]);
-  expect(imported.variants[0]).toStrictEqual(
-    expect.objectContaining({
-      matches: [{ type: "catchall-match", key: "context" }],
-      pattern: [{ type: "text", value: "the variant" }],
-    } satisfies Partial<Variant>),
-  );
-  expect(imported.variants[1]).toStrictEqual(
-    expect.objectContaining({
-      matches: [{ type: "literal-match", key: "context", value: "male" }],
-      pattern: [{ type: "text", value: "the male variant" }],
-    } satisfies Partial<Variant>),
-  );
-  expect(imported.variants[2]).toStrictEqual(
-    expect.objectContaining({
-      matches: [{ type: "literal-match", key: "context", value: "female" }],
-      pattern: [{ type: "text", value: "the female variant" }],
-    } satisfies Partial<Variant>),
-  );
+	expect(imported.bundles[0]?.id).toStrictEqual("keyContext");
+	expect(imported.bundles[0]?.declarations).toStrictEqual([
+		{ type: "input-variable", name: "context" },
+	]);
+	expect(imported?.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "context" },
+	]);
+	expect(imported.variants[0]).toStrictEqual(
+		expect.objectContaining({
+			matches: [{ type: "catchall-match", key: "context" }],
+			pattern: [{ type: "text", value: "the variant" }],
+		} satisfies Partial<Variant>)
+	);
+	expect(imported.variants[1]).toStrictEqual(
+		expect.objectContaining({
+			matches: [{ type: "literal-match", key: "context", value: "male" }],
+			pattern: [{ type: "text", value: "the male variant" }],
+		} satisfies Partial<Variant>)
+	);
+	expect(imported.variants[2]).toStrictEqual(
+		expect.objectContaining({
+			matches: [{ type: "literal-match", key: "context", value: "female" }],
+			pattern: [{ type: "text", value: "the female variant" }],
+		} satisfies Partial<Variant>)
+	);
 });
 
 test("keyPluralSimple", async () => {
-  const imported = await runImportFiles({
-    keyPluralSimple_one: "the singular",
-    keyPluralSimple_other: "the plural",
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyPluralSimple_one: "the singular",
-    keyPluralSimple_other: "the plural",
-  });
+	const imported = await runImportFiles({
+		keyPluralSimple_one: "the singular",
+		keyPluralSimple_other: "the plural",
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyPluralSimple_one: "the singular",
+		keyPluralSimple_other: "the plural",
+	});
 
-  expect(imported.bundles[0]?.id).toStrictEqual("keyPluralSimple");
+	expect(imported.bundles[0]?.id).toStrictEqual("keyPluralSimple");
 
-  expect(imported.bundles[0]?.declarations).toStrictEqual(
-    expect.arrayContaining([
-      {
-        type: "input-variable",
-        name: "count",
-      },
-      expect.objectContaining({
-        type: "local-variable",
-        name: "countPlural",
-        value: {
-          type: "expression",
-          arg: {
-            type: "variable-reference",
-            name: "count",
-          },
-          annotation: {
-            type: "function-reference",
-            name: "plural",
-            options: [],
-          },
-        },
-      }),
-    ]),
-  );
+	expect(imported.bundles[0]?.declarations).toStrictEqual(
+		expect.arrayContaining([
+			{
+				type: "input-variable",
+				name: "count",
+			},
+			expect.objectContaining({
+				type: "local-variable",
+				name: "countPlural",
+				value: {
+					type: "expression",
+					arg: {
+						type: "variable-reference",
+						name: "count",
+					},
+					annotation: {
+						type: "function-reference",
+						name: "plural",
+						options: [],
+					},
+				},
+			}),
+		])
+	);
 
-  expect(imported?.messages[0]?.selectors).toStrictEqual([
-    {
-      type: "variable-reference",
-      name: "countPlural",
-    },
-  ]);
+	expect(imported?.messages[0]?.selectors).toStrictEqual([
+		{
+			type: "variable-reference",
+			name: "countPlural",
+		},
+	]);
 
-  expect(imported?.variants[0]).toStrictEqual(
-    expect.objectContaining({
-      matches: [
-        {
-          type: "literal-match",
-          key: "countPlural",
-          value: "one",
-        },
-      ],
-      pattern: [{ type: "text", value: "the singular" }],
-    } satisfies Partial<Variant>),
-  );
+	expect(imported?.variants[0]).toStrictEqual(
+		expect.objectContaining({
+			matches: [
+				{
+					type: "literal-match",
+					key: "countPlural",
+					value: "one",
+				},
+			],
+			pattern: [{ type: "text", value: "the singular" }],
+		} satisfies Partial<Variant>)
+	);
 
-  expect(imported?.variants[1]).toStrictEqual(
-    expect.objectContaining({
-      matches: [
-        {
-          type: "literal-match",
-          key: "countPlural",
-          value: "other",
-        },
-      ],
-      pattern: [{ type: "text", value: "the plural" }],
-    } satisfies Partial<Variant>),
-  );
+	expect(imported?.variants[1]).toStrictEqual(
+		expect.objectContaining({
+			matches: [
+				{
+					type: "literal-match",
+					key: "countPlural",
+					value: "other",
+				},
+			],
+			pattern: [{ type: "text", value: "the plural" }],
+		} satisfies Partial<Variant>)
+	);
 });
 
 test("keyPluralMultipleEgArabic", async () => {
-  const imported = await runImportFiles({
-    keyPluralMultipleEgArabic_zero: "the plural form 0",
-    keyPluralMultipleEgArabic_one: "the plural form 1",
-    keyPluralMultipleEgArabic_two: "the plural form 2",
-    keyPluralMultipleEgArabic_few: "the plural form 3",
-    keyPluralMultipleEgArabic_many: "the plural form 4",
-    keyPluralMultipleEgArabic_other: "the plural form 5",
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyPluralMultipleEgArabic_zero: "the plural form 0",
-    keyPluralMultipleEgArabic_one: "the plural form 1",
-    keyPluralMultipleEgArabic_two: "the plural form 2",
-    keyPluralMultipleEgArabic_few: "the plural form 3",
-    keyPluralMultipleEgArabic_many: "the plural form 4",
-    keyPluralMultipleEgArabic_other: "the plural form 5",
-  });
+	const imported = await runImportFiles({
+		keyPluralMultipleEgArabic_zero: "the plural form 0",
+		keyPluralMultipleEgArabic_one: "the plural form 1",
+		keyPluralMultipleEgArabic_two: "the plural form 2",
+		keyPluralMultipleEgArabic_few: "the plural form 3",
+		keyPluralMultipleEgArabic_many: "the plural form 4",
+		keyPluralMultipleEgArabic_other: "the plural form 5",
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyPluralMultipleEgArabic_zero: "the plural form 0",
+		keyPluralMultipleEgArabic_one: "the plural form 1",
+		keyPluralMultipleEgArabic_two: "the plural form 2",
+		keyPluralMultipleEgArabic_few: "the plural form 3",
+		keyPluralMultipleEgArabic_many: "the plural form 4",
+		keyPluralMultipleEgArabic_other: "the plural form 5",
+	});
 
-  expect(imported.bundles[0]?.id).toStrictEqual("keyPluralMultipleEgArabic");
+	expect(imported.bundles[0]?.id).toStrictEqual("keyPluralMultipleEgArabic");
 
-  expect(imported?.messages[0]?.selectors).toStrictEqual([
-    { type: "variable-reference", name: "countPlural" },
-  ]);
+	expect(imported?.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "countPlural" },
+	]);
 
-  expect(imported.bundles[0]?.declarations).toStrictEqual(
-    expect.arrayContaining([
-      {
-        type: "input-variable",
-        name: "count",
-      },
-      expect.objectContaining({
-        type: "local-variable",
-        name: "countPlural",
-        value: {
-          type: "expression",
-          arg: {
-            type: "variable-reference",
-            name: "count",
-          },
-          annotation: {
-            type: "function-reference",
-            name: "plural",
-            options: [],
-          },
-        },
-      }),
-    ]),
-  );
+	expect(imported.bundles[0]?.declarations).toStrictEqual(
+		expect.arrayContaining([
+			{
+				type: "input-variable",
+				name: "count",
+			},
+			expect.objectContaining({
+				type: "local-variable",
+				name: "countPlural",
+				value: {
+					type: "expression",
+					arg: {
+						type: "variable-reference",
+						name: "count",
+					},
+					annotation: {
+						type: "function-reference",
+						name: "plural",
+						options: [],
+					},
+				},
+			}),
+		])
+	);
 
-  const matches = imported.variants.map(
-    (variant) => (variant.matches?.[0] as LiteralMatch).value,
-  );
+	const matches = imported.variants.map(
+		(variant) => (variant.matches?.[0] as LiteralMatch).value
+	);
 
-  expect(matches).toStrictEqual(["zero", "one", "two", "few", "many", "other"]);
-  expect(imported.variants[0]?.pattern).toStrictEqual([
-    { type: "text", value: "the plural form 0" },
-  ]);
-  expect(imported.variants[1]?.pattern).toStrictEqual([
-    { type: "text", value: "the plural form 1" },
-  ]);
-  expect(imported.variants[2]?.pattern).toStrictEqual([
-    { type: "text", value: "the plural form 2" },
-  ]);
-  expect(imported.variants[3]?.pattern).toStrictEqual([
-    { type: "text", value: "the plural form 3" },
-  ]);
-  expect(imported.variants[4]?.pattern).toStrictEqual([
-    { type: "text", value: "the plural form 4" },
-  ]);
-  expect(imported.variants[5]?.pattern).toStrictEqual([
-    { type: "text", value: "the plural form 5" },
-  ]);
+	expect(matches).toStrictEqual(["zero", "one", "two", "few", "many", "other"]);
+	expect(imported.variants[0]?.pattern).toStrictEqual([
+		{ type: "text", value: "the plural form 0" },
+	]);
+	expect(imported.variants[1]?.pattern).toStrictEqual([
+		{ type: "text", value: "the plural form 1" },
+	]);
+	expect(imported.variants[2]?.pattern).toStrictEqual([
+		{ type: "text", value: "the plural form 2" },
+	]);
+	expect(imported.variants[3]?.pattern).toStrictEqual([
+		{ type: "text", value: "the plural form 3" },
+	]);
+	expect(imported.variants[4]?.pattern).toStrictEqual([
+		{ type: "text", value: "the plural form 4" },
+	]);
+	expect(imported.variants[5]?.pattern).toStrictEqual([
+		{ type: "text", value: "the plural form 5" },
+	]);
 });
 
 test("keyWithObjectValue", async () => {
-  const imported = await runImportFiles({
-    keyWithObjectValue: {
-      valueA: "return this with valueB",
-      valueB: "more text",
-    },
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyWithObjectValue: {
-      valueA: "return this with valueB",
-      valueB: "more text",
-    },
-  });
+	const imported = await runImportFiles({
+		keyWithObjectValue: {
+			valueA: "return this with valueB",
+			valueB: "more text",
+		},
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyWithObjectValue: {
+			valueA: "return this with valueB",
+			valueB: "more text",
+		},
+	});
 
-  expect(imported.bundles[0]?.id).toStrictEqual("keyWithObjectValue.valueA");
-  expect(imported.bundles[1]?.id).toStrictEqual("keyWithObjectValue.valueB");
+	expect(imported.bundles[0]?.id).toStrictEqual("keyWithObjectValue.valueA");
+	expect(imported.bundles[1]?.id).toStrictEqual("keyWithObjectValue.valueB");
 
-  expect(
-    imported.variants.find(
-      (v) => v.messageBundleId === "keyWithObjectValue.valueA",
-    )?.pattern,
-  ).toStrictEqual([
-    { type: "text", value: "return this with valueB" },
-  ] satisfies Pattern);
-  expect(
-    imported.variants.find(
-      (v) => v.messageBundleId === "keyWithObjectValue.valueB",
-    )?.pattern,
-  ).toStrictEqual([{ type: "text", value: "more text" }] satisfies Pattern);
+	expect(
+		imported.variants.find(
+			(v) => v.messageBundleId === "keyWithObjectValue.valueA"
+		)?.pattern
+	).toStrictEqual([
+		{ type: "text", value: "return this with valueB" },
+	] satisfies Pattern);
+	expect(
+		imported.variants.find(
+			(v) => v.messageBundleId === "keyWithObjectValue.valueB"
+		)?.pattern
+	).toStrictEqual([{ type: "text", value: "more text" }] satisfies Pattern);
 });
 
 test("keyWithArrayValue", async () => {
-  const imported = await runImportFiles({
-    keyWithArrayValue: ["multiple", "things"],
-  });
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    keyWithArrayValue: ["multiple", "things"],
-  });
+	const imported = await runImportFiles({
+		keyWithArrayValue: ["multiple", "things"],
+	});
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		keyWithArrayValue: ["multiple", "things"],
+	});
 
-  expect(imported.bundles[0]?.id).toStrictEqual("keyWithArrayValue.0");
-  expect(imported.bundles[1]?.id).toStrictEqual("keyWithArrayValue.1");
+	expect(imported.bundles[0]?.id).toStrictEqual("keyWithArrayValue.0");
+	expect(imported.bundles[1]?.id).toStrictEqual("keyWithArrayValue.1");
 
-  expect(
-    imported.variants.find((v) => v.messageBundleId === "keyWithArrayValue.0")
-      ?.pattern,
-  ).toStrictEqual([{ type: "text", value: "multiple" }] satisfies Pattern);
-  expect(
-    imported.variants.find((v) => v.messageBundleId === "keyWithArrayValue.1")
-      ?.pattern,
-  ).toStrictEqual([{ type: "text", value: "things" }] satisfies Pattern);
+	expect(
+		imported.variants.find((v) => v.messageBundleId === "keyWithArrayValue.0")
+			?.pattern
+	).toStrictEqual([{ type: "text", value: "multiple" }] satisfies Pattern);
+	expect(
+		imported.variants.find((v) => v.messageBundleId === "keyWithArrayValue.1")
+			?.pattern
+	).toStrictEqual([{ type: "text", value: "things" }] satisfies Pattern);
 });
 
 test("im- and exporting multiple files should succeed", async () => {
-  const en = {
-    key: "value",
-  };
-  const de = {
-    key: "Wert",
-  };
+	const en = {
+		key: "value",
+	};
+	const de = {
+		key: "Wert",
+	};
 
-  const imported = await importFiles({
-    settings: {} as any,
-    files: [
-      {
-        locale: "en",
-        content: new TextEncoder().encode(JSON.stringify(en)),
-      },
-      {
-        locale: "de",
-        content: new TextEncoder().encode(JSON.stringify(de)),
-      },
-    ],
-  });
+	const imported = await importFiles({
+		settings: {} as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(JSON.stringify(en)),
+			},
+			{
+				locale: "de",
+				content: new TextEncoder().encode(JSON.stringify(de)),
+			},
+		],
+	});
 
-  const exported = await runExportFiles(imported);
+	const exported = await runExportFiles(imported);
 
-  const exportedEn = JSON.parse(
-    new TextDecoder().decode(exported.find((e) => e.locale === "en")?.content),
-  );
-  const exportedDe = JSON.parse(
-    new TextDecoder().decode(exported.find((e) => e.locale === "de")?.content),
-  );
+	const exportedEn = JSON.parse(
+		new TextDecoder().decode(exported.find((e) => e.locale === "en")?.content)
+	);
+	const exportedDe = JSON.parse(
+		new TextDecoder().decode(exported.find((e) => e.locale === "de")?.content)
+	);
 
-  expect(exportedEn).toStrictEqual({
-    key: "value",
-  });
-  expect(exportedDe).toStrictEqual({
-    key: "Wert",
-  });
+	expect(exportedEn).toStrictEqual({
+		key: "value",
+	});
+	expect(exportedDe).toStrictEqual({
+		key: "Wert",
+	});
 });
 
 test("it should handle namespaces", async () => {
-  const enCommon = {
-    confirm: "value1",
-  };
-  const enLogin = {
-    button: "value2",
-  };
+	const enCommon = {
+		confirm: "value1",
+	};
+	const enLogin = {
+		button: "value2",
+	};
 
-  const imported = await importFiles({
-    settings: {} as any,
-    files: [
-      {
-        locale: "en",
-        content: new TextEncoder().encode(JSON.stringify(enCommon)),
-        toBeImportedFilesMetadata: {
-          namespace: "common",
-        },
-      },
-      {
-        locale: "en",
-        content: new TextEncoder().encode(JSON.stringify(enLogin)),
-        toBeImportedFilesMetadata: {
-          namespace: "login",
-        },
-      },
-    ],
-  });
-  const exported = await runExportFiles(imported);
+	const imported = await importFiles({
+		settings: {} as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(JSON.stringify(enCommon)),
+				toBeImportedFilesMetadata: {
+					namespace: "common",
+				},
+			},
+			{
+				locale: "en",
+				content: new TextEncoder().encode(JSON.stringify(enLogin)),
+				toBeImportedFilesMetadata: {
+					namespace: "login",
+				},
+			},
+		],
+	});
+	const exported = await runExportFiles(imported);
 
-  const exportedCommon = JSON.parse(
-    new TextDecoder().decode(
-      exported.find((e) => e.name === "common-en.json")?.content,
-    ),
-  );
-  const exportedLogin = JSON.parse(
-    new TextDecoder().decode(
-      exported.find((e) => e.name === "login-en.json")?.content,
-    ),
-  );
+	const exportedCommon = JSON.parse(
+		new TextDecoder().decode(
+			exported.find((e) => e.name === "common-en.json")?.content
+		)
+	);
+	const exportedLogin = JSON.parse(
+		new TextDecoder().decode(
+			exported.find((e) => e.name === "login-en.json")?.content
+		)
+	);
 
-  expect(exportedCommon).toStrictEqual({
-    confirm: "value1",
-  });
-  expect(exportedLogin).toStrictEqual({
-    button: "value2",
-  });
+	expect(exportedCommon).toStrictEqual({
+		confirm: "value1",
+	});
+	expect(exportedLogin).toStrictEqual({
+		button: "value2",
+	});
 });
 
 test("it should put new entities into the file without a namespace", async () => {
-  const enNoNamespace = {
-    blue_box: "value1",
-  };
+	const enNoNamespace = {
+		blue_box: "value1",
+	};
 
-  const enCommon = {
-    foo_bar: "value2",
-  };
+	const enCommon = {
+		foo_bar: "value2",
+	};
 
-  const imported = await importFiles({
-    settings: {} as any,
-    files: [
-      {
-        locale: "en",
-        content: new TextEncoder().encode(JSON.stringify(enNoNamespace)),
-      },
-      {
-        locale: "en",
-        content: new TextEncoder().encode(JSON.stringify(enCommon)),
-        toBeImportedFilesMetadata: {
-          namespace: "common",
-        },
-      },
-    ],
-  });
+	const imported = await importFiles({
+		settings: {} as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(JSON.stringify(enNoNamespace)),
+			},
+			{
+				locale: "en",
+				content: new TextEncoder().encode(JSON.stringify(enCommon)),
+				toBeImportedFilesMetadata: {
+					namespace: "common",
+				},
+			},
+		],
+	});
 
-  const newBundle: Bundle = {
-    id: "new_bundle",
-    declarations: [],
-  };
+	const newBundle: Bundle = {
+		id: "new_bundle",
+		declarations: [],
+	};
 
-  const newMessage: Message = {
-    id: "mock-29jas",
-    bundleId: "new_bundle",
-    locale: "en",
-    selectors: [],
-  };
+	const newMessage: Message = {
+		id: "mock-29jas",
+		bundleId: "new_bundle",
+		locale: "en",
+		selectors: [],
+	};
 
-  const newVariant: Variant = {
-    id: "mock-111sss",
-    matches: [],
-    messageId: "mock-29jas",
-    pattern: [{ type: "text", value: "elephant" }],
-  };
+	const newVariant: Variant = {
+		id: "mock-111sss",
+		matches: [],
+		messageId: "mock-29jas",
+		pattern: [{ type: "text", value: "elephant" }],
+	};
 
-  const exported = await runExportFiles({
-    bundles: [...imported.bundles, newBundle],
-    messages: [...imported.messages, newMessage],
-    variants: [...imported.variants, newVariant],
-  });
+	const exported = await runExportFiles({
+		bundles: [...imported.bundles, newBundle],
+		messages: [...imported.messages, newMessage],
+		variants: [...imported.variants, newVariant],
+	});
 
-  const exportedNoNamespace = JSON.parse(
-    new TextDecoder().decode(
-      exported.find((e) => e.name === "en.json")?.content,
-    ),
-  );
+	const exportedNoNamespace = JSON.parse(
+		new TextDecoder().decode(
+			exported.find((e) => e.name === "en.json")?.content
+		)
+	);
 
-  const exportedCommon = JSON.parse(
-    new TextDecoder().decode(
-      exported.find((e) => e.name === "common-en.json")?.content,
-    ),
-  );
+	const exportedCommon = JSON.parse(
+		new TextDecoder().decode(
+			exported.find((e) => e.name === "common-en.json")?.content
+		)
+	);
 
-  expect(exportedNoNamespace).toStrictEqual({
-    blue_box: "value1",
-    new_bundle: "elephant",
-  });
+	expect(exportedNoNamespace).toStrictEqual({
+		blue_box: "value1",
+		new_bundle: "elephant",
+	});
 
-  expect(exportedCommon).toStrictEqual({
-    foo_bar: "value2",
-  });
+	expect(exportedCommon).toStrictEqual({
+		foo_bar: "value2",
+	});
 });
 
 test("a key with a single variant should have no matches even if other keys are multi variant", async () => {
-  const imported = await runImportFiles({
-    key: "value",
-    keyPluralSimple_one: "the singular",
-    keyPluralSimple_other: "the plural",
-  });
+	const imported = await runImportFiles({
+		key: "value",
+		keyPluralSimple_one: "the singular",
+		keyPluralSimple_other: "the plural",
+	});
 
-  expect(await runExportFilesParsed(imported)).toStrictEqual({
-    key: "value",
-    keyPluralSimple_one: "the singular",
-    keyPluralSimple_other: "the plural",
-  });
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		key: "value",
+		keyPluralSimple_one: "the singular",
+		keyPluralSimple_other: "the plural",
+	});
 
-  expect(imported.bundles).lengthOf(2);
-  expect(imported.messages).lengthOf(3);
-  expect(imported.variants).lengthOf(3);
+	expect(imported.bundles).lengthOf(2);
+	expect(imported.messages).lengthOf(3);
+	expect(imported.variants).lengthOf(3);
 
-  expect(imported.bundles[0]?.id).toStrictEqual("key");
+	expect(imported.bundles[0]?.id).toStrictEqual("key");
 
-  expect(imported.messages[0]?.selectors).toStrictEqual([]);
-  expect(imported.variants[0]?.matches).toStrictEqual([]);
-  expect(imported.variants[0]?.pattern).toStrictEqual([
-    { type: "text", value: "value" },
-  ]);
+	expect(imported.messages[0]?.selectors).toStrictEqual([]);
+	expect(imported.variants[0]?.matches).toStrictEqual([]);
+	expect(imported.variants[0]?.pattern).toStrictEqual([
+		{ type: "text", value: "value" },
+	]);
+});
+
+// https://github.com/opral/inlang-paraglide-js/issues/513
+test("custom variable reference patterns can be provided", async () => {
+	const settings = {
+		"plugin.inlang.i18next": {
+			variableReferencePattern: ["<", ">"],
+		},
+	};
+
+	const imported = await runImportFiles(
+		{
+			blue: "blue {{blue}}",
+			red: "red <red>",
+		},
+		settings
+	);
+
+	expect(imported.variants[0]?.pattern).toStrictEqual([
+		{ type: "text", value: "blue {{blue}}" },
+	] satisfies Pattern);
+	expect(imported.variants[1]?.pattern).toStrictEqual([
+		{ type: "text", value: "red " },
+		{ type: "expression", arg: { type: "variable-reference", name: "red" } },
+	] satisfies Pattern);
+
+	expect(await runExportFilesParsed(imported, settings)).toStrictEqual({
+		blue: "blue {{blue}}",
+		red: "red <red>",
+	});
 });
 
 // convenience wrapper for less testing code
-function runImportFiles(json: Record<string, any>) {
-  return importFiles({
-    settings: {} as any,
-    files: [
-      {
-        locale: "en",
-        content: new TextEncoder().encode(JSON.stringify(json)),
-      },
-    ],
-  });
+function runImportFiles(json: Record<string, any>, settings?: any) {
+	return importFiles({
+		settings: settings ?? {},
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(JSON.stringify(json)),
+			},
+		],
+	});
 }
 
 // convenience wrapper for less testing code
 async function runExportFiles(
-  imported: Awaited<ReturnType<typeof importFiles>>,
+	imported: Awaited<ReturnType<typeof importFiles>>,
+	settings?: any
 ) {
-  // add ids which are undefined from the import
-  for (const message of imported.messages) {
-    if (message.id === undefined) {
-      message.id = `${Math.random() * 1000}`;
-    }
-  }
-  for (const variant of imported.variants) {
-    if (variant.id === undefined) {
-      // @ts-expect-error - variant is an VariantImport
-      variant.id = `${Math.random() * 1000}`;
-    }
-    if (variant.messageId === undefined) {
-      // @ts-expect-error - variant is an VariantImport
-      variant.messageId = imported.messages.find(
-        (m: any) =>
-          m.bundleId === variant.messageBundleId &&
-          m.locale === variant.messageLocale,
-      )?.id;
-    }
-  }
+	// add ids which are undefined from the import
+	for (const message of imported.messages) {
+		if (message.id === undefined) {
+			message.id = `${Math.random() * 1000}`;
+		}
+	}
+	for (const variant of imported.variants) {
+		if (variant.id === undefined) {
+			// @ts-expect-error - variant is an VariantImport
+			variant.id = `${Math.random() * 1000}`;
+		}
+		if (variant.messageId === undefined) {
+			// @ts-expect-error - variant is an VariantImport
+			variant.messageId = imported.messages.find(
+				(m: any) =>
+					m.bundleId === variant.messageBundleId &&
+					m.locale === variant.messageLocale
+			)?.id;
+		}
+	}
 
-  const exported = await exportFiles({
-    settings: {} as any,
-    bundles: imported.bundles as Bundle[],
-    messages: imported.messages as Message[],
-    variants: imported.variants as Variant[],
-  });
-  return exported;
+	const exported = await exportFiles({
+		settings: settings ?? {},
+		bundles: imported.bundles as Bundle[],
+		messages: imported.messages as Message[],
+		variants: imported.variants as Variant[],
+	});
+	return exported;
 }
 
 // convenience wrapper for less testing code
-async function runExportFilesParsed(imported: any) {
-  const exported = await runExportFiles(imported);
-  return JSON.parse(new TextDecoder().decode(exported[0]?.content));
+async function runExportFilesParsed(imported: any, settings?: any) {
+	const exported = await runExportFiles(imported, settings);
+	return JSON.parse(new TextDecoder().decode(exported[0]?.content));
 }


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/513