### PR TITLE
plugin-m-function-matcher support for nested messages

### DIFF
--- a/.changeset/polite-spies-argue.md
+++ b/.changeset/polite-spies-argue.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-m-function-matcher": minor
+---
+
+Adds support for nested messages

--- a/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
@@ -2,66 +2,66 @@ import { describe, expect, it } from "vitest";
 import { parse } from "./messageReferenceMatchers.js"; // Replace with the actual filename
 
 describe("Paraglide Message Parser", () => {
-	it("should match simple m function call", () => {
-		const sourceCode = `
+  it("should match simple m function call", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.helloWorld();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 3, character: 5 },
-					end: { line: 3, character: 17 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 3, character: 5 },
+          end: { line: 3, character: 17 },
+        },
+      },
+    ]);
+  });
 
-	it("should match simple named import m function call", () => {
-		const sourceCode = `
+  it("should match simple named import m function call", () => {
+    const sourceCode = `
 		import { m } from "../../i18n-generated/messages";
 		m.helloWorld();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 3, character: 5 },
-					end: { line: 3, character: 17 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 3, character: 5 },
+          end: { line: 3, character: 17 },
+        },
+      },
+    ]);
+  });
 
-	// it should match minified m function call
-	it("should match minified m function call", () => {
-		const sourceCode = `
+  // it should match minified m function call
+  it("should match minified m function call", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";m.helloWorld();m.hello_world();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 2, character: 56 },
-					end: { line: 2, character: 68 },
-				},
-			},
-			{
-				messageId: "hello_world",
-				position: {
-					start: { line: 2, character: 71 },
-					end: { line: 2, character: 84 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 2, character: 56 },
+          end: { line: 2, character: 68 },
+        },
+      },
+      {
+        messageId: "hello_world",
+        position: {
+          start: { line: 2, character: 71 },
+          end: { line: 2, character: 84 },
+        },
+      },
+    ]);
+  });
 
-	it("should match m function call with arguments", () => {
-		const sourceCode = `
+  it("should match m function call with arguments", () => {
+    const sourceCode = `
 		import * as m from from "../../i18n-generated/messages";
 		
     m.someFunction({
@@ -71,97 +71,97 @@ describe("Paraglide Message Parser", () => {
 		m.someFunction({args1: "", args2: ""}, {languageTag: "en"});
 		m.some_function({args1: "", args2: ""}, {languageTag: "en"});
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "someFunction",
-				position: {
-					start: { line: 4, character: 7 },
-					end: { line: 4, character: 72 },
-				},
-			},
-			{
-				messageId: "someFunction",
-				position: {
-					start: { line: 8, character: 5 },
-					end: { line: 8, character: 62 },
-				},
-			},
-			{
-				messageId: "some_function",
-				position: {
-					start: { line: 9, character: 5 },
-					end: { line: 9, character: 63 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "someFunction",
+        position: {
+          start: { line: 4, character: 7 },
+          end: { line: 4, character: 72 },
+        },
+      },
+      {
+        messageId: "someFunction",
+        position: {
+          start: { line: 8, character: 5 },
+          end: { line: 8, character: 62 },
+        },
+      },
+      {
+        messageId: "some_function",
+        position: {
+          start: { line: 9, character: 5 },
+          end: { line: 9, character: 63 },
+        },
+      },
+    ]);
+  });
 
-	it("should match multiple messages", () => {
-		const sourceCode = `
+  it("should match multiple messages", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		
 		m.helloWorld();
 		m.someFunction({args1: "", args2: ""}, {languageTag: "en"});
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 4, character: 5 },
-					end: { line: 4, character: 17 },
-				},
-			},
-			{
-				messageId: "someFunction",
-				position: {
-					start: { line: 5, character: 5 },
-					end: { line: 5, character: 62 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 4, character: 5 },
+          end: { line: 4, character: 17 },
+        },
+      },
+      {
+        messageId: "someFunction",
+        position: {
+          start: { line: 5, character: 5 },
+          end: { line: 5, character: 62 },
+        },
+      },
+    ]);
+  });
 
-	it("should match message from multiple namespaces", () => {
-		const namespaces = ["frontend", "backend", "example", "other", "project-1"];
-		for (const namespace of namespaces) {
-			const sourceCode = `
+  it("should match message from multiple namespaces", () => {
+    const namespaces = ["frontend", "backend", "example", "other", "project-1"];
+    for (const namespace of namespaces) {
+      const sourceCode = `
 		import * as m from "@inlang/paraglide-js/${namespace}/messages";
 		m.helloWorld();
 		`;
-			const result = parse(sourceCode);
-			expect(result).toEqual([
-				{
-					messageId: "helloWorld",
-					position: {
-						start: { line: 3, character: 5 },
-						end: { line: 3, character: 17 },
-					},
-				},
-			]);
-		}
-	});
+      const result = parse(sourceCode);
+      expect(result).toEqual([
+        {
+          messageId: "helloWorld",
+          position: {
+            start: { line: 3, character: 5 },
+            end: { line: 3, character: 17 },
+          },
+        },
+      ]);
+    }
+  });
 
-	it("should match message with no namespace", () => {
-		const sourceCode = `
+  it("should match message with no namespace", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.helloWorld();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 3, character: 5 },
-					end: { line: 3, character: 17 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 3, character: 5 },
+          end: { line: 3, character: 17 },
+        },
+      },
+    ]);
+  });
 
-	it("should match mutiple references to @inlang/paraglide-js", () => {
-		const sourceCode = `
+  it("should match mutiple references to @inlang/paraglide-js", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 
 		@inlang/paraglide-js
@@ -169,62 +169,62 @@ describe("Paraglide Message Parser", () => {
 		m.helloWorld();
 		m.some_function_with_a_long_name({args1: "", args2: ""}, {languageTag: "en"});
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 6, character: 5 },
-					end: { line: 6, character: 17 },
-				},
-			},
-			{
-				messageId: "some_function_with_a_long_name",
-				position: {
-					start: { line: 7, character: 5 },
-					end: { line: 7, character: 80 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 6, character: 5 },
+          end: { line: 6, character: 17 },
+        },
+      },
+      {
+        messageId: "some_function_with_a_long_name",
+        position: {
+          start: { line: 7, character: 5 },
+          end: { line: 7, character: 80 },
+        },
+      },
+    ]);
+  });
 
-	it("should match the m function with an object and the arguments a function call", () => {
-		const sourceCode = `
+  it("should match the m function with an object and the arguments a function call", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.helloWorld({args1: someFunction(), args2: otherFunction(), args3: "some string"});
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 3, character: 5 },
-					end: { line: 3, character: 86 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 3, character: 5 },
+          end: { line: 3, character: 86 },
+        },
+      },
+    ]);
+  });
 
-	// it should match the m function which do have function chaining
-	it("should match the m function which do have function chaining", () => {
-		const sourceCode = `
+  // it should match the m function which do have function chaining
+  it("should match the m function which do have function chaining", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.helloWorld().someFunction().someOtherFunction();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 3, character: 5 },
-					end: { line: 3, character: 17 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 3, character: 5 },
+          end: { line: 3, character: 17 },
+        },
+      },
+    ]);
+  });
 
