### PR TITLE
perf(paraglide): improve bundle size for fully translated messages

### DIFF
--- a/.changeset/silver-bugs-hammer.md
+++ b/.changeset/silver-bugs-hammer.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+perf(paraglide): improve bundle size by removing message id fallback for fully translated messages

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-bundle.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-bundle.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "vitest";
 import { compileBundle } from "./compile-bundle.js";
-import type { BundleNested } from "@inlang/sdk";
+import type { BundleNested, ProjectSettings } from "@inlang/sdk";
 import { toSafeModuleId } from "./safe-module-id.js";
 
 test("compiles to jsdoc", async () => {
@@ -39,6 +39,9 @@ test("compiles to jsdoc", async () => {
 		bundle: mockBundle,
 		messageReferenceExpression: (locale) =>
 			`${toSafeModuleId(locale)}.blue_moon_bottle`,
+		settings: {
+			locales: ["en", "en-US"],
+		} as ProjectSettings,
 	});
 
 	expect(result.bundle.code).toMatchInlineSnapshot(
@@ -62,8 +65,7 @@ export const blue_moon_bottle = (inputs, options = {}) => {
 	const locale = options.locale ?? getLocale()
 	trackMessageCall("blue_moon_bottle", locale)
 	if (locale === "en") return en.blue_moon_bottle(inputs)
-	if (locale === "en-US") return en_us2.blue_moon_bottle(inputs)
-	return "blue_moon_bottle"
+	return en_us2.blue_moon_bottle(inputs)
 };"`
 	);
 });

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.ts
@@ -49,6 +49,7 @@ export const compileProject = async (args: {
 			bundle,
 			fallbackMap,
 			messageReferenceExpression: outputStructure.messageReferenceExpression,
+			settings,
 		})
 	);
 


### PR DESCRIPTION
Closes opral/inlang-paraglide-js#521

This could be further optimized (eg for cases where multiple languages return the same message, that branch could be moved to the end to remove the comparisons) but that's for another time.
(afaik SWC is already smart enough to optimize `cond1 ? a() : cond2 ? b() : a()` into `cond2 ? b() : a()` if cond1 has no side-effects, which applies here)