### PR TITLE
feat(paraglide-js): add experimentalFallbackToBaseLocal

### DIFF
--- a/.changeset/hip-walls-confess.md
+++ b/.changeset/hip-walls-confess.md
@@ -1,0 +1,10 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Add experimentalFallbackToBaseLocale
+
+---
+
+This option allows the fallback to the base locale's translation when the requested message is not found in the current locale.
+See https://github.com/opral/inlang-paraglide-js/issues/521 for more details including improved UX and bundle size.

--- a/inlang/packages/paraglide/paraglide-js/docs-api/compiler-options.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/compiler-options.md
@@ -2,7 +2,7 @@
 
 > **CompilerOptions** = `object`
 
-Defined in: [compiler-options.ts:19](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:20](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 ### Properties
 
@@ -10,7 +10,7 @@ Defined in: [compiler-options.ts:19](https://github.com/opral/monorepo/tree/main
 
 > `optional` **additionalFiles**: `Record`\<`string`, `string`\>
 
-Defined in: [compiler-options.ts:140](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:156](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The `additionalFiles` option is an array of paths to additional files that should be copied to the output directory.
 
@@ -40,7 +40,7 @@ The output will look like this:
 
 > `optional` **cleanOutdir**: `boolean`
 
-Defined in: [compiler-options.ts:246](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:262](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 Whether to clean the output directory before writing the new files.
 
@@ -54,7 +54,7 @@ true
 
 > `optional` **cookieDomain**: `string`
 
-Defined in: [compiler-options.ts:114](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:130](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The host to which the cookie will be sent.
 If null, this defaults to the host portion of the current document location and the cookie is not available on subdomains.
@@ -70,7 +70,7 @@ window.location.hostname
 
 > `optional` **cookieMaxAge**: `number`
 
-Defined in: [compiler-options.ts:106](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:122](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The max-age in seconds of the cookie until it expires.
 
@@ -84,7 +84,7 @@ The max-age in seconds of the cookie until it expires.
 
 > `optional` **cookieName**: `string`
 
-Defined in: [compiler-options.ts:100](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:116](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The name of the cookie to use for the cookie strategy.
 
@@ -98,7 +98,7 @@ The name of the cookie to use for the cookie strategy.
 
 > `optional` **disableAsyncLocalStorage**: `boolean`
 
-Defined in: [compiler-options.ts:175](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:191](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 Replaces AsyncLocalStorage with a synchronous implementation.
 
@@ -113,7 +113,7 @@ leak into another concurrent request.
 
 > `optional` **emitGitIgnore**: `boolean`
 
-Defined in: [compiler-options.ts:189](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:205](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 If `emitGitIgnore` is set to `true` a `.gitignore` file will be emitted in the output directory. Defaults to `true`.
 
@@ -135,7 +135,7 @@ true
 
 > `optional` **emitPrettierIgnore**: `boolean`
 
-Defined in: [compiler-options.ts:154](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:170](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 If `emitPrettierIgnore` is set to `true` a `.prettierignore` file will be emitted in the output directory. Defaults to `true`.
 
@@ -153,11 +153,34 @@ If `emitPrettierIgnore` is set to `true` a `.prettierignore` file will be emitte
 true
 ```
 
+#### experimentalFallbackToBaseLocale?
+
+> `optional` **experimentalFallbackToBaseLocale**: `boolean`
+
+Defined in: [compiler-options.ts:91](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+
+Whether or not to fallback to the base locale's translation if
+the message is not found in the current locale.
+This improves the user experience by showing a translation
+even if the current locale does not have a translation for a message
+(instead of showing the internal message ID).
+
+This also reduces the bundle size by not including message ids and allowing
+minifiers to remove dead branches more effectively.
+
+⚠️ This feature is experimental
+
+##### Default
+
+```ts
+false
+```
+
 #### experimentalMiddlewareLocaleSplitting?
 
 > `optional` **experimentalMiddlewareLocaleSplitting**: `boolean`
 
-Defined in: [compiler-options.ts:75](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:76](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 Whether or not to use experimental middleware locale splitting.
 
@@ -181,7 +204,7 @@ false
 
 > `optional` **fs**: `any`
 
-Defined in: [compiler-options.ts:253](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:269](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The file system to use. Defaults to `await import('node:fs')`.
 
@@ -191,7 +214,7 @@ Useful for testing the paraglide compiler by mocking the fs.
 
 > `optional` **includeEslintDisableComment**: `boolean`
 
-Defined in: [compiler-options.ts:164](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:180](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 Whether to include an eslint-disable comment at the top of each .js file.
 
@@ -205,7 +228,7 @@ true
 
 > `optional` **isServer**: `string`
 
-Defined in: [compiler-options.ts:94](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:110](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 Tree-shaking flag if the code is running on the server.
 
@@ -229,7 +252,7 @@ typeof window === "undefined"
 
 > `optional` **localStorageKey**: `string`
 
-Defined in: [compiler-options.ts:81](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:97](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The name of the localStorage key to use for the localStorage strategy.
 
@@ -243,7 +266,7 @@ The name of the localStorage key to use for the localStorage strategy.
 
 > **outdir**: `string`
 
-Defined in: [compiler-options.ts:43](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:44](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The path to the output directory.
 
@@ -260,7 +283,7 @@ await compile({
 
 > `optional` **outputStructure**: `"locale-modules"` \| `"message-modules"`
 
-Defined in: [compiler-options.ts:240](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:256](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The `outputStructure` defines how modules are structured in the output.
 
@@ -319,7 +342,7 @@ The benefit are substantially fewer files which is needed in large projects.
 
 > **project**: `string`
 
-Defined in: [compiler-options.ts:31](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:32](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The path to the inlang project.
 
@@ -336,7 +359,7 @@ await compile({
 
 > `optional` **strategy**: [`Runtime`](runtime/type/README.md#runtime)\[`"strategy"`\]
 
-Defined in: [compiler-options.ts:59](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:60](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 The strategy to use for getting the locale.
 
@@ -360,7 +383,7 @@ whereas both fallback to the base locale if not available.
 
 > `optional` **urlPatterns**: [`Runtime`](runtime/type/README.md#runtime)\[`"urlPatterns"`\]
 
-Defined in: [compiler-options.ts:158](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:174](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts)
 
 https://inlang.com/m/gerre34r/library-inlang-paraglideJs/strategy#url
 
@@ -401,6 +424,10 @@ Defined in: [compiler-options.ts:3](https://github.com/opral/monorepo/tree/main/
 #### emitPrettierIgnore
 
 > `readonly` **emitPrettierIgnore**: `true` = `true`
+
+#### experimentalFallbackToBaseLocale
+
+> `readonly` **experimentalFallbackToBaseLocale**: `false` = `false`
 
 #### experimentalMiddlewareLocaleSplitting
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.ts
@@ -49,6 +49,8 @@ export const compileProject = async (args: {
 			bundle,
 			fallbackMap,
 			messageReferenceExpression: outputStructure.messageReferenceExpression,
+			compilerOptions: args.compilerOptions,
+			settings,
 		})
 	);
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compiler-options.ts
@@ -8,6 +8,7 @@ export const defaultCompilerOptions = {
 	cleanOutdir: true,
 	disableAsyncLocalStorage: false,
 	experimentalMiddlewareLocaleSplitting: false,
+	experimentalFallbackToBaseLocale: false,
 	localStorageKey: "PARAGLIDE_LOCALE",
 	isServer: "typeof window === 'undefined'",
 	strategy: ["cookie", "globalVariable", "baseLocale"],
@@ -73,6 +74,21 @@ export type CompilerOptions = {
 	 * @default false
 	 */
 	experimentalMiddlewareLocaleSplitting?: boolean;
+	/**
+	 * Whether or not to fallback to the base locale's translation if
+	 * the message is not found in the current locale.
+	 * This improves the user experience by showing a translation
+	 * even if the current locale does not have a translation for a message
+	 * (instead of showing the internal message ID).
+	 *
+	 * This also reduces the bundle size by not including message ids and allowing
+	 * minifiers to remove dead branches more effectively.
+	 *
+	 * ⚠️ This feature is experimental
+	 *
+	 * @default false
+	 */
+	experimentalFallbackToBaseLocale?: boolean;
 	/**
 	 * The name of the localStorage key to use for the localStorage strategy.
 	 *


### PR DESCRIPTION
Closes opral/inlang-paraglide-js#521

I've opted to call it `experimentalFallbackToBaseLocale` for now.