-	it("should match the m function in a complete file", () => {
-		const sourceCode = `
+  it("should match the m function in a complete file", () => {
+    const sourceCode = `
 		import { createSignal } from "solid-js"
 		import { showToast } from "./Toast.jsx"
 		import { rpc } from "@inlang/rpc"
@@ -274,65 +274,65 @@ describe("Paraglide Message Parser", () => {
 			)
 		};
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "newsletter_error_alreadySubscribed",
-				position: {
-					end: {
-						character: 55,
-						line: 19,
-					},
-					start: {
-						character: 19,
-						line: 19,
-					},
-				},
-			},
-			{
-				messageId: "newsletter_success",
-				position: {
-					end: {
-						character: 39,
-						line: 25,
-					},
-					start: {
-						character: 19,
-						line: 25,
-					},
-				},
-			},
-			{
-				messageId: "newsletter_error_generic",
-				position: {
-					end: {
-						character: 45,
-						line: 31,
-					},
-					start: {
-						character: 19,
-						line: 31,
-					},
-				},
-			},
-			{
-				messageId: "newsletter_error_generic",
-				position: {
-					end: {
-						character: 44,
-						line: 38,
-					},
-					start: {
-						character: 18,
-						line: 38,
-					},
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "newsletter_error_alreadySubscribed",
+        position: {
+          end: {
+            character: 55,
+            line: 19,
+          },
+          start: {
+            character: 19,
+            line: 19,
+          },
+        },
+      },
+      {
+        messageId: "newsletter_success",
+        position: {
+          end: {
+            character: 39,
+            line: 25,
+          },
+          start: {
+            character: 19,
+            line: 25,
+          },
+        },
+      },
+      {
+        messageId: "newsletter_error_generic",
+        position: {
+          end: {
+            character: 45,
+            line: 31,
+          },
+          start: {
+            character: 19,
+            line: 31,
+          },
+        },
+      },
+      {
+        messageId: "newsletter_error_generic",
+        position: {
+          end: {
+            character: 44,
+            line: 38,
+          },
+          start: {
+            character: 18,
+            line: 38,
+          },
+        },
+      },
+    ]);
+  });
 
-	it("should parse function calls without parentheses", () => {
-		const sourceCode = `import * as m from 'module';
+  it("should parse function calls without parentheses", () => {
+    const sourceCode = `import * as m from 'module';
 
 		const a = {
 			b: m.helloWorld,
@@ -341,181 +341,172 @@ describe("Paraglide Message Parser", () => {
 			e: m.this_is_a_message123,
 		}
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 4, character: 9 },
-					end: { line: 4, character: 19 },
-				},
-			},
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 5, character: 9 },
-					end: { line: 5, character: 21 },
-				},
-			},
-			{
-				messageId: "helloWorld",
-				position: {
-					start: { line: 6, character: 9 },
-					end: { line: 6, character: 21 },
-				},
-			},
-			{
-				messageId: "this_is_a_message123",
-				position: {
-					start: { line: 7, character: 9 },
-					end: { line: 7, character: 29 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 4, character: 9 },
+          end: { line: 4, character: 19 },
+        },
+      },
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 5, character: 9 },
+          end: { line: 5, character: 21 },
+        },
+      },
+      {
+        messageId: "helloWorld",
+        position: {
+          start: { line: 6, character: 9 },
+          end: { line: 6, character: 21 },
+        },
+      },
+      {
+        messageId: "this_is_a_message123",
+        position: {
+          start: { line: 7, character: 9 },
+          end: { line: 7, character: 29 },
+        },
+      },
+    ]);
+  });
 
