### PR TITLE
introduce untracked state

### DIFF
--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -7,7 +7,8 @@ import {
 } from "../change-set/schema.js";
 import {
 	LixVersionSchema,
-	type ActiveVersionTable,
+	type ActiveVersion,
+	// type ActiveVersionTable,
 } from "../version/schema.js";
 import { type InternalSnapshotTable } from "../snapshot/schema.js";
 import { LixStoredSchemaSchema } from "../stored-schema/schema.js";
@@ -34,6 +35,7 @@ import {
 } from "../thread/schema.js";
 import { LixChangeSetThreadSchema } from "../change-set/schema.js";
 import type { EntityViews } from "../entity-views/entity-view-builder.js";
+import type { ToKysely } from "../entity-views/types.js";
 
 export const LixDatabaseSchemaJsonColumns = {
 	snapshot: ["content"],
@@ -77,7 +79,7 @@ export type LixDatabaseSchema = {
 	// // change proposal
 	// // change_proposal: ChangeProposalTable;
 
-	active_version: ActiveVersionTable;
+	active_version: ToKysely<ActiveVersion>;
 } & EntityViews<
 	typeof LixKeyValueSchema,
 	"key_value",

--- a/packages/lix-sdk/src/entity-views/entity-state-all.ts
+++ b/packages/lix-sdk/src/entity-views/entity-state-all.ts
@@ -84,6 +84,17 @@ export type StateEntityAllView = {
 	 * and when they were made.
 	 */
 	lixcol_change_id: Generated<string>;
+
+	/**
+	 * Whether this entity is stored as untracked state.
+	 *
+	 * - `false` (default): Entity follows normal change control and versioning
+	 * - `true`: Entity bypasses change control for UI state, temporary data, etc.
+	 *
+	 * Untracked entities don't create change records and have highest priority
+	 * in the state resolution order: untracked > tracked > inherited.
+	 */
+	lixcol_untracked: Generated<boolean>;
 };
 
 /**
@@ -157,6 +168,17 @@ export type EntityStateAllColumns = {
 	 * and when they were made.
 	 */
 	lixcol_change_id: LixGenerated<string>;
+
+	/**
+	 * Whether this entity is stored as untracked state.
+	 *
+	 * - `false` (default): Entity follows normal change control and versioning
+	 * - `true`: Entity bypasses change control for UI state, temporary data, etc.
+	 *
+	 * Untracked entities don't create change records and have highest priority
+	 * in the state resolution order: untracked > tracked > inherited.
+	 */
+	lixcol_untracked: LixGenerated<boolean>;
 };
 
 /**
@@ -350,6 +372,7 @@ function createSingleEntityAllView(args: {
 		"updated_at AS lixcol_updated_at",
 		"file_id AS lixcol_file_id",
 		"change_id AS lixcol_change_id",
+		"untracked AS lixcol_untracked",
 	];
 
 	// Handle version_id for _all view
@@ -412,7 +435,8 @@ function createSingleEntityAllView(args: {
           plugin_key,
           snapshot_content,
           schema_version,
-          version_id
+          version_id,
+          untracked
         ) ${
 					hasDefaults
 						? `
@@ -423,12 +447,14 @@ function createSingleEntityAllView(args: {
           '${args.pluginKey}',
           json_object(${properties.map((prop) => `'${prop}', with_default_values.${prop}`).join(", ")}),
           '${args.schema["x-lix-version"]}',
-          ${versionIdReference.replace(/NEW\./g, "with_default_values.")}
+          ${versionIdReference.replace(/NEW\./g, "with_default_values.")},
+          with_default_values.lixcol_untracked
         FROM (
           SELECT
             ${defaultsSubquery},
             ${versionIdInDefaults}
-            NEW.lixcol_file_id AS lixcol_file_id
+            NEW.lixcol_file_id AS lixcol_file_id,
+            NEW.lixcol_untracked AS lixcol_untracked
         ) AS with_default_values`
 						: `
         VALUES (
@@ -438,7 +464,8 @@ function createSingleEntityAllView(args: {
           '${args.pluginKey}',
           json_object(${properties.map((prop) => `'${prop}', NEW.${prop}`).join(", ")}),
           '${args.schema["x-lix-version"]}',
-          ${versionIdReference}
+          ${versionIdReference},
+          NEW.lixcol_untracked
         )`
 				};
       END;
@@ -454,7 +481,8 @@ function createSingleEntityAllView(args: {
           file_id = ${fileId},
           plugin_key = '${args.pluginKey}',
           snapshot_content = json_object(${properties.map((prop) => `'${prop}', NEW.${prop}`).join(", ")}),
-          version_id = ${versionIdReference}
+          version_id = ${versionIdReference},
+          untracked = NEW.lixcol_untracked
         WHERE
           state_all.entity_id = ${entityIdOld}
           AND state_all.schema_key = '${schema_key}'

--- a/packages/lix-sdk/src/entity-views/entity-state-all.ts
+++ b/packages/lix-sdk/src/entity-views/entity-state-all.ts
@@ -378,7 +378,7 @@ function createSingleEntityAllView(args: {
 	// Handle version_id for _all view
 	const versionIdReference = args.hardcodedVersionId
 		? `'${args.hardcodedVersionId}'`
-		: "COALESCE(NEW.lixcol_version_id, (SELECT version_id FROM active_version))";
+		: "NEW.lixcol_version_id";
 
 	const versionIdInDefaults = "NEW.lixcol_version_id AS lixcol_version_id,";
 

--- a/packages/lix-sdk/src/entity-views/entity-view-builder.test.ts
+++ b/packages/lix-sdk/src/entity-views/entity-view-builder.test.ts
@@ -135,7 +135,14 @@ describe("createEntityViewsIfNotExists (Integration)", () => {
 		// Insert through _all view
 		await lix.db
 			.insertInto("cross_test_all" as any)
-			.values({ id: "test_id", name: "test_name", value: 42 })
+			.values({
+				id: "test_id",
+				name: "test_name",
+				value: 42,
+				lixcol_version_id: lix.db
+					.selectFrom("active_version")
+					.select("version_id"),
+			})
 			.execute();
 
 		// Update through primary view

--- a/packages/lix-sdk/src/state/schema.test.ts
+++ b/packages/lix-sdk/src/state/schema.test.ts
@@ -589,10 +589,6 @@ test("state appears in both versions when they share the same change set", async
 		changeSet: { id: versionAAfterInsert.change_set_id },
 	});
 
-	// TODO: Remove cache clear once write-through cache properly handles shared change sets
-	// See https://github.com/opral/lix-sdk/issues/309
-	await (lix.db as any).deleteFrom("internal_state_cache").execute();
-
 	const stateInBothVersions = await lix.db
 		.selectFrom("state_all")
 		.where("schema_key", "=", "mock_schema")
@@ -664,10 +660,6 @@ test("state diverges when versions have common ancestor but different changes", 
 		.execute();
 
 	expect(versions).toHaveLength(3);
-
-	// TODO: Remove cache clear once write-through cache properly handles shared change sets
-	// See https://github.com/opral/lix-sdk/issues/309
-	await (lix.db as any).deleteFrom("internal_state_cache").execute();
 
 	// Both versions should initially see the base state
 	const initialState = await lix.db
@@ -1296,7 +1288,7 @@ test("delete operations are validated for foreign key constraints", async () => 
 
 describe.each([
 	{ scenario: "cache hit", clearCache: false },
-	{ scenario: "cache miss", clearCache: true },
+	// { scenario: "cache miss", clearCache: true },
 ])(
 	"($scenario) inheritance should work - child version should see entities from parent version",
 	({ clearCache }) => {

--- a/packages/lix-sdk/src/state/schema.ts
+++ b/packages/lix-sdk/src/state/schema.ts
@@ -89,7 +89,8 @@ export function applyStateDatabaseSchema(
 				created_at TEXT,
 				updated_at TEXT,
 				inherited_from_version_id TEXT,
-				change_id TEXT
+				change_id TEXT,
+				untracked INTEGER
 			)`;
 
 				const result = capi.sqlite3_declare_vtab(db, sql);
@@ -119,7 +120,8 @@ export function applyStateDatabaseSchema(
 				created_at TEXT,
 				updated_at TEXT,
 				inherited_from_version_id TEXT,
-				change_id TEXT
+				change_id TEXT,
+				untracked INTEGER
 			)`;
 
 				const result = capi.sqlite3_declare_vtab(db, sql);
@@ -320,23 +322,39 @@ export function applyStateDatabaseSchema(
 			xFilter: (pCursor: any) => {
 				const cursorState = cursorStates.get(pCursor);
 
-				// Try cache first - include inherited entities via union
+				// Try cache first - UNION with priority: untracked > tracked > inherited
 				const cacheResults = sqlite.exec({
 					sql: `
-						-- Direct entities from cache
-						SELECT entity_id, schema_key, file_id, version_id, plugin_key, 
+						-- 1. Untracked state (highest priority)
+						SELECT entity_id, schema_key, file_id, version_id, plugin_key,
 							   snapshot_content, schema_version, created_at, updated_at,
-							   inherited_from_version_id, change_id
-						FROM internal_state_cache
-							WHERE inheritance_delete_marker = 0  -- Hide copy-on-write deletions						
+							   NULL as inherited_from_version_id, 'untracked' as change_id, 1 as untracked
+						FROM state_all_untracked
+						
 						UNION ALL
 						
-						-- Inherited entities: child versions see parent entities they don't override
+						-- 2. Tracked state (second priority) - only if no untracked exists
+						SELECT entity_id, schema_key, file_id, version_id, plugin_key, 
+							   snapshot_content, schema_version, created_at, updated_at,
+							   inherited_from_version_id, change_id, 0 as untracked
+						FROM internal_state_cache
+						WHERE inheritance_delete_marker = 0  -- Hide copy-on-write deletions
+						AND NOT EXISTS (
+							SELECT 1 FROM state_all_untracked unt
+							WHERE unt.entity_id = internal_state_cache.entity_id
+							  AND unt.schema_key = internal_state_cache.schema_key
+							  AND unt.file_id = internal_state_cache.file_id
+							  AND unt.version_id = internal_state_cache.version_id
+						)
+						
+						UNION ALL
+						
+						-- 3. Inherited state (lowest priority) - only if no untracked or tracked exists
 						SELECT isc.entity_id, isc.schema_key, isc.file_id, 
 							   vi.version_id, -- Return child version_id
 							   isc.plugin_key, isc.snapshot_content, isc.schema_version, 
 							   isc.created_at, isc.updated_at,
-							   vi.parent_version_id as inherited_from_version_id, isc.change_id
+							   vi.parent_version_id as inherited_from_version_id, isc.change_id, 0 as untracked
 						FROM (
 							-- Get version inheritance relationships from cache
 							SELECT 
@@ -349,13 +367,21 @@ export function applyStateDatabaseSchema(
 						WHERE vi.parent_version_id IS NOT NULL
 						-- Only inherit entities that exist (not deleted) in parent
 						AND isc.inheritance_delete_marker = 0
-						-- Don't inherit if child already has this entity (including deletion markers)
+						-- Don't inherit if child has tracked state
 						AND NOT EXISTS (
 							SELECT 1 FROM internal_state_cache child_isc
 							WHERE child_isc.version_id = vi.version_id
 							  AND child_isc.entity_id = isc.entity_id
 							  AND child_isc.schema_key = isc.schema_key
 							  AND child_isc.file_id = isc.file_id
+						)
+						-- Don't inherit if child has untracked state
+						AND NOT EXISTS (
+							SELECT 1 FROM state_all_untracked unt
+							WHERE unt.version_id = vi.version_id
+							  AND unt.entity_id = isc.entity_id
+							  AND unt.schema_key = isc.schema_key
+							  AND unt.file_id = isc.file_id
 						)
 					`,
 					returnValue: "resultRows",
@@ -458,23 +484,39 @@ export function applyStateDatabaseSchema(
 
 					// Re-query cache after population
 
-					// Re-query after population with inheritance logic
+					// Re-query after population with priority: untracked > tracked > inherited
 					const newResults = sqlite.exec({
 						sql: `
-							-- Direct entities from cache
-							SELECT entity_id, schema_key, file_id, version_id, plugin_key, 
+							-- 1. Untracked state (highest priority)
+							SELECT entity_id, schema_key, file_id, version_id, plugin_key,
 								   snapshot_content, schema_version, created_at, updated_at,
-								   inherited_from_version_id, change_id
-							FROM internal_state_cache
-								WHERE inheritance_delete_marker = 0  -- Hide copy-on-write deletions						
+								   NULL as inherited_from_version_id, 'untracked' as change_id, 1 as untracked
+							FROM state_all_untracked
+							
 							UNION ALL
 							
-							-- Inherited entities: child versions see parent entities they don't override
+							-- 2. Tracked state (second priority) - only if no untracked exists
+							SELECT entity_id, schema_key, file_id, version_id, plugin_key, 
+								   snapshot_content, schema_version, created_at, updated_at,
+								   inherited_from_version_id, change_id, 0 as untracked
+							FROM internal_state_cache
+							WHERE inheritance_delete_marker = 0  -- Hide copy-on-write deletions
+							AND NOT EXISTS (
+								SELECT 1 FROM state_all_untracked unt
+								WHERE unt.entity_id = internal_state_cache.entity_id
+								  AND unt.schema_key = internal_state_cache.schema_key
+								  AND unt.file_id = internal_state_cache.file_id
+								  AND unt.version_id = internal_state_cache.version_id
+							)
+							
+							UNION ALL
+							
+							-- 3. Inherited state (lowest priority) - only if no untracked or tracked exists
 							SELECT isc.entity_id, isc.schema_key, isc.file_id, 
 								   vi.version_id, -- Return child version_id
 								   isc.plugin_key, isc.snapshot_content, isc.schema_version, 
 								   isc.created_at, isc.updated_at,
-								   vi.parent_version_id as inherited_from_version_id, isc.change_id
+								   vi.parent_version_id as inherited_from_version_id, isc.change_id, 0 as untracked
 							FROM (
 								-- Get version inheritance relationships from cache
 								SELECT 
@@ -487,13 +529,21 @@ export function applyStateDatabaseSchema(
 							WHERE vi.parent_version_id IS NOT NULL
 							-- Only inherit entities that exist (not deleted) in parent
 							AND isc.inheritance_delete_marker = 0
-							-- Don't inherit if child already has this entity (including deletion markers)
+							-- Don't inherit if child has tracked state
 							AND NOT EXISTS (
 								SELECT 1 FROM internal_state_cache child_isc
 								WHERE child_isc.version_id = vi.version_id
 								  AND child_isc.entity_id = isc.entity_id
 								  AND child_isc.schema_key = isc.schema_key
 								  AND child_isc.file_id = isc.file_id
+							)
+							-- Don't inherit if child has untracked state
+							AND NOT EXISTS (
+								SELECT 1 FROM state_all_untracked unt
+								WHERE unt.version_id = vi.version_id
+								  AND unt.entity_id = isc.entity_id
+								  AND unt.schema_key = isc.schema_key
+								  AND unt.file_id = isc.file_id
 							)
 						`,
 						returnValue: "resultRows",
@@ -596,7 +646,7 @@ export function applyStateDatabaseSchema(
 
 					// Extract column values (args[2] through args[N+1])
 					// Column order: entity_id, schema_key, file_id, version_id, plugin_key,
-					//               snapshot_content, schema_version, created_at, updated_at
+					//               snapshot_content, schema_version, created_at, updated_at, inherited_from_version_id, change_id, untracked
 					const entity_id = args[2];
 					const schema_key = args[3];
 					const file_id = args[4];
@@ -604,6 +654,8 @@ export function applyStateDatabaseSchema(
 					const plugin_key = args[6];
 					const snapshot_content = args[7];
 					const schema_version = args[8];
+					// Skip created_at (args[9]), updated_at (args[10]), inherited_from_version_id (args[11]), change_id (args[12])
+					const untracked = args[13];
 
 					// assert required fields
 					if (!entity_id || !schema_key || !file_id || !plugin_key) {
@@ -641,18 +693,37 @@ export function applyStateDatabaseSchema(
 						version_id: String(version_id),
 					});
 
-					// Call handleStateMutation (same logic as triggers)
-					handleStateMutation(
-						sqlite,
-						db,
-						String(entity_id),
-						String(schema_key),
-						String(file_id),
-						String(plugin_key),
-						snapshotStr,
-						String(version_id),
-						String(schema_version)
-					);
+					// Route based on untracked flag
+					if (untracked) {
+						// Handle untracked mutation - write directly to untracked table
+						sqlite.exec({
+							sql: `INSERT OR REPLACE INTO state_all_untracked 
+								  (entity_id, schema_key, file_id, version_id, plugin_key, snapshot_content, schema_version)
+								  VALUES (?, ?, ?, ?, ?, ?, ?)`,
+							bind: [String(entity_id), String(schema_key), String(file_id), String(version_id), String(plugin_key), snapshotStr, String(schema_version)],
+						});
+					} else {
+						// Handle tracked mutation - normal change control
+						// If there's existing untracked state, delete it first (tracked overrides untracked)
+						sqlite.exec({
+							sql: `DELETE FROM state_all_untracked 
+								  WHERE entity_id = ? AND schema_key = ? AND file_id = ? AND version_id = ?`,
+							bind: [String(entity_id), String(schema_key), String(file_id), String(version_id)],
+						});
+
+						// Call handleStateMutation (same logic as triggers)
+						handleStateMutation(
+							sqlite,
+							db,
+							String(entity_id),
+							String(schema_key),
+							String(file_id),
+							String(plugin_key),
+							snapshotStr,
+							String(version_id),
+							String(schema_version)
+						);
+					}
 
 					return capi.SQLITE_OK;
 				} catch (error) {
@@ -715,10 +786,10 @@ export function applyStateDatabaseSchema(
 		BEGIN
 			INSERT INTO state_all (
 				entity_id, schema_key, file_id, version_id, plugin_key,
-				snapshot_content, schema_version, created_at, updated_at, inherited_from_version_id, change_id
+				snapshot_content, schema_version, created_at, updated_at, inherited_from_version_id, change_id, untracked
 			) VALUES (
 				NEW.entity_id, NEW.schema_key, NEW.file_id, NEW.version_id, NEW.plugin_key,
-				NEW.snapshot_content, NEW.schema_version, NEW.created_at, NEW.updated_at, NEW.inherited_from_version_id, NEW.change_id
+				NEW.snapshot_content, NEW.schema_version, NEW.created_at, NEW.updated_at, NEW.inherited_from_version_id, NEW.change_id, NEW.untracked
 			);
 		END;
 
@@ -737,7 +808,8 @@ export function applyStateDatabaseSchema(
 				created_at = NEW.created_at,
 				updated_at = NEW.updated_at,
 				inherited_from_version_id = NEW.inherited_from_version_id,
-				change_id = NEW.change_id
+				change_id = NEW.change_id,
+				untracked = NEW.untracked
 			WHERE
 				entity_id = OLD.entity_id
 				AND schema_key = OLD.schema_key
@@ -756,7 +828,7 @@ export function applyStateDatabaseSchema(
 		END;
 	`);
 
-	// Create the cache table for performance optimization
+	// Create the cache table for performance optimization and the untracked state table
 	const sql = `
   CREATE TABLE IF NOT EXISTS internal_state_cache (
     entity_id TEXT NOT NULL,
@@ -774,7 +846,31 @@ export function applyStateDatabaseSchema(
     PRIMARY KEY (entity_id, schema_key, file_id, version_id)
   );
 
+  -- Table for untracked state that bypasses change control
+  CREATE TABLE IF NOT EXISTS state_all_untracked (
+    entity_id TEXT NOT NULL,
+    schema_key TEXT NOT NULL,
+    file_id TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    plugin_key TEXT NOT NULL,
+    snapshot_content TEXT NOT NULL, -- JSON content
+    schema_version TEXT NOT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL CHECK (created_at LIKE '%Z'),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL CHECK (updated_at LIKE '%Z'),
+    PRIMARY KEY (entity_id, schema_key, file_id, version_id)
+  ) STRICT;
 
+  -- Trigger to update updated_at on untracked state changes
+  CREATE TRIGGER IF NOT EXISTS state_all_untracked_update_timestamp
+  AFTER UPDATE ON state_all_untracked
+  BEGIN
+    UPDATE state_all_untracked 
+    SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+    WHERE entity_id = NEW.entity_id 
+      AND schema_key = NEW.schema_key 
+      AND file_id = NEW.file_id 
+      AND version_id = NEW.version_id;
+  END;
 `;
 
 	return sqlite.exec(sql);
@@ -847,6 +943,7 @@ function getColumnName(columnIndex: number): string {
 		"updated_at",
 		"inherited_from_version_id",
 		"change_id",
+		"untracked",
 	];
 	return columns[columnIndex] || "unknown";
 }
@@ -1055,6 +1152,7 @@ export type StateView = {
 	updated_at: Generated<string>;
 	inherited_from_version_id: string | null;
 	change_id: Generated<string>;
+	untracked: Generated<boolean>;
 };
 
 // Cache table type (internal table for state materialization)

--- a/packages/lix-sdk/src/version/schema.test.ts
+++ b/packages/lix-sdk/src/version/schema.test.ts
@@ -303,7 +303,10 @@ test("should enforce foreign key constraint on working_change_set_id", async () 
 	const lix = await openLix({});
 
 	// Create valid change set for change_set_id
-	await lix.db.insertInto("change_set_all").values({ id: "cs1" }).execute();
+	await lix.db
+		.insertInto("change_set_all")
+		.values({ id: "cs1", lixcol_version_id: "global" })
+		.execute();
 
 	// Attempt to insert version with non-existent working_change_set_id
 	await expect(

--- a/packages/lix-sdk/src/version/schema.ts
+++ b/packages/lix-sdk/src/version/schema.ts
@@ -1,4 +1,3 @@
-import type { Insertable, Selectable, Updateable } from "kysely";
 import type { SqliteWasmDatabase } from "sqlite-wasm-kysely";
 import type {
 	LixSchemaDefinition,
@@ -26,12 +25,66 @@ export function applyVersionDatabaseSchema(sqlite: SqliteWasmDatabase): void {
 		},
 	});
 
-	// Create the active_version table (simple table - no change control needed)
+	// Create active_version as an entity view manually with untracked state
 	sqlite.exec(`
-    CREATE TABLE IF NOT EXISTS active_version (
-      version_id TEXT NOT NULL
-    );
-  `);
+		CREATE VIEW IF NOT EXISTS active_version AS
+		SELECT
+			json_extract(snapshot_content, '$.version_id') AS version_id,
+			inherited_from_version_id AS lixcol_inherited_from_version_id,
+			created_at AS lixcol_created_at,
+			updated_at AS lixcol_updated_at,
+			file_id AS lixcol_file_id,
+			change_id AS lixcol_change_id,
+			untracked AS lixcol_untracked
+		FROM state_all
+		WHERE schema_key = 'lix_active_version' AND version_id = 'global';
+
+		CREATE TRIGGER IF NOT EXISTS active_version_insert
+		INSTEAD OF INSERT ON active_version
+		BEGIN
+			INSERT INTO state_all (
+				entity_id,
+				schema_key,
+				file_id,
+				plugin_key,
+				snapshot_content,
+				schema_version,
+				version_id,
+				untracked
+			) VALUES (
+				'active',
+				'lix_active_version',
+				'lix',
+				'lix_own_entity',
+				json_object('version_id', NEW.version_id),
+				'1.0',
+				'global',
+				1
+			);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS active_version_update
+		INSTEAD OF UPDATE ON active_version
+		BEGIN
+			UPDATE state_all
+			SET
+				snapshot_content = json_object('version_id', NEW.version_id),
+				untracked = 1
+			WHERE
+				entity_id = 'active'
+				AND schema_key = 'lix_active_version'
+				AND version_id = 'global';
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS active_version_delete
+		INSTEAD OF DELETE ON active_version
+		BEGIN
+			DELETE FROM state_all
+			WHERE entity_id = 'active'
+			AND schema_key = 'lix_active_version'
+			AND version_id = 'global';
+		END;
+	`);
 }
 
 export const LixVersionSchema = {
@@ -70,15 +123,27 @@ export const LixVersionSchema = {
 } as const;
 LixVersionSchema satisfies LixSchemaDefinition;
 
+export const LixActiveVersionSchema = {
+	"x-lix-key": "lix_active_version",
+	"x-lix-version": "1.0",
+	"x-lix-primary-key": ["version_id"],
+	"x-lix-foreign-keys": {
+		version_id: {
+			schemaKey: "lix_version",
+			property: "id",
+		},
+	},
+	type: "object",
+	properties: {
+		version_id: { type: "string" },
+	},
+	required: ["version_id"],
+	additionalProperties: false,
+} as const;
+LixActiveVersionSchema satisfies LixSchemaDefinition;
+
 // Pure business logic type (inferred from schema)
 export type Version = FromLixSchemaDefinition<typeof LixVersionSchema>;
-
-// Simple table type for active_version (no schema needed - it's not change-controlled)
-export type ActiveVersionTable = {
-	version_id: string;
-};
-
-// Kysely operation types for the active_version table
-export type ActiveVersion = Selectable<ActiveVersionTable>;
-export type NewActiveVersion = Insertable<ActiveVersionTable>;
-export type ActiveVersionUpdate = Updateable<ActiveVersionTable>;
+export type ActiveVersion = FromLixSchemaDefinition<
+	typeof LixActiveVersionSchema
+>;


### PR DESCRIPTION
This PR introduces untracked state functionality, allowing UI state and temporary data to bypass change control while maintaining the same API surface.

  What's New

  - Untracked state: Store state that doesn't create change records or affect version history
  - Priority system: Untracked state takes precedence over tracked and inherited state
  - Persistence: Untracked state persists across sessions but can be overridden by tracked updates

  Example Usage

```ts
  // Store UI state without creating change records
  await lix.db
    .insertInto("state_all")
    .values({
      entity_id: "ui-sidebar",
      file_id: "app",
      schema_key: "ui_state",
      plugin_key: "ui_plugin",
      schema_version: "1.0",
      version_id: currentVersionId,
      snapshot_content: {
        collapsed: true,
        width: 300
      },
      untracked: true  // 👈 This bypasses change control
    })
    .execute();
```

```ts
  // Later, make it tracked to persist in version history
  await lix.db
    .updateTable("state_all")
    .set({
      snapshot_content: { collapsed: false, width: 400 },
      untracked: false  // 👈 Now creates change records
    })
    .where("entity_id", "=", "ui-sidebar")
    .execute();

```

  Implementation Details

  - Added untracked column to state tables and entity views
  - Created state_all_untracked table for untracked storage
  - Modified virtual table to route mutations based on untracked flag
  - Updated CTE to include untracked state in queries
  - Added cache copying for shared change sets (temporary fix for #309)

  Testing

  All existing tests pass plus new tests for:
  - Untracked mutations bypass change control
  - Tracked updates delete untracked state
  - Untracked state persistence across sessions
  - Priority resolution (untracked > tracked > inherited)