### PR TITLE
feat: observe api

### DIFF
--- a/packages/lix-sdk/src/lix/open-lix.ts
+++ b/packages/lix-sdk/src/lix/open-lix.ts
@@ -12,6 +12,7 @@ import type { Account } from "../account/schema.js";
 import { InMemoryStorage } from "./storage/in-memory.js";
 import type { LixStorageAdapter } from "./storage/lix-storage-adapter.js";
 import { createHooks, type LixHooks } from "../hooks/create-hooks.js";
+import { createObserve } from "../observe/create-observe.js";
 
 export type Lix = {
 	/**
@@ -41,6 +42,7 @@ export type Lix = {
 	 * Closes the lix instance and its storage.
 	 */
 	close: () => Promise<void>;
+	observe: ReturnType<typeof createObserve>;
 	/**
 	 * Serialises the Lix into a {@link Blob}.
 	 *
@@ -196,11 +198,14 @@ export async function openLix(args: {
 
 	captureOpened({ db });
 
+	const observe = createObserve({ hooks });
+
 	const lix = {
 		db,
 		sqlite: database,
 		plugin,
 		hooks,
+		observe,
 		close: async () => {
 			await storage.close();
 		},

--- a/packages/lix-sdk/src/observe/create-observe.test.ts
+++ b/packages/lix-sdk/src/observe/create-observe.test.ts
@@ -1,0 +1,502 @@
+import { test, expect } from "vitest";
+import { openLix } from "../lix/open-lix.js";
+
+/**
+ * These tests use the key_value table as an example entity in the state.
+ * The key_value table is a built-in table in Lix that stores configuration
+ * and metadata. We use it here because it's always available in any Lix instance.
+ * 
+ * In real applications, you would observe your own domain-specific tables
+ * like "users", "documents", "settings", etc.
+ */
+
+
+test("observe should emit initial values and updates for key_value table", async () => {
+	const lix = await openLix({});
+	const values: any[] = [];
+
+	// 3.1 Full result-set stream - filtered to test keys only
+	const subscription = lix
+		.observe(
+			lix.db.selectFrom("key_value").selectAll().where("key", "like", "test_%")
+		)
+		.subscribe({ next: (rows) => values.push(rows) });
+
+	// Wait for initial emission
+	await new Promise(resolve => setTimeout(resolve, 10));
+	expect(values).toHaveLength(1);
+	expect(values[0]).toEqual([]);
+
+	// Insert a test key-value pair
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "test_key", value: "test_value" })
+		.execute();
+
+	// Wait for update
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should have received an update
+	expect(values).toHaveLength(2);
+	expect(values[1]).toHaveLength(1);
+	expect(values[1][0]).toMatchObject({
+		key: "test_key",
+		value: "test_value",
+	});
+
+	subscription.unsubscribe();
+	await lix.close();
+});
+
+test("subscribeTakeFirst should emit first row or undefined", async () => {
+	const lix = await openLix({});
+	const values: any[] = [];
+
+	// 3.2 Track latest change-set (row || undefined)
+	// Using key_value table as example, filtered to demo_ prefix
+	const subscription = lix
+		.observe(
+			lix.db
+				.selectFrom("key_value")
+				.selectAll()
+				.where("key", "like", "demo_%")
+				.orderBy("key", "asc")
+		)
+		.subscribeTakeFirst({ next: (row) => values.push(row) });
+
+	// Wait for initial emission
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should have initial undefined (no demo_ keys yet)
+	expect(values).toHaveLength(1);
+	expect(values[0]).toBeUndefined();
+
+	// Insert a demo key
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "demo_first", value: "first_value" })
+		.execute();
+
+	// Wait for update
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should have received an update with the new first row
+	expect(values).toHaveLength(2);
+	expect(values[1]).toMatchObject({
+		key: "demo_first",
+		value: "first_value",
+	});
+
+	// Insert another demo key that comes first alphabetically
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "demo_aaa", value: "aaa_value" })
+		.execute();
+
+	// Wait for update
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should now get the alphabetically first key
+	expect(values).toHaveLength(3);
+	expect(values[2]).toMatchObject({
+		key: "demo_aaa",
+		value: "aaa_value",
+	});
+
+	subscription.unsubscribe();
+	await lix.close();
+});
+
+test("subscribeTakeFirstOrThrow should error when no rows exist", async () => {
+	const lix = await openLix({});
+	const values: any[] = [];
+	const errors: any[] = [];
+
+	// 3.3 Strict singleton (error when empty)
+	// Query for specific non-existent key
+	const subscription = lix
+		.observe(
+			lix.db
+				.selectFrom("key_value")
+				.selectAll()
+				.where("key", "=", "singleton_test_key")
+		)
+		.subscribeTakeFirstOrThrow({
+			next: (row) => values.push(row),
+			error: (err) => errors.push(err),
+		});
+
+	// Wait for initial emission (error)
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should have received an error
+	expect(values).toHaveLength(0);
+	expect(errors).toHaveLength(1);
+	expect(errors[0]).toBeInstanceOf(Error);
+	expect(errors[0].message).toBe("Query returned no rows");
+
+	subscription.unsubscribe();
+	await lix.close();
+});
+
+test("subscribeTakeFirstOrThrow should emit value when row exists", async () => {
+	const lix = await openLix({});
+	const values: any[] = [];
+	const errors: any[] = [];
+
+	// First insert a singleton row
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "singleton_test_key", value: "singleton_value" })
+		.execute();
+
+	// Then observe it
+	const subscription = lix
+		.observe(
+			lix.db
+				.selectFrom("key_value")
+				.selectAll()
+				.where("key", "=", "singleton_test_key")
+		)
+		.subscribeTakeFirstOrThrow({
+			next: (row) => values.push(row),
+			error: (err) => errors.push(err),
+		});
+
+	// Wait for initial emission
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should have received the row
+	expect(errors).toHaveLength(0);
+	expect(values).toHaveLength(1);
+	expect(values[0]).toMatchObject({
+		key: "singleton_test_key",
+		value: "singleton_value",
+	});
+
+	// Update the singleton value
+	await lix.db
+		.updateTable("key_value")
+		.set({ value: "updated_singleton" })
+		.where("key", "=", "singleton_test_key")
+		.execute();
+
+	// Wait for update
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should have received the updated row
+	expect(values).toHaveLength(2);
+	expect(values[1]).toMatchObject({
+		key: "singleton_test_key",
+		value: "updated_singleton",
+	});
+
+	subscription.unsubscribe();
+	await lix.close();
+});
+
+test("observe should re-execute queries on any state commit", async () => {
+	const lix = await openLix({});
+	const values: any[] = [];
+
+	// Observe only our test namespace
+	const subscription = lix
+		.observe(
+			lix.db.selectFrom("key_value").selectAll().where("key", "like", "multi_%")
+		)
+		.subscribe({ next: (rows) => values.push(rows) });
+
+	// Wait for initial emission
+	await new Promise(resolve => setTimeout(resolve, 10));
+	expect(values).toHaveLength(1);
+	expect(values[0]).toEqual([]);
+
+	// Make multiple changes
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "multi_key1", value: "value1" })
+		.execute();
+
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "multi_key2", value: "value2" })
+		.execute();
+
+	await lix.db
+		.updateTable("key_value")
+		.set({ value: "updated_value1" })
+		.where("key", "=", "multi_key1")
+		.execute();
+
+	// Wait for mutations to complete
+	await new Promise((resolve) => setTimeout(resolve, 50));
+
+	// Focus on final state rather than exact emission count
+	// (in case of future optimizations that batch commits)
+	expect(values.length).toBeGreaterThanOrEqual(4); // initial + 3 mutations
+
+	// Verify final state contains both keys with correct values
+	const finalResult = values[values.length - 1];
+	expect(finalResult).toHaveLength(2);
+	expect(
+		finalResult.find((row: any) => row.key === "multi_key1")
+	).toMatchObject({
+		key: "multi_key1",
+		value: "updated_value1",
+	});
+	expect(
+		finalResult.find((row: any) => row.key === "multi_key2")
+	).toMatchObject({
+		key: "multi_key2",
+		value: "value2",
+	});
+
+	subscription.unsubscribe();
+	await lix.close();
+});
+
+test("unsubscribe should stop receiving updates", async () => {
+	const lix = await openLix({});
+	const values: any[] = [];
+
+	const subscription = lix
+		.observe(
+			lix.db.selectFrom("key_value").selectAll().where("key", "like", "unsub_%")
+		)
+		.subscribe({ next: (rows) => values.push(rows) });
+
+	// Wait for initial emission
+	await new Promise(resolve => setTimeout(resolve, 10));
+	const countBeforeUnsubscribe = values.length;
+
+	// Unsubscribe
+	subscription.unsubscribe();
+
+	// Make changes after unsubscribe
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "unsub_after", value: "should_not_see" })
+		.execute();
+
+	// Small delay to ensure no updates are received
+	await new Promise((resolve) => setTimeout(resolve, 20));
+
+	// Should not have received any more updates
+	expect(values.length).toBe(countBeforeUnsubscribe);
+
+	await lix.close();
+});
+
+test("multiple subscriptions should work independently", async () => {
+	const lix = await openLix({});
+	const values1: any[] = [];
+	const values2: any[] = [];
+
+	// Two different queries with different filters
+	const sub1 = lix
+		.observe(
+			lix.db
+				.selectFrom("key_value")
+				.selectAll()
+				.where("key", "like", "scope1_%")
+		)
+		.subscribe({ next: (rows) => values1.push(rows) });
+
+	const sub2 = lix
+		.observe(
+			lix.db
+				.selectFrom("key_value")
+				.selectAll()
+				.where("key", "like", "scope2_%")
+		)
+		.subscribe({ next: (rows) => values2.push(rows) });
+
+	// Wait for initial emissions
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Insert keys for different scopes
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "scope1_key", value: "scope1_value" })
+		.execute();
+
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "scope2_key", value: "scope2_value" })
+		.execute();
+
+	// Wait for updates from both insertions
+	await new Promise((resolve) => setTimeout(resolve, 50));
+
+	// First subscription should only see scope1 keys
+	const lastResult1 = values1[values1.length - 1];
+	expect(lastResult1).toHaveLength(1);
+	expect(lastResult1[0]).toMatchObject({
+		key: "scope1_key",
+		value: "scope1_value",
+	});
+
+	// Second subscription should only see scope2 keys
+	const lastResult2 = values2[values2.length - 1];
+	expect(lastResult2).toHaveLength(1);
+	expect(lastResult2[0]).toMatchObject({
+		key: "scope2_key",
+		value: "scope2_value",
+	});
+
+	sub1.unsubscribe();
+	sub2.unsubscribe();
+	await lix.close();
+});
+
+test("query errors should be delivered to error handler", async () => {
+	const lix = await openLix({});
+	const errors: any[] = [];
+	const values: any[] = [];
+
+	// Create an invalid query (selecting from non-existent table)
+	const subscription = lix
+		.observe(lix.db.selectFrom("non_existent_table" as any).selectAll())
+		.subscribe({
+			next: (rows) => values.push(rows),
+			error: (err) => errors.push(err),
+		});
+
+	// Wait for error
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should have received an error
+	expect(values).toHaveLength(0);
+	expect(errors).toHaveLength(1);
+	expect(errors[0]).toBeInstanceOf(Error);
+
+	// Subscription should be terminated after error
+	// (no cleanup needed, but calling unsubscribe should be safe)
+	subscription.unsubscribe();
+	await lix.close();
+});
+
+test("Symbol.observable interop should work", async () => {
+	const lix = await openLix({});
+
+	const observable = lix.observe(
+		lix.db.selectFrom("key_value").selectAll().where("key", "like", "interop_%")
+	);
+
+	// Should implement Symbol.observable
+	expect(observable[Symbol.observable]).toBeDefined();
+	expect(observable[Symbol.observable]()).toBe(observable);
+
+	await lix.close();
+});
+
+test("observing specific key should not emit when unrelated key is inserted", async () => {
+	const lix = await openLix({});
+	const valuesA: any[] = [];
+	const valuesB: any[] = [];
+
+	// Observe only key A
+	const subscriptionA = lix
+		.observe(
+			lix.db.selectFrom("key_value").selectAll().where("key", "=", "key_A")
+		)
+		.subscribe({ next: (rows) => valuesA.push(rows) });
+
+	// Observe only key B
+	const subscriptionB = lix
+		.observe(
+			lix.db.selectFrom("key_value").selectAll().where("key", "=", "key_B")
+		)
+		.subscribe({ next: (rows) => valuesB.push(rows) });
+
+	// Wait for initial emissions
+	await new Promise((resolve) => setTimeout(resolve, 10));
+	expect(valuesA).toHaveLength(1);
+	expect(valuesA[0]).toEqual([]); // No key_A yet
+	expect(valuesB).toHaveLength(1);
+	expect(valuesB[0]).toEqual([]); // No key_B yet
+
+	// Insert key A
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "key_A", value: "value_A" })
+		.execute();
+
+	// Wait for update
+	await new Promise((resolve) => setTimeout(resolve, 10));
+
+	// Key A observer should get an update
+	expect(valuesA).toHaveLength(2);
+	expect(valuesA[1]).toHaveLength(1);
+	expect(valuesA[1][0]).toMatchObject({ key: "key_A", value: "value_A" });
+
+	// Key B observer should NOT get an update (only key A was inserted)
+	expect(valuesB).toHaveLength(1); // Still only initial emission
+
+	const countABeforeKeyB = valuesA.length;
+	const countBBeforeKeyB = valuesB.length;
+
+	// Insert key B
+	await lix.db
+		.insertInto("key_value")
+		.values({ key: "key_B", value: "value_B" })
+		.execute();
+
+	// Wait to see if we get emissions
+	await new Promise((resolve) => setTimeout(resolve, 10));
+
+	// Key A observer should NOT get an update (only key B was inserted)
+	expect(valuesA).toHaveLength(countABeforeKeyB); // No new emission
+
+	// Key B observer should get an update
+	expect(valuesB).toHaveLength(countBBeforeKeyB + 1);
+	expect(valuesB[valuesB.length - 1]).toHaveLength(1);
+	expect(valuesB[valuesB.length - 1][0]).toMatchObject({
+		key: "key_B",
+		value: "value_B",
+	});
+
+	subscriptionA.unsubscribe();
+	subscriptionB.unsubscribe();
+	await lix.close();
+});
+
+test("subscribeTakeFirst with explicit limit(1) should not double-limit", async () => {
+	const lix = await openLix({});
+	const values: any[] = [];
+
+	// Insert multiple test keys
+	await lix.db
+		.insertInto("key_value")
+		.values([
+			{ key: "limit_test_1", value: "value_1" },
+			{ key: "limit_test_2", value: "value_2" },
+			{ key: "limit_test_3", value: "value_3" },
+		])
+		.execute();
+
+	// User already provides limit(1) in their query
+	const subscription = lix
+		.observe(
+			lix.db
+				.selectFrom("key_value")
+				.selectAll()
+				.where("key", "like", "limit_test_%")
+				.orderBy("key", "asc")
+				.limit(1)
+		)
+		.subscribeTakeFirst({ next: (row) => values.push(row) });
+
+	// Wait for initial emission
+	await new Promise(resolve => setTimeout(resolve, 10));
+
+	// Should work correctly even with double limit
+	expect(values).toHaveLength(1);
+	expect(values[0]).toMatchObject({
+		key: "limit_test_1",
+		value: "value_1",
+	});
+
+	subscription.unsubscribe();
+	await lix.close();
+});