-	it("should match a message in human readble id", () => {
-		const sourceCode = `
+  it("should match a message in human readble id", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.penguin_purple_shoe_window();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "penguin_purple_shoe_window",
-				position: {
-					start: { line: 3, character: 5 },
-					end: { line: 3, character: 33 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "penguin_purple_shoe_window",
+        position: {
+          start: { line: 3, character: 5 },
+          end: { line: 3, character: 33 },
+        },
+      },
+    ]);
+  });
 
-	it("should match nested message format using bracket notation", () => {
-		const sourceCode = `
+  it("should match nested message format using bracket notation", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m["simple"]();
 		m['simple']();
 		m["with.dot"]();
 		m["with.two.dots"]();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "simple",
-				position: {
-					start: { line: 3, character: 6 },
-					end: { line: 3, character: 16 },
-				},
-			},
-			{
-				messageId: "simple",
-				position: {
-					start: { line: 4, character: 6 },
-					end: { line: 4, character: 16 },
-				},
-			},
-			{
-				messageId: "with.dot",
-				position: {
-					start: { line: 5, character: 6 },
-					end: { line: 5, character: 18 },
-				},
-			},
-			{
-				messageId: "with.two.dots",
-				position: {
-					start: { line: 6, character: 6 },
-					end: { line: 6, character: 23 },
-				},
-			},
-		]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "simple",
+        position: {
+          start: { line: 3, character: 6 },
+          end: { line: 3, character: 16 },
+        },
+      },
+      {
+        messageId: "simple",
+        position: {
+          start: { line: 4, character: 6 },
+          end: { line: 4, character: 16 },
+        },
+      },
+      {
+        messageId: "with.dot",
+        position: {
+          start: { line: 5, character: 6 },
+          end: { line: 5, character: 18 },
+        },
+      },
+      {
+        messageId: "with.two.dots",
+        position: {
+          start: { line: 6, character: 6 },
+          end: { line: 6, character: 23 },
+        },
+      },
+   ]);
+  });
 
