### PR TITLE
fix: Add refresh handling for useQuery when switching lix instances

### DIFF
--- a/packages/lix/lix-react-utils/src/hooks/use-query.ts
+++ b/packages/lix/lix-react-utils/src/hooks/use-query.ts
@@ -111,7 +111,7 @@ export function useQuery<TRow>(
 			},
 		});
 		return () => sub.unsubscribe();
-	}, [cacheKey, subscribe, initialRows]); // Re-subscribe when query changes
+	}, [cacheKey, subscribe, initialRows, lix]); // Re-subscribe when query changes
 
 	return rows;
 }


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/337

Implement refresh logic in the `useQuery` hook to ensure data updates correctly when switching between different lix instances. Add a test to verify that the query refreshes appropriately upon instance change.