--- a/packages/lix-sdk/src/observe/create-observe.ts
+++ b/packages/lix-sdk/src/observe/create-observe.ts
@@ -1,0 +1,145 @@
+import type { SelectQueryBuilder } from "kysely";
+import type { Lix } from "../lix/open-lix.js";
+import { LixObservable } from "./lix-observable.js";
+
+/**
+ * Options for the observe method.
+ */
+export interface ObserveOptions {
+	mode?: "array" | "first" | "firstOrThrow";
+}
+
+/**
+ * Map to track active observables and their cleanup functions.
+ */
+interface ActiveObservable {
+	unsubscribeFromStateCommit: () => void;
+}
+
+/**
+ * Deep equality check for query results.
+ * Compares arrays element by element using JSON.stringify for simplicity.
+ */
+function areResultsEqual<T>(a: T[], b: T[]): boolean {
+	if (a.length !== b.length) return false;
+	
+	// Simple deep equality using JSON.stringify
+	// This works well for database results which are typically JSON-serializable
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Creates the observe function for a Lix instance.
+ *
+ * @param lix - The Lix instance to add observables to
+ * @returns The observe function
+ */
+export function createObserve(lix: Pick<Lix, "hooks">) {
+	const activeObservables = new WeakMap<LixObservable<any>, ActiveObservable>();
+
+	/**
+	 * Converts a **Kysely read-query** into a **LixObservable** – an implementation of
+	 * the TC-39 Observable protocol that emits a fresh result-set every time the
+	 * underlying state mutates.
+	 *
+	 * @example **Full table stream**
+	 * ```ts
+	 * observe(
+	 *   lix.db.selectFrom('key_value').selectAll()
+	 * ).subscribe({
+	 *   next: rows => console.table(rows)
+	 * })
+	 * ```
+	 *
+	 * @example **Watch latest change-set (first row)**
+	 * ```ts
+	 * observe(
+	 *   lix.db.selectFrom('change_set_all')
+	 *         .selectAll()
+	 *         .orderBy('created_at desc')
+	 * ).subscribeTakeFirst({
+	 *   next: cs => console.log('head →', cs)
+	 * })
+	 * ```
+	 */
+	return function observe<T>(
+		query: SelectQueryBuilder<any, any, T>,
+		options: ObserveOptions = { mode: "array" }
+	): LixObservable<T> {
+		// Create the observable
+		const observable = new LixObservable<T>((observer) => {
+			let isActive = true;
+			let previousResult: T[] | undefined;
+
+			// Helper to execute the query
+			const executeQuery = async () => {
+				if (!isActive) return;
+
+				try {
+					// Optimize query for first/firstOrThrow modes
+					let optimizedQuery = query;
+					if (options.mode === "first" || options.mode === "firstOrThrow") {
+						// Add limit(1) if we only need the first row
+						optimizedQuery = query.limit(1) as any;
+					}
+
+					// Execute the query
+					const result = await optimizedQuery.execute();
+
+					if (!isActive) return;
+
+					// Check if results have changed
+					const hasChanged = !previousResult || !areResultsEqual(previousResult, result as T[]);
+
+					if (hasChanged) {
+						previousResult = result as T[];
+						
+						// Handle different modes
+						if (options.mode === "first") {
+							observer.next?.(result as T[]);
+						} else if (options.mode === "firstOrThrow") {
+							observer.next?.(result as T[]);
+						} else {
+							// Default: array mode
+							observer.next?.(result as T[]);
+						}
+					}
+				} catch (error) {
+					if (!isActive) return;
+					observer.error?.(error);
+				}
+			};
+
+			// Execute initial query
+			executeQuery();
+
+			// Subscribe to state commits for updates
+			const unsubscribeFromStateCommit = lix.hooks.onStateCommit(() => {
+				executeQuery();
+			});
+
+			// Store the cleanup function
+			activeObservables.set(observable, { unsubscribeFromStateCommit });
+
+			// Return cleanup function
+			return () => {
+				isActive = false;
+				unsubscribeFromStateCommit();
+				activeObservables.delete(observable);
+			};
+		});
+
+		// Handle mode-specific behavior by returning wrapped observables
+		if (options.mode === "first") {
+			// For compatibility, we still return the base observable
+			// The subscribeTakeFirst method handles the transformation
+			return observable;
+		} else if (options.mode === "firstOrThrow") {
+			// For compatibility, we still return the base observable
+			// The subscribeTakeFirstOrThrow method handles the transformation
+			return observable;
+		}
+
+		return observable;
+	};
+}

--- a/packages/lix-sdk/src/observe/implementation.md
+++ b/packages/lix-sdk/src/observe/implementation.md
@@ -1,0 +1,89 @@
+# Lix **Live-Query API** — Specification v1
+
+_(Wrapper name: \*\*`LixObservable`_)\*  
+**Status:** Pilot · 2025-06-29
+
+Turns any Kysely **read** query into a push-stream that updates after every
+relevant commit.  
+The stream object implements the **TC-39 Observable** protocol and adds two
+Kysely-style convenience helpers.
+
+---
+
+## 1 Design Principles
+
+| #   | Principle                               | Rationale                                     |
+| --- | --------------------------------------- | --------------------------------------------- |
+| P-1 | **Leave the Kysely builder untouched**  | avoid name collisions with upstream           |
+| P-2 | **Single freeze point** (`lix.observe`) | clear mental model: build ⇢ freeze ⇢ stream   |
+| P-3 | **Transport = TC-39 Observable**        | works in React, Solid, RxJS, Signals, Workers |
+| P-4 | **Ergonomic parity with `execute*`**    | expose `subscribe*` helpers mirroring Kysely  |
+
+---
+
+## 2 Public API
+
+### 2.1 `lix.observe(query[, options])`
+
+| param     | type                                              | default            | description                               |
+| --------- | ------------------------------------------------- | ------------------ | ----------------------------------------- |
+| `query`   | `SelectQueryBuilder<any, T>`                      | —                  | any Kysely read query                     |
+| `options` | `{ mode?: "array" \| "first" \| "firstOrThrow" }` | `{ mode:"array" }` | rarely needed; helpers cover common cases |
+
+Returns **`LixObservable<T>`**.
+
+---
+
+### 2.2 `LixObservable<T>` interface
+
+```ts
+interface LixObservable<T> extends Observable<T[]> {
+	subscribe(observer: Partial<Observer<T[]>>): Subscription;
+
+	subscribeTakeFirst(observer: Partial<Observer<T | undefined>>): Subscription; // first row or undefined
+
+	subscribeTakeFirstOrThrow(observer: Partial<Observer<T>>): Subscription; // first row or -> error
+
+	[Symbol.observable](): LixObservable<T>; // TC-39 hook
+}
+```
+
+---
+
+```ts
+// 3.1  Full result-set stream
+lix
+	.observe(lix.db.selectFrom("key_value").selectAll())
+	.subscribe({ next: (rows) => console.table(rows) });
+
+// 3.2  Track latest change-set (row ∥ undefined)
+lix
+	.observe(
+		lix.db.selectFrom("change_set_all").selectAll().orderBy("created_at desc")
+	)
+	.subscribeTakeFirst({ next: (cs) => console.log("head →", cs) });
+
+// 3.3  Strict singleton (error when empty)
+lix
+	.observe(lix.db.selectFrom("settings").where("id", "=", 1).selectAll())
+	.subscribeTakeFirstOrThrow({
+		next: (row) => render(row),
+		error: (err) => alert(err.message),
+	});
+
+// 3.4  RxJS interop
+import { from, debounceTime } from "rxjs";
+from(lix.observe(qb)).pipe(debounceTime(50)).subscribe(console.log);
+```
+
+### 4. behavior
+
+| Event                  | Observable behaviour                                                                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Subscribe**          | Returns immediately; runs the query asynchronously.                                                                                       |
+| **Initial snapshot**   | Exactly **one** `next(value)` after the first select resolves (even if empty).                                                            |
+| **Subsequent commits** | Each relevant `state_commit` triggers one re-select → one `next(updated)`, preserving commit order.                                       |
+| **Errors**             | If the select fails **at any time**, an `error(err)` is emitted and the stream terminates.                                                |
+| **Completion**         | Stream **never** completes on its own. `complete()` is sent only when the DB is closed or the subscriber calls `unsubscribe()`.           |
+| **Unsubscribe**        | Stops future `next/error/complete` deliveries; detaches `state_commit` listener. An in-flight SQL may finish but its result is discarded. |
+| **Back-pressure**      | Not implemented in v1 (always eager). Users may wrap the Observable in RxJS operators (`debounceTime`, `throttleTime`, …).                |

--- a/packages/lix-sdk/src/observe/lix-observable.test.ts
+++ b/packages/lix-sdk/src/observe/lix-observable.test.ts
@@ -1,0 +1,244 @@
+import { test, expect, vi } from "vitest";
+import { LixObservable } from "./lix-observable.js";
+
+test("should deliver values to observer", () => {
+	const values: number[][] = [];
+	const observable = new LixObservable<number>((observer) => {
+		observer.next?.([1, 2, 3]);
+		observer.next?.([4, 5, 6]);
+	});
+
+	observable.subscribe({
+		next: (value) => values.push(value),
+	});
+
+	expect(values).toEqual([[1, 2, 3], [4, 5, 6]]);
+});
+
+test("should call error handler", () => {
+	const error = new Error("Test error");
+	const errorHandler = vi.fn();
+	
+	const observable = new LixObservable<number>((observer) => {
+		observer.error?.(error);
+	});
+
+	observable.subscribe({
+		error: errorHandler,
+	});
+
+	expect(errorHandler).toHaveBeenCalledWith(error);
+});
+
+test("should call complete handler", () => {
+	const completeHandler = vi.fn();
+	
+	const observable = new LixObservable<number>((observer) => {
+		observer.complete?.();
+	});
+
+	observable.subscribe({
+		complete: completeHandler,
+	});
+
+	expect(completeHandler).toHaveBeenCalled();
+});
+
+test("should stop delivering values after unsubscribe", () => {
+	const values: number[][] = [];
+	let observerRef: any;
+	
+	const observable = new LixObservable<number>((observer) => {
+		observerRef = observer;
+		observer.next?.([1]);
+		return () => {
+			// cleanup
+		};
+	});
+
+	const subscription = observable.subscribe({
+		next: (value) => values.push(value),
+	});
+
+	expect(values).toEqual([[1]]);
+	
+	subscription.unsubscribe();
+	observerRef.next?.([2]); // Should not be delivered
+	
+	expect(values).toEqual([[1]]);
+});
+
+test("should not deliver values after error", () => {
+	const values: number[][] = [];
+	const errors: any[] = [];
+	let observerRef: any;
+	
+	const observable = new LixObservable<number>((observer) => {
+		observerRef = observer;
+	});
+
+	observable.subscribe({
+		next: (value) => values.push(value),
+		error: (err) => errors.push(err),
+	});
+
+	observerRef.next?.([1]);
+	observerRef.error?.(new Error("Test"));
+	observerRef.next?.([2]); // Should not be delivered
+	
+	expect(values).toEqual([[1]]);
+	expect(errors).toHaveLength(1);
+});
+
+test("should not deliver values after complete", () => {
+	const values: number[][] = [];
+	let observerRef: any;
+	
+	const observable = new LixObservable<number>((observer) => {
+		observerRef = observer;
+	});
+
+	observable.subscribe({
+		next: (value) => values.push(value),
+	});
+
+	observerRef.next?.([1]);
+	observerRef.complete?.();
+	observerRef.next?.([2]); // Should not be delivered
+	
+	expect(values).toEqual([[1]]);
+});
+
+test("should call cleanup function on unsubscribe", () => {
+	const cleanup = vi.fn();
+	
+	const observable = new LixObservable<number>(() => {
+		return cleanup;
+	});
+
+	const subscription = observable.subscribe({});
+	expect(cleanup).not.toHaveBeenCalled();
+	
+	subscription.unsubscribe();
+	expect(cleanup).toHaveBeenCalledOnce();
+});
+
+test("should not call cleanup multiple times", () => {
+	const cleanup = vi.fn();
+	
+	const observable = new LixObservable<number>(() => {
+		return cleanup;
+	});
+
+	const subscription = observable.subscribe({});
+	subscription.unsubscribe();
+	subscription.unsubscribe(); // Second call
+	
+	expect(cleanup).toHaveBeenCalledOnce();
+});
+
+test("should implement Symbol.observable", () => {
+	const observable = new LixObservable<number>(() => {});
+	expect(observable[Symbol.observable]()).toBe(observable);
+});
+
+test("subscribeTakeFirst should return first element", () => {
+	const values: (number | undefined)[] = [];
+	
+	const observable = new LixObservable<number>((observer) => {
+		observer.next?.([1, 2, 3]);
+		observer.next?.([4, 5, 6]);
+	});
+
+	observable.subscribeTakeFirst({
+		next: (value) => values.push(value),
+	});
+
+	expect(values).toEqual([1, 4]);
+});
+
+test("subscribeTakeFirst should return undefined for empty array", () => {
+	const values: (number | undefined)[] = [];
+	
+	const observable = new LixObservable<number>((observer) => {
+		observer.next?.([]);
+	});
+
+	observable.subscribeTakeFirst({
+		next: (value) => values.push(value),
+	});
+
+	expect(values).toEqual([undefined]);
+});
+
+test("subscribeTakeFirstOrThrow should return first element", () => {
+	const values: number[] = [];
+	
+	const observable = new LixObservable<number>((observer) => {
+		observer.next?.([1, 2, 3]);
+	});
+
+	observable.subscribeTakeFirstOrThrow({
+		next: (value) => values.push(value),
+	});
+
+	expect(values).toEqual([1]);
+});
+
+test("subscribeTakeFirstOrThrow should error on empty array", () => {
+	const errors: any[] = [];
+	
+	const observable = new LixObservable<number>((observer) => {
+		observer.next?.([]);
+	});
+
+	observable.subscribeTakeFirstOrThrow({
+		error: (err) => errors.push(err),
+	});
+
+	expect(errors).toHaveLength(1);
+	expect(errors[0]).toBeInstanceOf(Error);
+	expect(errors[0].message).toBe("Query returned no rows");
+});
+
+test("subscribeTakeFirstOrThrow should pass through original errors", () => {
+	const originalError = new Error("Original error");
+	const errors: any[] = [];
+	
+	const observable = new LixObservable<number>((observer) => {
+		observer.error?.(originalError);
+	});
+
+	observable.subscribeTakeFirstOrThrow({
+		error: (err) => errors.push(err),
+	});
+
+	expect(errors).toEqual([originalError]);
+});
+
+test("should handle observer without handlers gracefully", () => {
+	const observable = new LixObservable<number>((observer) => {
+		observer.next?.([1]);
+		observer.error?.(new Error("Test"));
+		observer.complete?.();
+	});
+
+	// Should not throw
+	expect(() => {
+		observable.subscribe({});
+	}).not.toThrow();
+});
+
+test("should support RxJS interop pattern", () => {
+	const observable = new LixObservable<number>(() => {});
+	
+	// Simulate RxJS from() behavior
+	const rxjsCompatible = observable[Symbol.observable]();
+	expect(rxjsCompatible).toBe(observable);
+	
+	// Should be able to subscribe to the returned value
+	const values: number[][] = [];
+	rxjsCompatible.subscribe({
+		next: (value) => values.push(value),
+	});
+});

--- a/packages/lix-sdk/src/observe/lix-observable.ts
+++ b/packages/lix-sdk/src/observe/lix-observable.ts
@@ -1,0 +1,90 @@
+/**
+ * Micro-observable implementation following TC-39 Observable protocol.
+ * ~25 lines of code for minimal footprint while maintaining spec compliance.
+ */
+
+// Polyfill Symbol.observable if not present
+declare global {
+	interface SymbolConstructor {
+		readonly observable: symbol;
+	}
+}
+
+if (typeof Symbol.observable === "undefined") {
+	(Symbol as any).observable = Symbol("observable");
+}
+
+export interface Observer<T> {
+	next?: (value: T) => void;
+	error?: (error: any) => void;
+	complete?: () => void;
+}
+
+export interface Subscription {
+	unsubscribe(): void;
+}
+
+export interface Observable<T> {
+	subscribe(observer: Partial<Observer<T>>): Subscription;
+	[Symbol.observable](): Observable<T>;
+}
+
+export class LixObservable<T> implements Observable<T[]> {
+	constructor(private subscriber: (observer: Observer<T[]>) => (() => void) | void) {}
+
+	subscribe(observer: Partial<Observer<T[]>>): Subscription {
+		let closed = false;
+		const safeObserver: Observer<T[]> = {
+			next: (value) => !closed && observer.next?.(value),
+			error: (err) => {
+				if (!closed) {
+					closed = true;
+					observer.error?.(err);
+				}
+			},
+			complete: () => {
+				if (!closed) {
+					closed = true;
+					observer.complete?.();
+				}
+			},
+		};
+
+		const cleanup = this.subscriber(safeObserver);
+		
+		return {
+			unsubscribe() {
+				if (!closed) {
+					closed = true;
+					cleanup?.();
+				}
+			},
+		};
+	}
+
+	[Symbol.observable](): LixObservable<T> {
+		return this;
+	}
+
+	subscribeTakeFirst(observer: Partial<Observer<T | undefined>>): Subscription {
+		return this.subscribe({
+			next: (rows) => observer.next?.(rows[0]),
+			error: observer.error,
+			complete: observer.complete,
+		});
+	}
+
+	subscribeTakeFirstOrThrow(observer: Partial<Observer<T>>): Subscription {
+		return this.subscribe({
+			next: (rows) => {
+				if (rows.length === 0) {
+					observer.error?.(new Error("Query returned no rows"));
+				} else {
+					observer.next?.(rows[0]!);
+				}
+			},
+			error: observer.error,
+			complete: observer.complete,
+		});
+	}
+}


### PR DESCRIPTION
# Lix **Live-Query API** — Specification v1

_(Wrapper name: \*\*`LixObservable`_)\*  
**Status:** Pilot · 2025-06-29

Turns any Kysely **read** query into a push-stream that updates after every
relevant commit.  
The stream object implements the **TC-39 Observable** protocol and adds two
Kysely-style convenience helpers.

---

## 1 Design Principles

| #   | Principle                               | Rationale                                     |
| --- | --------------------------------------- | --------------------------------------------- |
| P-1 | **Leave the Kysely builder untouched**  | avoid name collisions with upstream           |
| P-2 | **Single freeze point** (`lix.observe`) | clear mental model: build ⇢ freeze ⇢ stream   |
| P-3 | **Transport = TC-39 Observable**        | works in React, Solid, RxJS, Signals, Workers |
| P-4 | **Ergonomic parity with `execute*`**    | expose `subscribe*` helpers mirroring Kysely  |

---

## 2 Public API

### 2.1 `lix.observe(query[, options])`

| param     | type                                              | default            | description                               |
| --------- | ------------------------------------------------- | ------------------ | ----------------------------------------- |
| `query`   | `SelectQueryBuilder<any, T>`                      | —                  | any Kysely read query                     |
| `options` | `{ mode?: "array" \| "first" \| "firstOrThrow" }` | `{ mode:"array" }` | rarely needed; helpers cover common cases |

Returns **`LixObservable<T>`**.

---

### 2.2 `LixObservable<T>` interface

```ts
interface LixObservable<T> extends Observable<T[]> {
	subscribe(observer: Partial<Observer<T[]>>): Subscription;

	subscribeTakeFirst(observer: Partial<Observer<T | undefined>>): Subscription; // first row or undefined

	subscribeTakeFirstOrThrow(observer: Partial<Observer<T>>): Subscription; // first row or -> error

	[Symbol.observable](): LixObservable<T>; // TC-39 hook
}
```

---

```ts
// 3.1  Full result-set stream
lix
	.observe(lix.db.selectFrom("key_value").selectAll())
	.subscribe({ next: (rows) => console.table(rows) });

// 3.2  Track latest change-set (row ∥ undefined)
lix
	.observe(
		lix.db.selectFrom("change_set_all").selectAll().orderBy("created_at desc")
	)
	.subscribeTakeFirst({ next: (cs) => console.log("head →", cs) });

// 3.3  Strict singleton (error when empty)
lix
	.observe(lix.db.selectFrom("settings").where("id", "=", 1).selectAll())
	.subscribeTakeFirstOrThrow({
		next: (row) => render(row),
		error: (err) => alert(err.message),
	});

// 3.4  RxJS interop
import { from, debounceTime } from "rxjs";
from(lix.observe(qb)).pipe(debounceTime(50)).subscribe(console.log);
```

### 4. behavior

| Event                  | Observable behaviour                                                                                                                      |
| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
| **Subscribe**          | Returns immediately; runs the query asynchronously.                                                                                       |
| **Initial snapshot**   | Exactly **one** `next(value)` after the first select resolves (even if empty).                                                            |
| **Subsequent commits** | Each relevant `state_commit` triggers one re-select → one `next(updated)`, preserving commit order.                                       |
| **Errors**             | If the select fails **at any time**, an `error(err)` is emitted and the stream terminates.                                                |
| **Completion**         | Stream **never** completes on its own. `complete()` is sent only when the DB is closed or the subscriber calls `unsubscribe()`.           |
| **Unsubscribe**        | Stops future `next/error/complete` deliveries; detaches `state_commit` listener. An in-flight SQL may finish but its result is discarded. |
| **Back-pressure**      | Not implemented in v1 (always eager). Users may wrap the Observable in RxJS operators (`debounceTime`, `throttleTime`, …).                |