-	it("should match if both dot and bracket notation are used in the same file", () => {
-		const sourceCode = `
-		import * as m from "../../i18n-generated/messages";
-		m.simple();
-		m["simple"]();
-		m.simple();
-		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([
-			{
-				messageId: "simple",
-				position: {
-					start: { line: 3, character: 5 },
-					end: { line: 3, character: 13 },
-				},
-			},
-			{
-				messageId: "simple",
-				position: {
-					start: { line: 4, character: 6 },
-					end: { line: 4, character: 16 },
-				},
-			},
-			{
-				messageId: "simple",
-				position: {
-					start: { line: 5, character: 5 },
-					end: { line: 5, character: 13 },
-				},
-			},
-		]);
-	});
+  it("should match if both dot and bracket notation are used in the same file", () => {
+    const sourceCode = `
+    import * as m from "../../i18n-generated/messages";
+    m.simple();
+    m["simple"]();
+    m.simple();
+    `;
+    const result = parse(sourceCode);
+    expect(result).toEqual([
+      {
+        messageId: "simple",
+        position: {
+          start: { line: 3, character: 5 },
+          end: { line: 3, character: 13 },
+        },
+      },
+      {
+        messageId: "simple",
+        position: {
+          start: { line: 4, character: 6 },
+          end: { line: 4, character: 16 },
+        },
+      },
+      {
+        messageId: "simple",
+        position: {
+          start: { line: 5, character: 5 },
+          end: { line: 5, character: 13 },
+        },
+      },
+    ]);
+  });
 
-	it("should match if m is defined before the reference to paraglide", () => {
-		const sourceCode = `
+  it("should match if m is defined before the reference to paraglide", () => {
+    const sourceCode = `
 		m.helloWorld();
 		import * as m from "../../i18n-generated/messages";
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([]);
+  });
 
-	it("should match if m is defined but no reference to paraglide", () => {
-		const sourceCode = `
+  it("should match if m is defined but no reference to paraglide", () => {
+    const sourceCode = `
 		m.helloWorld();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([]);
+  });
 
-	it("should match if m is defined but has a spell error", () => {
-		const sourceCode = `
+  it("should match if m is defined but has a spell error", () => {
+    const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		xm.helloWorld();
 		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([]);
-	});
+    const result = parse(sourceCode);
+    expect(result).toEqual([]);
+  });
 
-	it("should match no matches", () => {
-		const sourceCode = "const x = 42;";
-		const result = parse(sourceCode);
-		expect(result).toEqual([]);
-	});
+  it("should match no matches", () => {
+    const sourceCode = "const x = 42;";
+    const result = parse(sourceCode);
+    expect(result).toEqual([]);
+  });
 
-	it("should match invalid syntax", () => {
-		const sourceCode = "const x = 42; m.helloWorld(";
-		const result = parse(sourceCode);
-		expect(result).toEqual([]);
-	});
+  it("should match invalid syntax", () => {
+    const sourceCode = "const x = 42; m.helloWorld(";
+    const result = parse(sourceCode);
+    expect(result).toEqual([]);
+  });
 
-	it("should match invalid bracket notation syntax", () => {
-		const sourceCode = `
-		import * as m from "../../i18n-generated/messages";
-		m['simple"]();
-		`;
-		const result = parse(sourceCode);
-		expect(result).toEqual([]);
-	});
+  it("should return an empty array when parsing fails", () => {
+    const sourceCode = undefined;
 
-	it("should return an empty array when parsing fails", () => {
-		const sourceCode = undefined;
-
-		const result = parse(sourceCode as unknown as string);
-		expect(result).toEqual([]);
-	});
+    const result = parse(sourceCode as unknown as string);
+    expect(result).toEqual([]);
+  });
 });

--- a/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
@@ -2,66 +2,66 @@ import { describe, expect, it } from "vitest";
 import { parse } from "./messageReferenceMatchers.js"; // Replace with the actual filename
 
 describe("Paraglide Message Parser", () => {
-  it("should match simple m function call", () => {
-    const sourceCode = `
+	it("should match simple m function call", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.helloWorld();
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 3, character: 5 },
-          end: { line: 3, character: 17 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 17 },
+				},
+			},
+		]);
+	});
 
-  it("should match simple named import m function call", () => {
-    const sourceCode = `
+	it("should match simple named import m function call", () => {
+		const sourceCode = `
 		import { m } from "../../i18n-generated/messages";
 		m.helloWorld();
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 3, character: 5 },
-          end: { line: 3, character: 17 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 17 },
+				},
+			},
+		]);
+	});
 
-  // it should match minified m function call
-  it("should match minified m function call", () => {
-    const sourceCode = `
+	// it should match minified m function call
+	it("should match minified m function call", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";m.helloWorld();m.hello_world();
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 2, character: 56 },
-          end: { line: 2, character: 68 },
-        },
-      },
-      {
-        messageId: "hello_world",
-        position: {
-          start: { line: 2, character: 71 },
-          end: { line: 2, character: 84 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 2, character: 56 },
+					end: { line: 2, character: 68 },
+				},
+			},
+			{
+				messageId: "hello_world",
+				position: {
+					start: { line: 2, character: 71 },
+					end: { line: 2, character: 84 },
+				},
+			},
+		]);
+	});
 
-  it("should match m function call with arguments", () => {
-    const sourceCode = `
+	it("should match m function call with arguments", () => {
+		const sourceCode = `
 		import * as m from from "../../i18n-generated/messages";
 		
     m.someFunction({
@@ -71,97 +71,97 @@ describe("Paraglide Message Parser", () => {
 		m.someFunction({args1: "", args2: ""}, {languageTag: "en"});
 		m.some_function({args1: "", args2: ""}, {languageTag: "en"});
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "someFunction",
-        position: {
-          start: { line: 4, character: 7 },
-          end: { line: 4, character: 72 },
-        },
-      },
-      {
-        messageId: "someFunction",
-        position: {
-          start: { line: 8, character: 5 },
-          end: { line: 8, character: 62 },
-        },
-      },
-      {
-        messageId: "some_function",
-        position: {
-          start: { line: 9, character: 5 },
-          end: { line: 9, character: 63 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "someFunction",
+				position: {
+					start: { line: 4, character: 7 },
+					end: { line: 4, character: 72 },
+				},
+			},
+			{
+				messageId: "someFunction",
+				position: {
+					start: { line: 8, character: 5 },
+					end: { line: 8, character: 62 },
+				},
+			},
+			{
+				messageId: "some_function",
+				position: {
+					start: { line: 9, character: 5 },
+					end: { line: 9, character: 63 },
+				},
+			},
+		]);
+	});
 
-  it("should match multiple messages", () => {
-    const sourceCode = `
+	it("should match multiple messages", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		
 		m.helloWorld();
 		m.someFunction({args1: "", args2: ""}, {languageTag: "en"});
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 4, character: 5 },
-          end: { line: 4, character: 17 },
-        },
-      },
-      {
-        messageId: "someFunction",
-        position: {
-          start: { line: 5, character: 5 },
-          end: { line: 5, character: 62 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 4, character: 5 },
+					end: { line: 4, character: 17 },
+				},
+			},
+			{
+				messageId: "someFunction",
+				position: {
+					start: { line: 5, character: 5 },
+					end: { line: 5, character: 62 },
+				},
+			},
+		]);
+	});
 
-  it("should match message from multiple namespaces", () => {
-    const namespaces = ["frontend", "backend", "example", "other", "project-1"];
-    for (const namespace of namespaces) {
-      const sourceCode = `
+	it("should match message from multiple namespaces", () => {
+		const namespaces = ["frontend", "backend", "example", "other", "project-1"];
+		for (const namespace of namespaces) {
+			const sourceCode = `
 		import * as m from "@inlang/paraglide-js/${namespace}/messages";
 		m.helloWorld();
 		`;
-      const result = parse(sourceCode);
-      expect(result).toEqual([
-        {
-          messageId: "helloWorld",
-          position: {
-            start: { line: 3, character: 5 },
-            end: { line: 3, character: 17 },
-          },
-        },
-      ]);
-    }
-  });
+			const result = parse(sourceCode);
+			expect(result).toEqual([
+				{
+					messageId: "helloWorld",
+					position: {
+						start: { line: 3, character: 5 },
+						end: { line: 3, character: 17 },
+					},
+				},
+			]);
+		}
+	});
 
-  it("should match message with no namespace", () => {
-    const sourceCode = `
+	it("should match message with no namespace", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.helloWorld();
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 3, character: 5 },
-          end: { line: 3, character: 17 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 17 },
+				},
+			},
+		]);
+	});
 
-  it("should match mutiple references to @inlang/paraglide-js", () => {
-    const sourceCode = `
+	it("should match mutiple references to @inlang/paraglide-js", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 
 		@inlang/paraglide-js
@@ -169,62 +169,62 @@ describe("Paraglide Message Parser", () => {
 		m.helloWorld();
 		m.some_function_with_a_long_name({args1: "", args2: ""}, {languageTag: "en"});
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 6, character: 5 },
-          end: { line: 6, character: 17 },
-        },
-      },
-      {
-        messageId: "some_function_with_a_long_name",
-        position: {
-          start: { line: 7, character: 5 },
-          end: { line: 7, character: 80 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 6, character: 5 },
+					end: { line: 6, character: 17 },
+				},
+			},
+			{
+				messageId: "some_function_with_a_long_name",
+				position: {
+					start: { line: 7, character: 5 },
+					end: { line: 7, character: 80 },
+				},
+			},
+		]);
+	});
 
-  it("should match the m function with an object and the arguments a function call", () => {
-    const sourceCode = `
+	it("should match the m function with an object and the arguments a function call", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.helloWorld({args1: someFunction(), args2: otherFunction(), args3: "some string"});
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 3, character: 5 },
-          end: { line: 3, character: 86 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 86 },
+				},
+			},
+		]);
+	});
 
-  // it should match the m function which do have function chaining
-  it("should match the m function which do have function chaining", () => {
-    const sourceCode = `
+	// it should match the m function which do have function chaining
+	it("should match the m function which do have function chaining", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.helloWorld().someFunction().someOtherFunction();
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 3, character: 5 },
-          end: { line: 3, character: 17 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 17 },
+				},
+			},
+		]);
+	});
 
