### PR TITLE
refactor: rename LixFileSchema to LixFileDescriptorSchema and update references

### DIFF
--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -19,7 +19,7 @@ import type {
 	InternalChangeInTransactionTable,
 } from "../state/schema.js";
 import type { StateHistoryView } from "../state-history/schema.js";
-import { LixFileSchema } from "../file/schema.js";
+import { LixFileDescriptorSchema } from "../file/schema.js";
 import { LixLogSchema } from "../log/schema.js";
 import {
 	LixAccountSchema,
@@ -54,7 +54,7 @@ export const LixSchemaViewMap: Record<string, LixSchemaDefinition> = {
 	change_set_edge: LixChangeSetEdgeSchema,
 	change_set_label: LixChangeSetLabelSchema,
 	change_set_thread: LixChangeSetThreadSchema,
-	file: LixFileSchema,
+	file: LixFileDescriptorSchema,
 	log: LixLogSchema,
 	stored_schema: LixStoredSchemaSchema,
 	key_value: LixKeyValueSchema,
@@ -90,7 +90,7 @@ export type LixDatabaseSchema = {
 	EntityViews<typeof LixChangeSetLabelSchema, "change_set_label"> &
 	EntityViews<typeof LixChangeSetThreadSchema, "change_set_thread"> &
 	EntityViews<typeof LixChangeAuthorSchema, "change_author"> &
-	EntityViews<typeof LixFileSchema, "file", { data: Uint8Array }> &
+	EntityViews<typeof LixFileDescriptorSchema, "file", { data: Uint8Array }> &
 	EntityViews<typeof LixLabelSchema, "label"> &
 	EntityViews<typeof LixStoredSchemaSchema, "stored_schema", { value: any }> &
 	EntityViews<typeof LixLogSchema, "log"> &

--- a/packages/lix-sdk/src/file/file-handlers.ts
+++ b/packages/lix-sdk/src/file/file-handlers.ts
@@ -1,6 +1,6 @@
 import { executeSync } from "../database/execute-sync.js";
 import type { LixFile } from "./schema.js";
-import { LixFileSchema } from "./schema.js";
+import { LixFileDescriptorSchema } from "./schema.js";
 import { createLixOwnLogSync } from "../log/create-lix-own-log.js";
 import type { Lix } from "../lix/open-lix.js";
 import { lixUnknownFileFallbackPlugin } from "./unknown-file-fallback-plugin.js";
@@ -32,7 +32,7 @@ export function handleFileInsert(args: {
 		lix: args.lix,
 		query: args.lix.db.insertInto("state_all").values({
 			entity_id: args.file.id,
-			schema_key: "lix_file",
+			schema_key: LixFileDescriptorSchema["x-lix-key"],
 			file_id: args.file.id,
 			plugin_key: "lix_own_entity",
 			snapshot_content: {
@@ -40,7 +40,7 @@ export function handleFileInsert(args: {
 				path: args.file.path,
 				metadata: args.file.metadata || null,
 			},
-			schema_version: LixFileSchema["x-lix-version"],
+			schema_version: LixFileDescriptorSchema["x-lix-version"],
 			version_id: args.versionId,
 		}),
 	});
@@ -180,7 +180,7 @@ export function handleFileUpdate(args: {
 				},
 			})
 			.where("entity_id", "=", args.file.id)
-			.where("schema_key", "=", "lix_file")
+			.where("schema_key", "=", "lix_file_descriptor")
 			.where("version_id", "=", args.versionId),
 	});
 

--- a/packages/lix-sdk/src/file/index.ts
+++ b/packages/lix-sdk/src/file/index.ts
@@ -1,1 +1,5 @@
-export { LixFileSchema, type LixFile } from "./schema.js";
+export {
+	LixFileDescriptorSchema,
+	type LixFileDescriptor,
+	type LixFile,
+} from "./schema.js";

--- a/packages/lix-sdk/src/file/schema.test.ts
+++ b/packages/lix-sdk/src/file/schema.test.ts
@@ -98,7 +98,7 @@ test("insert, update, delete on the file view", async () => {
 		expect.arrayContaining([
 			// insert
 			expect.objectContaining({
-				schema_key: "lix_file",
+				schema_key: "lix_file_descriptor",
 				entity_id: "file0",
 				snapshot_content: expect.any(Object),
 			}),
@@ -111,7 +111,7 @@ test("insert, update, delete on the file view", async () => {
 			}),
 			// update
 			expect.objectContaining({
-				schema_key: "lix_file",
+				schema_key: "lix_file_descriptor",
 				entity_id: "file0",
 				snapshot_content: expect.any(Object),
 			}),
@@ -124,7 +124,7 @@ test("insert, update, delete on the file view", async () => {
 			}),
 			// delete (file‑level)
 			expect.objectContaining({
-				schema_key: "lix_file",
+				schema_key: "lix_file_descriptor",
 				entity_id: "file0",
 				snapshot_content: null,
 			}),
@@ -562,7 +562,7 @@ test("file and file_all views expose change_id for blame and diff functionality"
 	const fileChangeRecord = await lix.db
 		.selectFrom("change")
 		.where("entity_id", "=", "change-id-test-file")
-		.where("schema_key", "=", "lix_file")
+		.where("schema_key", "=", "lix_file_descriptor")
 		.select(["id", "snapshot_content"])
 		.executeTakeFirstOrThrow();
 
@@ -606,7 +606,7 @@ test("file and file_all views expose change_id for blame and diff functionality"
 	const newFileChangeRecord = await lix.db
 		.selectFrom("change")
 		.where("entity_id", "=", "change-id-test-file")
-		.where("schema_key", "=", "lix_file")
+		.where("schema_key", "=", "lix_file_descriptor")
 		.orderBy("created_at", "desc")
 		.select(["id", "snapshot_content"])
 		.executeTakeFirstOrThrow();
@@ -768,11 +768,11 @@ test("file metadata updates create new change_id", async () => {
 		.selectFrom("change")
 		.where("id", "=", updatedMetadataFile.lixcol_change_id)
 		.where("entity_id", "=", "metadata-change-test")
-		.where("schema_key", "=", "lix_file")
+		.where("schema_key", "=", "lix_file_descriptor")
 		.selectAll()
 		.executeTakeFirst();
 
 	expect(finalFileChangeRecord).toBeDefined();
 	expect(finalFileChangeRecord?.entity_id).toBe("metadata-change-test");
-	expect(finalFileChangeRecord?.schema_key).toBe("lix_file");
+	expect(finalFileChangeRecord?.schema_key).toBe("lix_file_descriptor");
 });


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/310

- separates lix file from file descriptor
- view "file" remains identical 