### PR TITLE
Refactor state handling to use 'state_all' table

### DIFF
--- a/packages/lix-plugin-md/src/e2e.test.ts
+++ b/packages/lix-plugin-md/src/e2e.test.ts
@@ -121,10 +121,10 @@ This is the original paragraph content.`;
 		})
 		.execute();
 
-	// 2. Mutate the paragraph via state_active using the known entity_id
+	// 2. Mutate the paragraph via state using the known entity_id
 	// Create proper MD-AST node structure for paragraph
 	await lix.db
-		.updateTable("state_active")
+		.updateTable("state_all")
 		.set({
 			snapshot_content: {
 				type: "paragraph",
@@ -143,10 +143,10 @@ This is the original paragraph content.`;
 		.where("file_id", "=", "file1")
 		.execute();
 
-	// 3. Mutate the title via state_active using the known entity_id
+	// 3. Mutate the title via state using the known entity_id
 	// Create proper MD-AST node structure for heading
 	await lix.db
-		.updateTable("state_active")
+		.updateTable("state_all")
 		.set({
 			snapshot_content: {
 				type: "heading",

--- a/packages/lix-sdk/src/change-author/schema.test.ts
+++ b/packages/lix-sdk/src/change-author/schema.test.ts
@@ -74,7 +74,7 @@ describe("change_author", () => {
 
 		// After delete, there should be no state records for the change_author
 		const allStates = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("schema_key", "=", "lix_change_author")
 			.selectAll()
 			.execute();

--- a/packages/lix-sdk/src/database/execute-sync.test.ts
+++ b/packages/lix-sdk/src/database/execute-sync.test.ts
@@ -51,8 +51,13 @@ test("manual JSON parsing with executeSync", async () => {
 
 	const result = executeSync({
 		lix,
-		query: lix.db.selectFrom("key_value").selectAll(),
+		query: lix.db
+			.selectFrom("key_value")
+			.where("key", "=", "test-key")
+			.selectAll(),
 	});
+
+	expect(result).toHaveLength(1);
 
 	// Raw result - value is a JSON string
 	expect(typeof result[0].value).toBe("string");

--- a/packages/lix-sdk/src/database/init-db.ts
+++ b/packages/lix-sdk/src/database/init-db.ts
@@ -27,7 +27,7 @@ import { applyStateHistoryDatabaseSchema } from "../state-history/schema.js";
 // via the json schemas.
 const ViewsWithJsonColumns = {
 	state: ["snapshot_content"],
-	state_active: ["snapshot_content"],
+	state_all: ["snapshot_content"],
 	state_history: ["snapshot_content"],
 	snapshot: ["content"],
 	...(() => {

--- a/packages/lix-sdk/src/database/kysely-plugin/view-insert-returning-error-plugin.test.ts
+++ b/packages/lix-sdk/src/database/kysely-plugin/view-insert-returning-error-plugin.test.ts
@@ -46,7 +46,7 @@ test("should allow returning on non-view tables", async () => {
 	// This should not throw since 'state' is a table, not a view
 	expect(() => {
 		lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "test",
 				schema_key: "test",

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -73,7 +73,7 @@ export const LixSchemaViewMap: Record<string, LixSchemaDefinition> = {
 
 export type LixDatabaseSchema = {
 	state: StateView;
-	state_active: StateView;
+	state_all: StateView;
 	state_history: StateHistoryView;
 	// account
 	active_account: ActiveAccountTable;

--- a/packages/lix-sdk/src/entity-views/entity-state-all.test.ts
+++ b/packages/lix-sdk/src/entity-views/entity-state-all.test.ts
@@ -164,7 +164,7 @@ describe("createEntityAllViewIfNotExists", () => {
 
 		// Verify explicit version_id was used
 		const stateData = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.selectAll()
 			.where("entity_id", "=", "test_id")
 			.execute();

--- a/packages/lix-sdk/src/entity-views/entity-state-all.ts
+++ b/packages/lix-sdk/src/entity-views/entity-state-all.ts
@@ -200,7 +200,7 @@ export function createEntityStateAllView(args: {
 	createSingleEntityAllView({
 		...args,
 		viewName: view_name,
-		stateTable: "state",
+		stateTable: "state_all",
 	});
 }
 
@@ -208,7 +208,7 @@ function createSingleEntityAllView(args: {
 	lix: Pick<Lix, "sqlite">;
 	schema: LixSchemaDefinition;
 	viewName: string;
-	stateTable: "state";
+	stateTable: "state_all";
 	/** Plugin identifier for the entity */
 	pluginKey: string;
 	/** Optional hardcoded file_id (if not provided, uses lixcol_file_id from mutations) */
@@ -386,7 +386,7 @@ function createSingleEntityAllView(args: {
       INSTEAD OF INSERT ON ${view_name}
       BEGIN      
         ${insertValidationSQL}
-        INSERT INTO state (
+        INSERT INTO state_all (
           entity_id,
           schema_key,
           file_id,
@@ -428,7 +428,7 @@ function createSingleEntityAllView(args: {
       INSTEAD OF UPDATE ON ${view_name}
       BEGIN
         ${updateValidationSQL}
-        UPDATE state
+        UPDATE state_all
         SET
           entity_id = ${entityIdNew},
           schema_key = '${schema_key}',
@@ -437,17 +437,17 @@ function createSingleEntityAllView(args: {
           snapshot_content = json_object(${properties.map((prop) => `'${prop}', NEW.${prop}`).join(", ")}),
           version_id = ${versionIdReference}
         WHERE
-          state.entity_id = ${entityIdOld}
-          AND state.schema_key = '${schema_key}'
-          AND state.file_id = ${args.hardcodedFileId ? `'${args.hardcodedFileId}'` : "OLD.lixcol_file_id"}
-          AND state.version_id = ${oldVersionIdReference};
+          state_all.entity_id = ${entityIdOld}
+          AND state_all.schema_key = '${schema_key}'
+          AND state_all.file_id = ${args.hardcodedFileId ? `'${args.hardcodedFileId}'` : "OLD.lixcol_file_id"}
+          AND state_all.version_id = ${oldVersionIdReference};
       END;
 
       CREATE TRIGGER IF NOT EXISTS ${view_name}_delete
       INSTEAD OF DELETE ON ${view_name}
       BEGIN
         ${deleteValidationSQL}
-        DELETE FROM state
+        DELETE FROM state_all
         WHERE entity_id = ${entityIdOld}
         AND schema_key = '${schema_key}'
         AND file_id = ${args.hardcodedFileId ? `'${args.hardcodedFileId}'` : "OLD.lixcol_file_id"}

--- a/packages/lix-sdk/src/entity-views/entity-state-history.test.ts
+++ b/packages/lix-sdk/src/entity-views/entity-state-history.test.ts
@@ -52,7 +52,7 @@ describe("createEntityHistoryViewIfNotExists", () => {
 
 		// Insert some test data into state to create history
 		await lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "test_id",
 				schema_key: "test_entity",
@@ -115,7 +115,7 @@ describe("createEntityHistoryViewIfNotExists", () => {
 
 		// Insert test data
 		await lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "test_id",
 				schema_key: "test_entity",
@@ -182,7 +182,7 @@ describe("createEntityHistoryViewIfNotExists", () => {
 
 		// Insert initial state
 		await lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "tracked_entity",
 				schema_key: "test_entity",
@@ -196,7 +196,7 @@ describe("createEntityHistoryViewIfNotExists", () => {
 
 		// Update to create history
 		await lix.db
-			.updateTable("state")
+			.updateTable("state_all")
 			.set({
 				snapshot_content: { id: "tracked_entity", name: "updated", value: 2 },
 			})
@@ -205,7 +205,7 @@ describe("createEntityHistoryViewIfNotExists", () => {
 
 		// Update again to create more history
 		await lix.db
-			.updateTable("state")
+			.updateTable("state_all")
 			.set({
 				snapshot_content: { id: "tracked_entity", name: "final", value: 3 },
 			})
@@ -272,7 +272,7 @@ describe("createEntityHistoryViewIfNotExists", () => {
 
 		// Insert some data directly into state for testing UPDATE/DELETE
 		await lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "test_id",
 				schema_key: "test_entity",

--- a/packages/lix-sdk/src/entity-views/entity-state.test.ts
+++ b/packages/lix-sdk/src/entity-views/entity-state.test.ts
@@ -170,7 +170,7 @@ describe("createEntityViewIfNotExists", () => {
 
 		// Verify data was inserted into state table
 		const stateData = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.selectAll()
 			.where("schema_key", "=", "test_entity")
 			.execute();
@@ -248,7 +248,7 @@ describe("createEntityViewIfNotExists", () => {
 
 		// Verify update in state table
 		const stateData = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.selectAll()
 			.where("entity_id", "=", "test_id")
 			.execute();
@@ -297,7 +297,7 @@ describe("createEntityViewIfNotExists", () => {
 
 		// Verify deletion in state table
 		const stateData = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.selectAll()
 			.where("entity_id", "=", "test_id")
 			.execute();
@@ -328,7 +328,7 @@ describe("createEntityViewIfNotExists", () => {
 
 		// Verify data was inserted with composite entity_id
 		const stateData = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.selectAll()
 			.where("schema_key", "=", "composite_entity")
 			.execute();
@@ -472,7 +472,7 @@ describe("createEntityViewIfNotExists", () => {
 
 		// Verify file_id was used from the mutation
 		const stateData = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.selectAll()
 			.where("entity_id", "=", "test_id")
 			.execute();

--- a/packages/lix-sdk/src/entity-views/entity-view-builder.test.ts
+++ b/packages/lix-sdk/src/entity-views/entity-view-builder.test.ts
@@ -17,7 +17,7 @@ describe("createEntityViewsIfNotExists (Integration)", () => {
 		required: ["id", "name"],
 	} as const;
 
-	test("should create all three views: primary, _all, and _history", async () => {
+	test("should create all three views: active, _all, and _history", async () => {
 		const lix = await openLixInMemory({});
 
 		// Add stored schema
@@ -52,7 +52,7 @@ describe("createEntityViewsIfNotExists (Integration)", () => {
 			.execute();
 
 		// All three views should be queryable
-		const primaryResult = await lix.db
+		const activeResult = await lix.db
 			.selectFrom("triple_test" as any)
 			.selectAll()
 			.execute();
@@ -76,12 +76,12 @@ describe("createEntityViewsIfNotExists (Integration)", () => {
 			.execute();
 
 		// All views should return data
-		expect(primaryResult).toHaveLength(1);
+		expect(activeResult).toHaveLength(1);
 		expect(allResult).toHaveLength(1);
 		expect(historyResult).toHaveLength(1);
 
 		// Verify business data consistency across all views
-		expect(primaryResult[0]).toMatchObject({
+		expect(activeResult[0]).toMatchObject({
 			id: "test_id",
 			name: "test_name",
 			value: 42,
@@ -98,7 +98,7 @@ describe("createEntityViewsIfNotExists (Integration)", () => {
 		});
 
 		// Verify column differences between views
-		expect(primaryResult[0]).not.toHaveProperty("lixcol_version_id"); // Primary view hides version_id
+		expect(activeResult[0]).not.toHaveProperty("lixcol_version_id"); // Primary view hides version_id
 		expect(allResult[0]).toHaveProperty("lixcol_version_id"); // _all view exposes version_id
 		expect(historyResult[0]).toHaveProperty("lixcol_change_set_id"); // _history view has history columns
 		expect(historyResult[0]).toHaveProperty("lixcol_depth", 0); // Current state is at depth 0

--- a/packages/lix-sdk/src/entity-views/entity-view-builder.ts
+++ b/packages/lix-sdk/src/entity-views/entity-view-builder.ts
@@ -70,7 +70,7 @@ export type EntityViews<
  * Creates SQL views and CRUD triggers for an entity based on its schema definition.
  *
  * This function automatically generates three views:
- * - Primary view (e.g., "key_value") - uses state_active (active version only)
+ * - Primary view (e.g., "key_value") - uses state (active version only)
  * - All view (e.g., "key_value_all") - uses state (all versions)
  * - History view (e.g., "key_value_history") - uses state_history (historical states)
  *

--- a/packages/lix-sdk/src/file/file-handlers.test.ts
+++ b/packages/lix-sdk/src/file/file-handlers.test.ts
@@ -118,7 +118,7 @@ describe("file update", () => {
 
 		// Verify both entities were created
 		const initialEntities = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("file_id", "=", fileId)
 			.where("schema_key", "=", "mock_json_property")
 			.where("version_id", "=", version.id)
@@ -149,7 +149,7 @@ describe("file update", () => {
 
 		// Verify that jane's entities were deleted
 		const finalEntities = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("file_id", "=", fileId)
 			.where("schema_key", "=", "mock_json_property")
 			.where("version_id", "=", version.id)

--- a/packages/lix-sdk/src/file/file-handlers.ts
+++ b/packages/lix-sdk/src/file/file-handlers.ts
@@ -30,7 +30,7 @@ export function handleFileInsert(args: {
 	// Insert the file metadata into state table
 	executeSync({
 		lix: args.lix,
-		query: args.lix.db.insertInto("state").values({
+		query: args.lix.db.insertInto("state_all").values({
 			entity_id: args.file.id,
 			schema_key: "lix_file",
 			file_id: args.file.id,
@@ -93,7 +93,7 @@ export function handleFileInsert(args: {
 			for (const change of detectedChanges) {
 				executeSync({
 					lix: args.lix,
-					query: args.lix.db.insertInto("state").values({
+					query: args.lix.db.insertInto("state_all").values({
 						entity_id: change.entity_id,
 						schema_key: change.schema["x-lix-key"],
 						file_id: args.file.id,
@@ -134,7 +134,7 @@ export function handleFileInsert(args: {
 				for (const change of detectedChanges) {
 					executeSync({
 						lix: args.lix,
-						query: args.lix.db.insertInto("state").values({
+						query: args.lix.db.insertInto("state_all").values({
 							entity_id: change.entity_id,
 							schema_key: change.schema["x-lix-key"],
 							file_id: args.file.id,
@@ -171,7 +171,7 @@ export function handleFileUpdate(args: {
 	executeSync({
 		lix: args.lix,
 		query: args.lix.db
-			.updateTable("state")
+			.updateTable("state_all")
 			.set({
 				snapshot_content: {
 					id: args.file.id,
@@ -247,7 +247,7 @@ export function handleFileUpdate(args: {
 						executeSync({
 							lix: args.lix,
 							query: args.lix.db
-								.deleteFrom("state")
+								.deleteFrom("state_all")
 								.where("entity_id", "=", change.entity_id)
 								.where("schema_key", "=", change.schema["x-lix-key"])
 								.where("file_id", "=", args.file.id)
@@ -257,7 +257,7 @@ export function handleFileUpdate(args: {
 						// Handle update/insert: upsert the entity in state table
 						executeSync({
 							lix: args.lix,
-							query: args.lix.db.insertInto("state").values({
+							query: args.lix.db.insertInto("state_all").values({
 								entity_id: change.entity_id,
 								schema_key: change.schema["x-lix-key"],
 								file_id: args.file.id,
@@ -303,7 +303,7 @@ export function handleFileUpdate(args: {
 							executeSync({
 								lix: args.lix,
 								query: args.lix.db
-									.deleteFrom("state")
+									.deleteFrom("state_all")
 									.where("entity_id", "=", change.entity_id)
 									.where("schema_key", "=", change.schema["x-lix-key"])
 									.where("file_id", "=", args.file.id)
@@ -313,7 +313,7 @@ export function handleFileUpdate(args: {
 							// Handle update/insert: upsert the entity in state table
 							executeSync({
 								lix: args.lix,
-								query: args.lix.db.insertInto("state").values({
+								query: args.lix.db.insertInto("state_all").values({
 									entity_id: change.entity_id,
 									schema_key: change.schema["x-lix-key"],
 									file_id: args.file.id,

--- a/packages/lix-sdk/src/file/materialize-file-data.test.ts
+++ b/packages/lix-sdk/src/file/materialize-file-data.test.ts
@@ -38,7 +38,7 @@ test("materializeFileData with plugin that has changes", async () => {
 
 	// Manually insert some state data to simulate plugin changes
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "entity1",
 			schema_key: "test_schema",

--- a/packages/lix-sdk/src/file/materialize-file-data.ts
+++ b/packages/lix-sdk/src/file/materialize-file-data.ts
@@ -47,7 +47,7 @@ export function materializeFileData(args: {
 		const changes = executeSync({
 			lix: args.lix,
 			query: args.lix.db
-				.selectFrom("state")
+				.selectFrom("state_all")
 				.where("plugin_key", "=", plugin.key)
 				.where("file_id", "=", args.file.id)
 				.where("version_id", "=", args.versionId)
@@ -82,7 +82,7 @@ export function materializeFileData(args: {
 	const changes = executeSync({
 		lix: args.lix,
 		query: args.lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("plugin_key", "=", lixUnknownFileFallbackPlugin.key)
 			.where("file_id", "=", args.file.id)
 			.where("version_id", "=", args.versionId)

--- a/packages/lix-sdk/src/file/schema.ts
+++ b/packages/lix-sdk/src/file/schema.ts
@@ -118,7 +118,7 @@ export function applyFileDatabaseSchema(
 		inherited_from_version_id AS lixcol_inherited_from_version_id,
 		created_at AS lixcol_created_at,
 		updated_at AS lixcol_updated_at
-	FROM state_active
+	FROM state
 	WHERE schema_key = 'lix_file';
 
   CREATE VIEW IF NOT EXISTS file_all AS
@@ -136,7 +136,7 @@ export function applyFileDatabaseSchema(
 		inherited_from_version_id AS lixcol_inherited_from_version_id,
 		created_at AS lixcol_created_at,
 		updated_at AS lixcol_updated_at
-	FROM state
+	FROM state_all
 	WHERE schema_key = 'lix_file';
 
 
@@ -168,13 +168,13 @@ export function applyFileDatabaseSchema(
   INSTEAD OF DELETE ON file
   BEGIN
       -- Delete all non-lix_file entities associated with this file first
-      DELETE FROM state
+      DELETE FROM state_all
       WHERE file_id = OLD.id
         AND version_id = (SELECT version_id FROM active_version)
         AND schema_key != 'lix_file';
         
       -- Delete the file entity itself
-      DELETE FROM state
+      DELETE FROM state_all
       WHERE entity_id = OLD.id
         AND schema_key = 'lix_file'
         AND version_id = (SELECT version_id FROM active_version);
@@ -208,13 +208,13 @@ export function applyFileDatabaseSchema(
   INSTEAD OF DELETE ON file_all
   BEGIN
       -- Delete all non-lix_file entities associated with this file first
-      DELETE FROM state
+      DELETE FROM state_all
       WHERE file_id = OLD.id
         AND version_id = OLD.lixcol_version_id
         AND schema_key != 'lix_file';
         
       -- Delete the file entity itself
-      DELETE FROM state
+      DELETE FROM state_all
       WHERE entity_id = OLD.id
         AND schema_key = 'lix_file'
         AND version_id = OLD.lixcol_version_id;

--- a/packages/lix-sdk/src/lix/new-lix.test.ts
+++ b/packages/lix-sdk/src/lix/new-lix.test.ts
@@ -12,7 +12,7 @@ test("newLixFile creates a valid lix that can be reopened", async () => {
 	const lix = await openLixInMemory({ blob });
 
 	// Try to query the state table to ensure it works
-	const result = await lix.db.selectFrom("state").selectAll().execute();
+	const result = await lix.db.selectFrom("state_all").selectAll().execute();
 	expect(Array.isArray(result)).toBe(true);
 });
 

--- a/packages/lix-sdk/src/state-history/schema.test.ts
+++ b/packages/lix-sdk/src/state-history/schema.test.ts
@@ -29,7 +29,7 @@ test("query current state at head of version lineage", async () => {
 
 	// Insert initial state (defaults to active version)
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "paragraph0",
 			file_id: "f0",
@@ -85,7 +85,7 @@ test("query state at specific depth in history", async () => {
 
 	// Insert and modify entity multiple times
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "paragraph0",
 			file_id: "f0",
@@ -98,13 +98,13 @@ test("query state at specific depth in history", async () => {
 		.execute();
 
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "value1" } })
 		.where("entity_id", "=", "paragraph0")
 		.execute();
 
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "value2" } })
 		.where("entity_id", "=", "paragraph0")
 		.execute();
@@ -208,7 +208,7 @@ test("query state at checkpoint using createCheckpoint API", async () => {
 
 	// Insert initial state
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "paragraph0",
 			file_id: "f0",
@@ -259,7 +259,7 @@ test("diff detection between current and checkpoint state", async () => {
 
 	// Insert entity
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "paragraph0",
 			file_id: "f0",
@@ -276,7 +276,7 @@ test("diff detection between current and checkpoint state", async () => {
 
 	// Modify the same entity after checkpoint
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "modified" } })
 		.where("entity_id", "=", "paragraph0")
 		.execute();
@@ -338,7 +338,7 @@ test("deletion diff - entity exists at checkpoint but not current", async () => 
 
 	// Insert entity
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "paragraph0",
 			file_id: "f0",
@@ -355,7 +355,7 @@ test("deletion diff - entity exists at checkpoint but not current", async () => 
 
 	// Delete entity
 	await lix.db
-		.deleteFrom("state")
+		.deleteFrom("state_all")
 		.where("entity_id", "=", "paragraph0")
 		.execute();
 
@@ -414,7 +414,7 @@ test("insertion diff - entity exists current but not at checkpoint", async () =>
 
 	// Insert entity after checkpoint
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "paragraph0",
 			file_id: "f0",
@@ -479,7 +479,7 @@ test("blame functionality - track entity changes over time", async () => {
 
 	// Simulate multiple edits by different authors
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "paragraph0",
 			file_id: "f0",
@@ -492,13 +492,13 @@ test("blame functionality - track entity changes over time", async () => {
 		.execute();
 
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "bob's revision", author: "bob" } })
 		.where("entity_id", "=", "paragraph0")
 		.execute();
 
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "charlie's final", author: "charlie" } })
 		.where("entity_id", "=", "paragraph0")
 		.execute();
@@ -556,7 +556,7 @@ test("working change set diff - compare current vs checkpoints", async () => {
 
 	// Insert initial entity
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "paragraph0",
 			file_id: "f0",
@@ -573,7 +573,7 @@ test("working change set diff - compare current vs checkpoints", async () => {
 
 	// Modify and create second checkpoint
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "checkpoint 2 content" } })
 		.where("entity_id", "=", "paragraph0")
 		.execute();
@@ -582,7 +582,7 @@ test("working change set diff - compare current vs checkpoints", async () => {
 
 	// Modify for current working state
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "working content" } })
 		.where("entity_id", "=", "paragraph0")
 		.execute();
@@ -648,7 +648,7 @@ test("query history between two change sets using ancestor/descendant filters", 
 
 	// Create a series of checkpoints with entity changes
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "tracked-entity",
 			file_id: "f0",
@@ -664,7 +664,7 @@ test("query history between two change sets using ancestor/descendant filters", 
 
 	// Modify and create checkpoint 2
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "checkpoint 2 content" } })
 		.where("entity_id", "=", "tracked-entity")
 		.execute();
@@ -673,7 +673,7 @@ test("query history between two change sets using ancestor/descendant filters", 
 
 	// Modify and create checkpoint 3
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "checkpoint 3 content" } })
 		.where("entity_id", "=", "tracked-entity")
 		.execute();
@@ -682,7 +682,7 @@ test("query history between two change sets using ancestor/descendant filters", 
 
 	// Modify and create checkpoint 4
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "checkpoint 4 content" } })
 		.where("entity_id", "=", "tracked-entity")
 		.execute();
@@ -747,7 +747,7 @@ test.skip("parent_change_set_ids field shows correct parent relationships", asyn
 
 	// Create initial entity
 	await lix.db
-		.insertInto("state_active")
+		.insertInto("state")
 		.values({
 			entity_id: "test-entity",
 			file_id: "f0",
@@ -768,7 +768,7 @@ test.skip("parent_change_set_ids field shows correct parent relationships", asyn
 
 	// Update entity to value1
 	await lix.db
-		.updateTable("state_active")
+		.updateTable("state")
 		.set({ snapshot_content: { value: "value1" } })
 		.where("entity_id", "=", "test-entity")
 		.execute();
@@ -782,7 +782,7 @@ test.skip("parent_change_set_ids field shows correct parent relationships", asyn
 
 	// Update entity to value2
 	await lix.db
-		.updateTable("state_active")
+		.updateTable("state")
 		.set({ snapshot_content: { value: "value2" } })
 		.where("entity_id", "=", "test-entity")
 		.execute();

--- a/packages/lix-sdk/src/state-history/schema.ts
+++ b/packages/lix-sdk/src/state-history/schema.ts
@@ -115,7 +115,7 @@ WITH
 	-- For state_history, we work with any change_set_id, not just version heads
 	requested_change_sets AS (
 		SELECT DISTINCT cs.id as change_set_id
-		FROM change_set cs
+		FROM change_set_all cs
 		-- This will be filtered by the WHERE clause in queries
 	),
 	-- Find all change sets reachable from requested ones (including ancestors)

--- a/packages/lix-sdk/src/state/create-changeset-for-transaction.ts
+++ b/packages/lix-sdk/src/state/create-changeset-for-transaction.ts
@@ -198,7 +198,7 @@ export function createChangesetForTransaction(
 				const toDelete = executeSync({
 					lix: { sqlite },
 					query: db
-						.selectFrom("state")
+						.selectFrom("state_all")
 
 						// @ts-expect-error - rowid is a valid SQLite column but not in Kysely types
 						.select("rowid")
@@ -261,7 +261,7 @@ export function createChangesetForTransaction(
 				const toDelete = executeSync({
 					lix: { sqlite },
 					query: db
-						.selectFrom("state")
+						.selectFrom("state_all")
 						// @ts-expect-error - rowid is a valid SQLite column but not in Kysely types
 						.select("rowid")
 						.where(

--- a/packages/lix-sdk/src/state/handle-state-mutation.test.ts
+++ b/packages/lix-sdk/src/state/handle-state-mutation.test.ts
@@ -133,7 +133,7 @@ test("should throw error when version_id is null", async () => {
 	// Try to insert state with null version_id - should throw
 	await expect(
 		lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "test_entity",
 				schema_key: "lix_key_value",
@@ -155,7 +155,7 @@ test("should throw error when version_id does not exist", async () => {
 	// Try to insert state with non-existent version_id - should throw
 	await expect(
 		lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "test_entity",
 				schema_key: "lix_key_value",

--- a/packages/lix-sdk/src/state/schema.bench.ts
+++ b/packages/lix-sdk/src/state/schema.bench.ts
@@ -18,7 +18,7 @@ bench(
 		// Create 100 changes for the same entity in the same version
 		for (let i = 0; i < 100; i++) {
 			await lix.db
-				.insertInto("state")
+				.insertInto("state_all")
 				.values({
 					entity_id: "mock_entity_id",
 					version_id: version.id,
@@ -33,7 +33,7 @@ bench(
 
 		// Benchmark querying the leaf state for this entity (should return the latest change)
 		await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("entity_id", "=", "mock_entity_id")
 			.where("version_id", "=", version.id)
 			.selectAll()

--- a/packages/lix-sdk/src/state/schema.test.ts
+++ b/packages/lix-sdk/src/state/schema.test.ts
@@ -26,7 +26,7 @@ test("select, insert, update, delete entity", async () => {
 		.execute();
 
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "e0",
 			file_id: "f0",
@@ -41,7 +41,7 @@ test("select, insert, update, delete entity", async () => {
 		.execute();
 
 	const viewAfterInsert = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.selectAll()
 		.execute();
@@ -59,7 +59,7 @@ test("select, insert, update, delete entity", async () => {
 	]);
 
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({
 			snapshot_content: {
 				value: "hello world - updated",
@@ -71,7 +71,7 @@ test("select, insert, update, delete entity", async () => {
 		.execute();
 
 	const viewAfterUpdate = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.selectAll()
 		.execute();
@@ -89,7 +89,7 @@ test("select, insert, update, delete entity", async () => {
 	]);
 
 	await lix.db
-		.deleteFrom("state")
+		.deleteFrom("state_all")
 		.where("entity_id", "=", "e0")
 		.where(
 			"version_id",
@@ -100,7 +100,7 @@ test("select, insert, update, delete entity", async () => {
 		.execute();
 
 	const viewAfterDelete = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.selectAll()
 		.execute();
@@ -129,7 +129,7 @@ test("validates the schema on insert", async () => {
 		.execute();
 	await expect(
 		lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "e0",
 				file_id: "f0",
@@ -166,7 +166,7 @@ test("validates the schema on update", async () => {
 		.execute();
 
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "e0",
 			file_id: "f0",
@@ -182,7 +182,7 @@ test("validates the schema on update", async () => {
 
 	await expect(
 		lix.db
-			.updateTable("state")
+			.updateTable("state_all")
 			.set({
 				snapshot_content: {
 					value: "hello world - updated",
@@ -195,7 +195,7 @@ test("validates the schema on update", async () => {
 	).rejects.toThrow(/value must be number/);
 
 	const viewAfterFailedUpdate = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.selectAll()
 		.execute();
@@ -220,7 +220,7 @@ test("state is separated by version", async () => {
 	await createVersion({ lix, id: "version_b" });
 
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values([
 			{
 				entity_id: "e0",
@@ -248,7 +248,7 @@ test("state is separated by version", async () => {
 		.execute();
 
 	const stateAfterInserts = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.where("entity_id", "=", "e0")
 		.selectAll()
@@ -284,7 +284,7 @@ test("state is separated by version", async () => {
 	expect(stateAfterInserts[1]?.updated_at).toBeDefined();
 
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({ snapshot_content: { value: "hello world from version b UPDATED" } })
 		.where("entity_id", "=", "e0")
 		.where("schema_key", "=", "mock_schema")
@@ -292,7 +292,7 @@ test("state is separated by version", async () => {
 		.execute();
 
 	const stateAfterUpdate = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.where("entity_id", "=", "e0")
 		.selectAll()
@@ -322,13 +322,13 @@ test("state is separated by version", async () => {
 	]);
 
 	await lix.db
-		.deleteFrom("state")
+		.deleteFrom("state_all")
 		.where("entity_id", "=", "e0")
 		.where("version_id", "=", "version_b")
 		.execute();
 
 	const stateAfterDelete = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.where("entity_id", "=", "e0")
 		.selectAll()
@@ -370,7 +370,7 @@ test("created_at and updated_at timestamps are computed correctly", async () => 
 
 	// Insert initial entity
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "e0",
 			file_id: "f0",
@@ -385,7 +385,7 @@ test("created_at and updated_at timestamps are computed correctly", async () => 
 		.execute();
 
 	const stateAfterInsert = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "e0")
 		.selectAll()
 		.execute();
@@ -400,7 +400,7 @@ test("created_at and updated_at timestamps are computed correctly", async () => 
 
 	// Update the entity
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({
 			snapshot_content: {
 				value: "updated value",
@@ -411,7 +411,7 @@ test("created_at and updated_at timestamps are computed correctly", async () => 
 		.execute();
 
 	const stateAfterUpdate = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "e0")
 		.selectAll()
 		.execute();
@@ -455,7 +455,7 @@ test("created_at and updated_at are version specific", async () => {
 
 	// Insert entity in version A
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "e0",
 			file_id: "f0",
@@ -474,7 +474,7 @@ test("created_at and updated_at are version specific", async () => {
 
 	// Insert same entity in version B
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "e0",
 			file_id: "f0",
@@ -489,14 +489,14 @@ test("created_at and updated_at are version specific", async () => {
 		.execute();
 
 	const stateVersionA = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "e0")
 		.where("version_id", "=", "version_a")
 		.selectAll()
 		.execute();
 
 	const stateVersionB = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "e0")
 		.where("version_id", "=", "version_b")
 		.selectAll()
@@ -518,7 +518,7 @@ test("created_at and updated_at are version specific", async () => {
 	await new Promise((resolve) => setTimeout(resolve, 1));
 
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({
 			snapshot_content: {
 				value: "updated value in version b",
@@ -529,14 +529,14 @@ test("created_at and updated_at are version specific", async () => {
 		.execute();
 
 	const updatedStateVersionA = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "e0")
 		.where("version_id", "=", "version_a")
 		.selectAll()
 		.execute();
 
 	const updatedStateVersionB = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "e0")
 		.where("version_id", "=", "version_b")
 		.selectAll()
@@ -562,7 +562,7 @@ test("state appears in both versions when they share the same change set", async
 	const versionA = await createVersion({ lix, id: "version_a" });
 	// Insert state into version A
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "e0",
 			file_id: "f0",
@@ -594,7 +594,7 @@ test("state appears in both versions when they share the same change set", async
 	await (lix.db as any).deleteFrom("internal_state_cache").execute();
 
 	const stateInBothVersions = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.where("entity_id", "=", "e0")
 		.selectAll()
@@ -624,7 +624,7 @@ test("state diverges when versions have common ancestor but different changes", 
 	const baseVersion = await createVersion({ lix, id: "base_version" });
 
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "e0",
 			file_id: "f0",
@@ -671,7 +671,7 @@ test("state diverges when versions have common ancestor but different changes", 
 
 	// Both versions should initially see the base state
 	const initialState = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.where("entity_id", "=", "e0")
 		.selectAll()
@@ -681,7 +681,7 @@ test("state diverges when versions have common ancestor but different changes", 
 
 	// Update state in version A
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({
 			snapshot_content: { value: "updated in version A" },
 		})
@@ -691,7 +691,7 @@ test("state diverges when versions have common ancestor but different changes", 
 
 	// Update state in version B differently
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({
 			snapshot_content: { value: "updated in version B" },
 		})
@@ -700,7 +700,7 @@ test("state diverges when versions have common ancestor but different changes", 
 		.execute();
 
 	const divergedState = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
 		.where("entity_id", "=", "e0")
 		.selectAll()
@@ -738,7 +738,7 @@ test("write-through cache: insert operations populate cache immediately", async 
 
 	// Insert state data - should populate cache via write-through
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "write-through-entity",
 			schema_key: "write-through-schema",
@@ -771,7 +771,7 @@ test("write-through cache: insert operations populate cache immediately", async 
 
 	// State view should return the same data (from cache)
 	const stateResults = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "write-through-entity")
 		.selectAll()
 		.execute();
@@ -794,7 +794,7 @@ test("write-through cache: update operations update cache immediately", async ()
 
 	// Insert initial state
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "update-cache-entity",
 			schema_key: "update-cache-schema",
@@ -808,7 +808,7 @@ test("write-through cache: update operations update cache immediately", async ()
 
 	// Update the state - should update cache via write-through
 	await lix.db
-		.updateTable("state")
+		.updateTable("state_all")
 		.set({
 			snapshot_content: { updated: "value" },
 			plugin_key: "updated-plugin",
@@ -839,7 +839,7 @@ test("write-through cache: update operations update cache immediately", async ()
 
 	// State view should return updated data
 	const stateResults = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "update-cache-entity")
 		.selectAll()
 		.execute();
@@ -860,7 +860,7 @@ test("delete operations remove entries from underlying data", async () => {
 
 	// Insert initial state
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "delete-cache-entity",
 			schema_key: "delete-cache-schema",
@@ -874,7 +874,7 @@ test("delete operations remove entries from underlying data", async () => {
 
 	// Verify data exists
 	const beforeDelete = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "delete-cache-entity")
 		.selectAll()
 		.execute();
@@ -883,7 +883,7 @@ test("delete operations remove entries from underlying data", async () => {
 
 	// Delete the state - this creates a deletion change (doesn't physically remove cache entry)
 	await lix.db
-		.deleteFrom("state")
+		.deleteFrom("state_all")
 		.where("entity_id", "=", "delete-cache-entity")
 		.where("schema_key", "=", "delete-cache-schema")
 		.where("file_id", "=", "delete-cache-file")
@@ -892,7 +892,7 @@ test("delete operations remove entries from underlying data", async () => {
 
 	// Data should no longer be accessible through state view
 	const afterDelete = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "delete-cache-entity")
 		.selectAll()
 		.execute();
@@ -922,7 +922,7 @@ test("change.created_at and state timestamps are consistent", async () => {
 
 	// Insert state data
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "timestamp-test-entity",
 			schema_key: "mock_schema",
@@ -980,7 +980,7 @@ test.todo(
 
 		// Verify it's accessible through state view (should populate cache)
 		const stateBeforeCacheClear = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("schema_key", "=", "lix_key_value")
 			.where("entity_id", "=", "test_cache_miss")
 			.selectAll()
@@ -1026,7 +1026,7 @@ test.todo(
 		// Try to access the same data through state view again
 		// This should trigger cache miss logic and repopulate from CTE
 		const stateAfterCacheClear = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("schema_key", "=", "lix_key_value")
 			.where("entity_id", "=", "test_cache_miss")
 			.selectAll()
@@ -1103,7 +1103,7 @@ test("delete operations are validated for foreign key constraints", async () => 
 
 	// Insert parent entity
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "parent-1",
 			schema_key: "parent_entity",
@@ -1120,7 +1120,7 @@ test("delete operations are validated for foreign key constraints", async () => 
 
 	// Insert child entity that references the parent
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "child-1",
 			schema_key: "child_entity",
@@ -1138,14 +1138,14 @@ test("delete operations are validated for foreign key constraints", async () => 
 
 	// Verify both entities exist
 	const parentBefore = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "parent-1")
 		.where("schema_key", "=", "parent_entity")
 		.selectAll()
 		.execute();
 
 	const childBefore = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "child-1")
 		.where("schema_key", "=", "child_entity")
 		.selectAll()
@@ -1158,7 +1158,7 @@ test("delete operations are validated for foreign key constraints", async () => 
 	// because there's a child entity that references it
 	await expect(
 		lix.db
-			.deleteFrom("state")
+			.deleteFrom("state_all")
 			.where("entity_id", "=", "parent-1")
 			.where("schema_key", "=", "parent_entity")
 			.execute()
@@ -1166,7 +1166,7 @@ test("delete operations are validated for foreign key constraints", async () => 
 
 	// Verify the parent still exists after failed deletion attempt
 	const parentAfter = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "parent-1")
 		.where("schema_key", "=", "parent_entity")
 		.selectAll()
@@ -1186,7 +1186,7 @@ describe.each([
 
 			// Insert an entity into global version
 			await lix.db
-				.insertInto("state")
+				.insertInto("state_all")
 				.values({
 					entity_id: "global-entity-1",
 					file_id: "test-file",
@@ -1218,7 +1218,7 @@ describe.each([
 
 			// The child version should inherit the entity from global
 			const inheritedEntity = await lix.db
-				.selectFrom("state")
+				.selectFrom("state_all")
 				.where("entity_id", "=", "global-entity-1")
 				.where("version_id", "=", childVersion.id)
 				.selectAll()
@@ -1262,7 +1262,7 @@ describe.each([
 
 				// Check the global version after mutation
 				const globalVersionAfterMutation = await lix.db
-					.selectFrom("state")
+					.selectFrom("state_all")
 					.where("schema_key", "=", "lix_version")
 					.where("entity_id", "=", mainVersion.id)
 					.where("version_id", "=", "global")
@@ -1283,7 +1283,7 @@ describe.each([
 				}
 
 				const state = await lix.db
-					.selectFrom("state")
+					.selectFrom("state_all")
 					.where("schema_key", "=", "lix_version")
 					.where("entity_id", "=", mainVersion.id)
 					.selectAll()
@@ -1365,7 +1365,7 @@ describe.skip.each([
 
 			// Insert an entity into global version
 			await lix.db
-				.insertInto("state")
+				.insertInto("state_all")
 				.values({
 					entity_id: "shared-entity",
 					file_id: "test-file",
@@ -1391,7 +1391,7 @@ describe.skip.each([
 
 			// Verify the child initially sees the inherited entity
 			const inheritedEntity = await lix.db
-				.selectFrom("state")
+				.selectFrom("state_all")
 				.where("entity_id", "=", "shared-entity")
 				.where("version_id", "=", childVersion.id)
 				.selectAll()
@@ -1408,7 +1408,7 @@ describe.skip.each([
 
 			// Now modify the entity in the child version (copy-on-write)
 			await lix.db
-				.updateTable("state")
+				.updateTable("state_all")
 				.set({
 					snapshot_content: {
 						id: "shared-entity",
@@ -1427,7 +1427,7 @@ describe.skip.each([
 
 			// Verify the child now has its own version of the entity
 			const childEntity = await lix.db
-				.selectFrom("state")
+				.selectFrom("state_all")
 				.where("entity_id", "=", "shared-entity")
 				.where("version_id", "=", childVersion.id)
 				.selectAll()
@@ -1444,7 +1444,7 @@ describe.skip.each([
 
 			// Verify the global version still has the original value
 			const globalEntity = await lix.db
-				.selectFrom("state")
+				.selectFrom("state_all")
 				.where("entity_id", "=", "shared-entity")
 				.where("version_id", "=", "global")
 				.selectAll()
@@ -1461,7 +1461,7 @@ describe.skip.each([
 
 			// Verify we now have 2 separate entities (one in global, one in child)
 			const allEntities = await lix.db
-				.selectFrom("state")
+				.selectFrom("state_all")
 				.where("entity_id", "=", "shared-entity")
 				.selectAll()
 				.execute();
@@ -1528,7 +1528,7 @@ describe.each([
 
 				// Insert an entity into global version
 				await lix.db
-					.insertInto("state")
+					.insertInto("state_all")
 					.values({
 						entity_id: "shared-entity",
 						file_id: "test-file",
@@ -1551,7 +1551,7 @@ describe.each([
 
 				// Verify the child initially sees the inherited entity
 				const inheritedEntity = await lix.db
-					.selectFrom("state")
+					.selectFrom("state_all")
 					.where("entity_id", "=", "shared-entity")
 					.where("version_id", "=", activeVersion.id)
 					.selectAll()
@@ -1563,7 +1563,7 @@ describe.each([
 
 				// Delete the inherited entity in child version (should create copy-on-write deletion)
 				await lix.db
-					.deleteFrom("state")
+					.deleteFrom("state_all")
 					.where("entity_id", "=", "shared-entity")
 					.where("version_id", "=", activeVersion.id)
 					.execute();
@@ -1575,7 +1575,7 @@ describe.each([
 
 				// Verify the entity is deleted in child version
 				const childEntityAfterDelete = await lix.db
-					.selectFrom("state")
+					.selectFrom("state_all")
 					.where("entity_id", "=", "shared-entity")
 					.where("version_id", "=", activeVersion.id)
 					.selectAll()
@@ -1586,7 +1586,7 @@ describe.each([
 
 				// Verify the entity still exists in global version (not affected by child deletion)
 				const inheritedEntityAfterDelete = await lix.db
-					.selectFrom("state")
+					.selectFrom("state_all")
 					.where("entity_id", "=", "shared-entity")
 					.where("version_id", "=", "global")
 					.selectAll()
@@ -1600,7 +1600,7 @@ describe.each([
 
 				// Verify we now only see the global entity through the state view (deletion marker is hidden)
 				const allEntities = await lix.db
-					.selectFrom("state")
+					.selectFrom("state_all")
 					.where("entity_id", "=", "shared-entity")
 					.selectAll()
 					.execute();
@@ -1635,7 +1635,7 @@ test.todo(
 
 		// Insert an entity into global version
 		await lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "shared-entity",
 				file_id: "test-file",
@@ -1659,7 +1659,7 @@ test.todo(
 
 		// Verify inheritance - both global and child should see the entity
 		const beforeDelete = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("entity_id", "=", "shared-entity")
 			.where("version_id", "in", ["global", childVersion.id])
 			.selectAll()
@@ -1682,13 +1682,13 @@ test.todo(
 		]);
 
 		await lix.db
-			.deleteFrom("state")
+			.deleteFrom("state_all")
 			.where("entity_id", "=", "shared-entity")
 			.where("schema_key", "=", "test_schema")
 			.execute();
 
 		const afterDelete = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("entity_id", "=", "shared-entity")
 			.selectAll()
 			.execute();
@@ -1707,7 +1707,7 @@ test.todo(
 
 		// First, insert a record successfully
 		await lix.db
-			.insertInto("state")
+			.insertInto("state_all")
 			.values({
 				entity_id: "test-duplicate-entity",
 				schema_key: "test_schema",
@@ -1721,7 +1721,7 @@ test.todo(
 
 		// Verify the record exists
 		const originalRecord = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("entity_id", "=", "test-duplicate-entity")
 			.selectAll()
 			.executeTakeFirst();
@@ -1748,7 +1748,7 @@ test.todo(
 
 		// Verify the original record is unchanged (OR IGNORE should have ignored the duplicate)
 		const afterIgnore = await lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.where("entity_id", "=", "test-duplicate-entity")
 			.selectAll()
 			.executeTakeFirst();

--- a/packages/lix-sdk/src/state/validate-state-mutation.test.ts
+++ b/packages/lix-sdk/src/state/validate-state-mutation.test.ts
@@ -181,7 +181,7 @@ test("throws when primary key violates uniqueness constraint", async () => {
 
 	// Insert first user into state
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "user1",
 			file_id: "file1",
@@ -239,7 +239,7 @@ test("handles composite primary keys", async () => {
 
 	// Insert first user-role into state
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "user_role1",
 			file_id: "file1",
@@ -359,7 +359,7 @@ test("throws when single field unique constraint is violated", async () => {
 
 	// Insert first user into state
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "user1",
 			file_id: "file1",
@@ -450,7 +450,7 @@ test("handles composite unique constraints", async () => {
 
 	// Insert first product into state
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "product1",
 			file_id: "file1",
@@ -586,7 +586,7 @@ test("passes when foreign key references exist", async () => {
 
 	// Insert a user that will be referenced
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "user1",
 			file_id: "file1",
@@ -751,7 +751,7 @@ test("handles multiple foreign keys", async () => {
 
 	// Insert referenced entities
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values([
 			{
 				entity_id: "user1",
@@ -1000,7 +1000,7 @@ test("allows updates with same primary key", async () => {
 
 	// Insert initial user
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "user1",
 			file_id: "file1",
@@ -1061,7 +1061,7 @@ test("unique constraints are validated per version, not globally", async () => {
 	});
 	// Insert file with path "/app.js" in version1
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "file1",
 			file_id: "file1",
@@ -1244,7 +1244,7 @@ test("should prevent deletion when foreign keys reference the entity", async () 
 
 	// Insert a user that will be referenced
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "user1",
 			file_id: "file1",
@@ -1261,7 +1261,7 @@ test("should prevent deletion when foreign keys reference the entity", async () 
 
 	// Insert a post that references the user
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "post1",
 			file_id: "file1",
@@ -1321,7 +1321,7 @@ test("should allow deletion when no foreign keys reference the entity", async ()
 
 	// Insert a user with no references
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "user1",
 			file_id: "file1",
@@ -1626,7 +1626,7 @@ test("foreign key validation should fail when referenced entity exists in differ
 
 	// Create a user in version A
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "user-1",
 			schema_key: "mock_user",
@@ -1660,7 +1660,7 @@ test("foreign key validation should fail when referenced entity exists in differ
 
 	// Verify that user-1 indeed doesn't exist in version B's context
 	const userInVersionB = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "user-1")
 		.where("schema_key", "=", "mock_user")
 		.where("version_id", "=", versionB.id)
@@ -1671,7 +1671,7 @@ test("foreign key validation should fail when referenced entity exists in differ
 
 	// But verify it does exist in version A
 	const userInVersionA = await lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.where("entity_id", "=", "user-1")
 		.where("schema_key", "=", "mock_user")
 		.where("version_id", "=", versionA.id)
@@ -1718,7 +1718,7 @@ test("should allow self-referential foreign keys", async () => {
 
 	// Insert a parent version first (with null inheritance)
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "version0",
 			file_id: "file1",
@@ -1817,7 +1817,7 @@ test("should allow self-referential foreign keys for update operations", async (
 
 	// Insert initial versions
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values([
 			{
 				entity_id: "version0",
@@ -1918,7 +1918,7 @@ test("should prevent deletion when self-referential foreign keys reference the e
 
 	// Insert parent and child versions
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values([
 			{
 				entity_id: "version0",

--- a/packages/lix-sdk/src/state/validate-state-mutation.ts
+++ b/packages/lix-sdk/src/state/validate-state-mutation.ts
@@ -164,7 +164,7 @@ function validatePrimaryKeyConstraints(args: {
 
 	// Query existing state to check for duplicates
 	let query = args.lix.db
-		.selectFrom("state")
+		.selectFrom("state_all")
 		.select("snapshot_content")
 		.where("schema_key", "=", args.schema["x-lix-key"])
 		.where("version_id", "=", args.version_id);
@@ -236,7 +236,7 @@ function validateUniqueConstraints(args: {
 
 		// Query existing state to check for duplicates
 		let query = args.lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.select("snapshot_content")
 			.where("schema_key", "=", args.schema["x-lix-key"])
 			.where("version_id", "=", args.version_id);
@@ -322,7 +322,7 @@ function validateForeignKeyConstraints(args: {
 		} else {
 			// Query JSON schema entities in the state table
 			query = args.lix.db
-				.selectFrom("state")
+				.selectFrom("state_all")
 				.select("snapshot_content")
 				.where("schema_key", "=", foreignKeyDef.schemaKey)
 				.where(
@@ -432,7 +432,7 @@ function validateDeletionConstraints(args: {
 	const currentEntity = executeSync({
 		lix: args.lix,
 		query: args.lix.db
-			.selectFrom("state")
+			.selectFrom("state_all")
 			.select(["snapshot_content", "inherited_from_version_id", "version_id"])
 			.where("entity_id", "=", args.entity_id)
 			.where("schema_key", "=", args.schema["x-lix-key"])
@@ -458,7 +458,7 @@ function validateDeletionConstraints(args: {
 		const entityInOtherVersions = executeSync({
 			lix: args.lix,
 			query: args.lix.db
-				.selectFrom("state")
+				.selectFrom("state_all")
 				.select(["version_id", "snapshot_content", "inherited_from_version_id"])
 				.where("entity_id", "=", args.entity_id)
 				.where("schema_key", "=", args.schema["x-lix-key"]),
@@ -545,7 +545,7 @@ function validateDeletionConstraints(args: {
 			const referencingEntities = executeSync({
 				lix: args.lix,
 				query: args.lix.db
-					.selectFrom("state")
+					.selectFrom("state_all")
 					.select("entity_id")
 					.where("schema_key", "=", schema["x-lix-key"])
 					.where("version_id", "=", args.version_id)

--- a/packages/lix-sdk/src/version/schema.test.ts
+++ b/packages/lix-sdk/src/version/schema.test.ts
@@ -461,7 +461,7 @@ test("mutation of a version's state should NOT lead to duplicate version entries
 	});
 
 	await lix.db
-		.insertInto("state")
+		.insertInto("state_all")
 		.values({
 			entity_id: "test_entity",
 			version_id: versionA.id,

--- a/packages/md-app/spec/lix-state-source-of-truth.md
+++ b/packages/md-app/spec/lix-state-source-of-truth.md
@@ -32,7 +32,7 @@ Plate AST → Markdown String → File → lix-plugin-md → lix entities → li
 **lix-plugin-md:**
 - Parses markdown string into simple blocks (text, type, id)
 - Uses `btoa(markdown) + position` for auto-generated IDs
-- Stores in `state_active.snapshot_content` as JSON
+- Stores in `state.snapshot_content` as JSON
 - Materializes file from entities via `applyChanges()`
 
 ## Proposed Architecture
@@ -591,7 +591,7 @@ export function useLixState(fileId: string) {
     try {
       setIsLoading(true);
       const result = await lix.db
-        .selectFrom('state_active')
+        .selectFrom('state')
         .select(['entity_id', 'snapshot_content'])
         .where('file_id', '=', fileId)
         .where('schema_key', '=', 'lix_plugin_md_block')
@@ -620,7 +620,7 @@ export function useLixState(fileId: string) {
       
       // Delete existing entities
       await lix.db
-        .deleteFrom('state_active')
+        .deleteFrom('state')
         .where('file_id', '=', fileId)
         .where('schema_key', '=', 'lix_plugin_md_block')
         .execute();
@@ -628,7 +628,7 @@ export function useLixState(fileId: string) {
       // Insert new entities
       if (newEntities.length > 0) {
         await lix.db
-          .insertInto('state_active')
+          .insertInto('state')
           .values(
             newEntities.map(entity => ({
               entity_id: entity.id,
@@ -763,7 +763,7 @@ This paragraph has **bold text** and [a link](https://example.com).`;
   }).execute();
 
   // Mutate heading entity using enhanced AST schema
-  await lix.db.updateTable("state_active")
+  await lix.db.updateTable("state_all")
     .set({
       snapshot_content: JSON.stringify({
         id: "V1StGXR8_Z",
@@ -777,7 +777,7 @@ This paragraph has **bold text** and [a link](https://example.com).`;
     .execute();
 
   // Mutate paragraph entity
-  await lix.db.updateTable("state_active")
+  await lix.db.updateTable("state_all")
     .set({
       snapshot_content: JSON.stringify({
         id: "3BqYGqeRws",
@@ -804,7 +804,7 @@ This paragraph has **bold text** and [a link](https://example.com).`;
   
   // Verify Plate editor would load with correct IDs
   const entities = await lix.db
-    .selectFrom("state_active")
+    .selectFrom("state_all")
     .where("file_id", "=", "file1")
     .where("schema_key", "=", "lix_plugin_md_block")
     .select(["entity_id", "snapshot_content"])


### PR DESCRIPTION
Aligns the state naming with the generated entity views. 

```diff
-state
-state_active
state_history

+state (active)
+state_all
state_history
```

This is a follow up of https://github.com/opral/lix-sdk/issues/321