-  it("should match the m function in a complete file", () => {
-    const sourceCode = `
+	it("should match the m function in a complete file", () => {
+		const sourceCode = `
 		import { createSignal } from "solid-js"
 		import { showToast } from "./Toast.jsx"
 		import { rpc } from "@inlang/rpc"
@@ -274,65 +274,65 @@ describe("Paraglide Message Parser", () => {
 			)
 		};
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "newsletter_error_alreadySubscribed",
-        position: {
-          end: {
-            character: 55,
-            line: 19,
-          },
-          start: {
-            character: 19,
-            line: 19,
-          },
-        },
-      },
-      {
-        messageId: "newsletter_success",
-        position: {
-          end: {
-            character: 39,
-            line: 25,
-          },
-          start: {
-            character: 19,
-            line: 25,
-          },
-        },
-      },
-      {
-        messageId: "newsletter_error_generic",
-        position: {
-          end: {
-            character: 45,
-            line: 31,
-          },
-          start: {
-            character: 19,
-            line: 31,
-          },
-        },
-      },
-      {
-        messageId: "newsletter_error_generic",
-        position: {
-          end: {
-            character: 44,
-            line: 38,
-          },
-          start: {
-            character: 18,
-            line: 38,
-          },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "newsletter_error_alreadySubscribed",
+				position: {
+					end: {
+						character: 55,
+						line: 19,
+					},
+					start: {
+						character: 19,
+						line: 19,
+					},
+				},
+			},
+			{
+				messageId: "newsletter_success",
+				position: {
+					end: {
+						character: 39,
+						line: 25,
+					},
+					start: {
+						character: 19,
+						line: 25,
+					},
+				},
+			},
+			{
+				messageId: "newsletter_error_generic",
+				position: {
+					end: {
+						character: 45,
+						line: 31,
+					},
+					start: {
+						character: 19,
+						line: 31,
+					},
+				},
+			},
+			{
+				messageId: "newsletter_error_generic",
+				position: {
+					end: {
+						character: 44,
+						line: 38,
+					},
+					start: {
+						character: 18,
+						line: 38,
+					},
+				},
+			},
+		]);
+	});
 
-  it("should parse function calls without parentheses", () => {
-    const sourceCode = `import * as m from 'module';
+	it("should parse function calls without parentheses", () => {
+		const sourceCode = `import * as m from 'module';
 
 		const a = {
 			b: m.helloWorld,
@@ -341,57 +341,57 @@ describe("Paraglide Message Parser", () => {
 			e: m.this_is_a_message123,
 		}
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 4, character: 9 },
-          end: { line: 4, character: 19 },
-        },
-      },
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 5, character: 9 },
-          end: { line: 5, character: 21 },
-        },
-      },
-      {
-        messageId: "helloWorld",
-        position: {
-          start: { line: 6, character: 9 },
-          end: { line: 6, character: 21 },
-        },
-      },
-      {
-        messageId: "this_is_a_message123",
-        position: {
-          start: { line: 7, character: 9 },
-          end: { line: 7, character: 29 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 4, character: 9 },
+					end: { line: 4, character: 19 },
+				},
+			},
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 5, character: 9 },
+					end: { line: 5, character: 21 },
+				},
+			},
+			{
+				messageId: "helloWorld",
+				position: {
+					start: { line: 6, character: 9 },
+					end: { line: 6, character: 21 },
+				},
+			},
+			{
+				messageId: "this_is_a_message123",
+				position: {
+					start: { line: 7, character: 9 },
+					end: { line: 7, character: 29 },
+				},
+			},
+		]);
+	});
 
