### PR TITLE
feat(inlang,mtl): include bundle id in "Source locale not found in bu…

### DIFF
--- a/.changeset/chilly-readers-fail.md
+++ b/.changeset/chilly-readers-fail.md
@@ -1,0 +1,5 @@
+---
+"@inlang/rpc": patch
+---
+
+Make "Source locale not found in the bundle" error message include the bundle id for better debuggability

--- a/inlang/packages/rpc/src/functions/machineTranslateBundle.ts
+++ b/inlang/packages/rpc/src/functions/machineTranslateBundle.ts
@@ -25,7 +25,9 @@ export async function machineTranslateBundle(args: {
 		);
 
 		if (!sourceMessage) {
-			return { error: "Source locale not found in the bundle" };
+			return {
+				error: `Source locale not found in the bundle: ${args.bundle.id}`,
+			};
 		}
 
 		for (const sourceVariant of sourceMessage.variants) {


### PR DESCRIPTION
…ndle" error message

Currently you simply have no way of knowing which bundle triggered the error. This fixes that.
Originally reported on Discord.