-  it("should match a message in human readble id", () => {
-    const sourceCode = `
+	it("should match a message in human readble id", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m.penguin_purple_shoe_window();
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([
-      {
-        messageId: "penguin_purple_shoe_window",
-        position: {
-          start: { line: 3, character: 5 },
-          end: { line: 3, character: 33 },
-        },
-      },
-    ]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "penguin_purple_shoe_window",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 33 },
+				},
+			},
+		]);
+	});
 
-  it("should match nested message format using bracket notation", () => {
+	it("should match nested message format using bracket notation", () => {
 		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		m["simple"]();
@@ -512,10 +512,10 @@ describe("Paraglide Message Parser", () => {
 		expect(result).toEqual([]);
 	});
 
-  it("should return an empty array when parsing fails", () => {
-    const sourceCode = undefined;
+	it("should return an empty array when parsing fails", () => {
+		const sourceCode = undefined;
 
-    const result = parse(sourceCode as unknown as string);
-    expect(result).toEqual([]);
-  });
+		const result = parse(sourceCode as unknown as string);
+		expect(result).toEqual([]);
+	});
 });

--- a/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
@@ -503,6 +503,15 @@ describe("Paraglide Message Parser", () => {
     expect(result).toEqual([]);
   });
 
+	it("should match invalid bracket notation syntax", () => {
+		const sourceCode = `
+		import * as m from "../../i18n-generated/messages";
+		m['simple"]();
+		`;
+		const result = parse(sourceCode);
+		expect(result).toEqual([]);
+	});
+
   it("should return an empty array when parsing fails", () => {
     const sourceCode = undefined;
 

--- a/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
@@ -391,43 +391,126 @@ describe("Paraglide Message Parser", () => {
     ]);
   });
 
-  it("should match if m is defined before the reference to paraglide", () => {
-    const sourceCode = `
+  it("should match nested message format using bracket notation", () => {
+		const sourceCode = `
+		import * as m from "../../i18n-generated/messages";
+		m["simple"]();
+		m['simple']();
+		m["with.dot"]();
+		m["with.two.dots"]();
+		`;
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "simple",
+				position: {
+					start: { line: 3, character: 6 },
+					end: { line: 3, character: 16 },
+				},
+			},
+			{
+				messageId: "simple",
+				position: {
+					start: { line: 4, character: 6 },
+					end: { line: 4, character: 16 },
+				},
+			},
+			{
+				messageId: "with.dot",
+				position: {
+					start: { line: 5, character: 6 },
+					end: { line: 5, character: 18 },
+				},
+			},
+			{
+				messageId: "with.two.dots",
+				position: {
+					start: { line: 6, character: 6 },
+					end: { line: 6, character: 23 },
+				},
+			},
+		]);
+	});
+
+	it("should match if both dot and bracket notation are used in the same file", () => {
+		const sourceCode = `
+		import * as m from "../../i18n-generated/messages";
+		m.simple();
+		m["simple"]();
+		m.simple();
+		`;
+		const result = parse(sourceCode);
+		expect(result).toEqual([
+			{
+				messageId: "simple",
+				position: {
+					start: { line: 3, character: 5 },
+					end: { line: 3, character: 13 },
+				},
+			},
+			{
+				messageId: "simple",
+				position: {
+					start: { line: 4, character: 6 },
+					end: { line: 4, character: 16 },
+				},
+			},
+			{
+				messageId: "simple",
+				position: {
+					start: { line: 5, character: 5 },
+					end: { line: 5, character: 13 },
+				},
+			},
+		]);
+	});
+
+	it("should match if m is defined before the reference to paraglide", () => {
+		const sourceCode = `
 		m.helloWorld();
 		import * as m from "../../i18n-generated/messages";
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([]);
+	});
 
-  it("should match if m is defined but no reference to paraglide", () => {
-    const sourceCode = `
+	it("should match if m is defined but no reference to paraglide", () => {
+		const sourceCode = `
 		m.helloWorld();
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([]);
+	});
 
-  it("should match if m is defined but has a spell error", () => {
-    const sourceCode = `
+	it("should match if m is defined but has a spell error", () => {
+		const sourceCode = `
 		import * as m from "../../i18n-generated/messages";
 		xm.helloWorld();
 		`;
-    const result = parse(sourceCode);
-    expect(result).toEqual([]);
-  });
+		const result = parse(sourceCode);
+		expect(result).toEqual([]);
+	});
 
-  it("should match no matches", () => {
-    const sourceCode = "const x = 42;";
-    const result = parse(sourceCode);
-    expect(result).toEqual([]);
-  });
+	it("should match no matches", () => {
+		const sourceCode = "const x = 42;";
+		const result = parse(sourceCode);
+		expect(result).toEqual([]);
+	});
 
-  it("should match invalid syntax", () => {
-    const sourceCode = "const x = 42; m.helloWorld(";
-    const result = parse(sourceCode);
-    expect(result).toEqual([]);
-  });
+	it("should match invalid syntax", () => {
+		const sourceCode = "const x = 42; m.helloWorld(";
+		const result = parse(sourceCode);
+		expect(result).toEqual([]);
+	});
+
+	it("should match invalid bracket notation syntax", () => {
+		const sourceCode = `
+		import * as m from "../../i18n-generated/messages";
+		m['simple"]();
+		`;
+		const result = parse(sourceCode);
+		expect(result).toEqual([]);
+	});
 
   it("should return an empty array when parsing fails", () => {
     const sourceCode = undefined;

--- a/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.test.ts
@@ -434,11 +434,11 @@ describe("Paraglide Message Parser", () => {
 
   it("should match if both dot and bracket notation are used in the same file", () => {
     const sourceCode = `
-    import * as m from "../../i18n-generated/messages";
-    m.simple();
-    m["simple"]();
-    m.simple();
-    `;
+		import * as m from "../../i18n-generated/messages";
+		m.simple();
+		m["simple"]();
+		m.simple();
+		`;
     const result = parse(sourceCode);
     expect(result).toEqual([
       {

--- a/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.ts
@@ -10,125 +10,125 @@
 import Parsimmon from "parsimmon";
 
 const createParser = () => {
-	return Parsimmon.createLanguage({
-		entry: (r) => {
-			return Parsimmon.alt(r.findReference!, Parsimmon.any)
-				.many()
-				.map((matches) => matches.flatMap((match) => match))
-				.map((matches) =>
-					matches
-						.filter((item) => typeof item === "object")
-						.flat()
-						.filter((item) => item !== null)
-				);
-		},
+  return Parsimmon.createLanguage({
+    entry: (r) => {
+      return Parsimmon.alt(r.findReference!, Parsimmon.any)
+        .many()
+        .map((matches) => matches.flatMap((match) => match))
+        .map((matches) =>
+          matches
+            .filter((item) => typeof item === "object")
+            .flat()
+            .filter((item) => item !== null)
+        );
+    },
 
-		findReference: function (r) {
-			return Parsimmon.seq(
-				Parsimmon.regex(/(import \* as m)|(import { m })/),
-				r.findMessage!.many()
-			);
-		},
+    findReference: function (r) {
+      return Parsimmon.seq(
+        Parsimmon.regex(/(import \* as m)|(import { m })/),
+        r.findMessage!.many()
+      );
+    },
 
-		dotNotation: () => {
-			return Parsimmon.seqMap(
-				Parsimmon.string("."),
-				Parsimmon.index, // Capture start position
-				Parsimmon.regex(/\w+/), // Match the function name
-				Parsimmon.index, // Capture end position of function name
-				(_, start, messageId, end) => {
-					return {
-						messageId,
-						start,
-						end,
-					};
-				}
-			);
-		},
+    dotNotation: () => {
+      return Parsimmon.seqMap(
+        Parsimmon.string("."),
+        Parsimmon.index, // Capture start position
+        Parsimmon.regex(/\w+/), // Match the function name
+        Parsimmon.index, // Capture end position of function name
+        (_, start, messageId, end) => {
+          return {
+            messageId,
+            start,
+            end,
+          };
+        }
+      );
+    },
 
-		doubleQuote: () => {
-			return Parsimmon.seqMap(
-				Parsimmon.string('"'),
-				Parsimmon.index, // Capture start position
-				Parsimmon.regex(/[\w.]+/), // Match the function name
-				Parsimmon.string('"'),
-				(_, start, messageId) => {
-					return {
-						messageId,
-						start,
-					};
-				}
-			);
-		},
+    doubleQuote: () => {
+      return Parsimmon.seqMap(
+        Parsimmon.string('"'),
+        Parsimmon.index, // Capture start position
+        Parsimmon.regex(/[\w.]+/), // Match the function name
+        Parsimmon.string('"'),
+        (_, start, messageId) => {
+          return {
+            messageId,
+            start,
+          };
+        }
+      );
+    },
 
-		singleQuote: () => {
-			return Parsimmon.seqMap(
-				Parsimmon.string("'"),
-				Parsimmon.index, // Capture start position
-				Parsimmon.regex(/[\w.]+/), // Match the function name
-				Parsimmon.string("'"),
-				(_, start, messageId) => {
-					return {
-						messageId,
-						start,
-					};
-				}
-			);
-		},
+    singleQuote: () => {
+      return Parsimmon.seqMap(
+        Parsimmon.string("'"),
+        Parsimmon.index, // Capture start position
+        Parsimmon.regex(/[\w.]+/), // Match the function name
+        Parsimmon.string("'"),
+        (_, start, messageId) => {
+          return {
+            messageId,
+            start,
+          };
+        }
+      );
+    },
 
-		bracketNotation: (r) => {
-			return Parsimmon.seqMap(
-				Parsimmon.string("["),
-				Parsimmon.alt(r.doubleQuote!, r.singleQuote!),
-				Parsimmon.string("]"),
-				Parsimmon.index, // Capture end position
-				(_, quote, __, end) => {
-					return {
-						messageId: quote.messageId,
-						start: quote.start,
-						end: end,
-					};
-				}
-			);
-		},
+    bracketNotation: (r) => {
+      return Parsimmon.seqMap(
+        Parsimmon.string("["),
+        Parsimmon.alt(r.doubleQuote!, r.singleQuote!),
+        Parsimmon.string("]"),
+        Parsimmon.index, // Capture end position
+        (_, quote, __, end) => {
+          return {
+            messageId: quote.messageId,
+            start: quote.start,
+            end: end,
+          };
+        }
+      );
+    },
 
-		findMessage: (r) => {
-			return Parsimmon.seqMap(
-				Parsimmon.regex(/.*?(?<![a-zA-Z0-9/])m/s), // find m that's not preceded by letters/numbers
-				Parsimmon.alt(r.dotNotation!, r.bracketNotation!).or(
-					Parsimmon.succeed(null)
-				),
-				Parsimmon.regex(/\((?:[^()]|\([^()]*\))*\)/).or(Parsimmon.succeed("")), // function arguments or empty string
-				(_, notation, args) => {
-					// false positive (m not followed by dot or bracket notation)
-					if (notation === null) {
-						return null;
-					}
-					return {
-						messageId: `${notation.messageId}`,
-						position: {
-							start: {
-								line: notation.start.line,
-								character: notation.start.column,
-							},
-							end: {
-								line: notation.end.line,
-								character: notation.end.column + args.length, // adjust for arguments length
-							},
-						},
-					};
-				}
-			);
-		},
-	});
+    findMessage: (r) => {
+      return Parsimmon.seqMap(
+        Parsimmon.regex(/.*?(?<![a-zA-Z0-9/])m/s), // find m that's not preceded by letters/numbers
+        Parsimmon.alt(r.dotNotation!, r.bracketNotation!).or(
+          Parsimmon.succeed(null)
+        ),
+        Parsimmon.regex(/\((?:[^()]|\([^()]*\))*\)/).or(Parsimmon.succeed("")), // function arguments or empty string
+        (_, notation, args) => {
+          // false positive (m not followed by dot or bracket notation)
+          if (notation === null) {
+            return null;
+          }
+          return {
+            messageId: `${notation.messageId}`,
+            position: {
+              start: {
+                line: notation.start.line,
+                character: notation.start.column,
+              },
+              end: {
+                line: notation.end.line,
+                character: notation.end.column + args.length, // adjust for arguments length
+              },
+            },
+          };
+        }
+      );
+    },
+  });
 };
 
 // Parse the expression
 export function parse(sourceCode: string) {
-	try {
-		const parser = createParser();
-		return parser.entry!.tryParse(sourceCode);
-	} catch (e) {
-		return [];
-	}
+  try {
+    const parser = createParser();
+    return parser.entry!.tryParse(sourceCode);
+  } catch (e) {
+    return [];
+  }
 }

--- a/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.ts
@@ -10,48 +10,117 @@
 import Parsimmon from "parsimmon";
 
 const createParser = () => {
-  return Parsimmon.createLanguage({
-    entry: (r) => {
-      return Parsimmon.alt(r.findReference!, Parsimmon.any)
-        .many()
-        .map((matches) => matches.flatMap((match) => match))
-        .map((matches) =>
-          matches.filter((item) => typeof item === "object").flat(),
-        );
-    },
+	return Parsimmon.createLanguage({
+		entry: (r) => {
+			return Parsimmon.alt(r.findReference!, Parsimmon.any)
+				.many()
+				.map((matches) => matches.flatMap((match) => match))
+				.map((matches) =>
+					matches
+						.filter((item) => typeof item === "object")
+						.flat()
+						.filter((item) => item !== null)
+				);
+		},
 
-    findReference: function (r) {
-      return Parsimmon.seq(
-        Parsimmon.regex(/(import \* as m)|(import { m })/),
-        r.findMessage!.many(),
-      );
-    },
+		findReference: function (r) {
+			return Parsimmon.seq(
+				Parsimmon.regex(/(import \* as m)|(import { m })/),
+				r.findMessage!.many()
+			);
+		},
 
-    findMessage: () => {
-      return Parsimmon.seqMap(
-        Parsimmon.regex(/.*?(?<![a-zA-Z0-9/])m\./s), // no preceding letters or numbers
-        Parsimmon.index, // Capture start position
-        Parsimmon.regex(/\w+/), // Match the function name
-        Parsimmon.index, // Capture end position of function name
-        Parsimmon.regex(/\((?:[^()]|\([^()]*\))*\)/).or(Parsimmon.succeed("")), // function arguments or empty string
-        (_, start, messageId, end, args) => {
-          return {
-            messageId: `${messageId}`,
-            position: {
-              start: {
-                line: start.line,
-                character: start.column,
-              },
-              end: {
-                line: end.line,
-                character: end.column + args.length, // adjust for arguments length
-              },
-            },
-          };
-        },
-      );
-    },
-  });
+		dotNotation: () => {
+			return Parsimmon.seqMap(
+				Parsimmon.string("."),
+				Parsimmon.index, // Capture start position
+				Parsimmon.regex(/\w+/), // Match the function name
+				Parsimmon.index, // Capture end position of function name
+				(_, start, messageId, end) => {
+					return {
+						messageId,
+						start,
+						end,
+					};
+				}
+			);
+		},
+
+		doubleQuote: () => {
+			return Parsimmon.seqMap(
+				Parsimmon.string('"'),
+				Parsimmon.index, // Capture start position
+				Parsimmon.regex(/[\w.]+/), // Match the function name
+				Parsimmon.string('"'),
+				(_, start, messageId) => {
+					return {
+						messageId,
+						start,
+					};
+				}
+			);
+		},
+
+		singleQuote: () => {
+			return Parsimmon.seqMap(
+				Parsimmon.string("'"),
+				Parsimmon.index, // Capture start position
+				Parsimmon.regex(/[\w.]+/), // Match the function name
+				Parsimmon.string("'"),
+				(_, start, messageId) => {
+					return {
+						messageId,
+						start,
+					};
+				}
+			);
+		},
+
+		bracketNotation: (r) => {
+			return Parsimmon.seqMap(
+				Parsimmon.string("["),
+				Parsimmon.alt(r.doubleQuote!, r.singleQuote!),
+				Parsimmon.string("]"),
+				Parsimmon.index, // Capture end position
+				(_, quote, __, end) => {
+					return {
+						messageId: quote.messageId,
+						start: quote.start,
+						end: end,
+					};
+				}
+			);
+		},
+
+		findMessage: (r) => {
+			return Parsimmon.seqMap(
+				Parsimmon.regex(/.*?(?<![a-zA-Z0-9/])m/s), // find m that's not preceded by letters/numbers
+				Parsimmon.alt(r.dotNotation!, r.bracketNotation!).or(
+					Parsimmon.succeed(null)
+				),
+				Parsimmon.regex(/\((?:[^()]|\([^()]*\))*\)/).or(Parsimmon.succeed("")), // function arguments or empty string
+				(_, notation, args) => {
+					// false positive (m not followed by dot or bracket notation)
+					if (notation === null) {
+						return null;
+					}
+					return {
+						messageId: `${notation.messageId}`,
+						position: {
+							start: {
+								line: notation.start.line,
+								character: notation.start.column,
+							},
+							end: {
+								line: notation.end.line,
+								character: notation.end.column + args.length, // adjust for arguments length
+							},
+						},
+					};
+				}
+			);
+		},
+	});
 };
 
 // Parse the expression

--- a/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.ts
+++ b/inlang/packages/plugins/m-function-matcher/src/ideExtension/messageReferenceMatchers.ts
@@ -125,10 +125,10 @@ const createParser = () => {
 
 // Parse the expression
 export function parse(sourceCode: string) {
-  try {
-    const parser = createParser();
-    return parser.entry!.tryParse(sourceCode);
-  } catch (e) {
-    return [];
-  }
+	try {
+		const parser = createParser();
+		return parser.entry!.tryParse(sourceCode);
+	} catch (e) {
+		return [];
+	}
 }


### PR DESCRIPTION
Sherlock will now correctly display inline annotations for function calls via bracket notation. This change is needed for nested messages to work

```
m["message"]()
m["nested.message"]()
```