### PR TITLE
enable change author tracking

### DIFF
--- a/packages/lix-docs/docs/guide/architecture.md
+++ b/packages/lix-docs/docs/guide/architecture.md
@@ -132,3 +132,20 @@ In the global change set graph above:
 - All versions can see and reference any change set
 - Version "main" can query the history of Version "feature-x" by traversing from CS6
 - Historical queries can point to any change set, even those not currently pointed to by a version (like CS4)
+
+
+## Foreign Keys
+
+Lix supports foreign key constraints to maintain referential integrity between entities. 
+
+For simplicity, Lix only allows foreign keys on entities in the same version scope, with the exception of references to changes themselves. This design choice avoids global cascading effects and acknowledges that changes are versionless - they exist outside the version system as the immutable source of truth.
+
+
+
+| Rule                                                  | Rationale                                                                        | Engine behaviour                                                                   |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **1. Version‑scoped → change**                        | Changes live outside any version, so the reference is valid across all versions. | Validator skips the `version_id = ?` check when the target schema is `lix_change`. |
+| **2. Version‑scoped → version‑scoped (same version)** | Keeps each version self‑contained and makes deletes cheap.                       | Current logic stands: both rows must share the same `version_id`.                  |
+| **3. Change → version‑scoped**                  | Would immediately violate Rule 2.                                                | Disallowed at schema‑registration time.                                            |
+
+> **Result:** An example\_entity, comment or change‑set element lives inside a specific version, but can freely point at any `lix_change.id` without special handling.

--- a/packages/lix-sdk/src/account/schema.test.ts
+++ b/packages/lix-sdk/src/account/schema.test.ts
@@ -22,6 +22,7 @@ test("insert, update, delete on the account view", async () => {
 	const viewAfterInsert = await lix.db
 		.selectFrom("account")
 		.select(["id", "name"])
+		.where("id", "in", ["account0", "account1"])
 		.orderBy("id")
 		.execute();
 
@@ -47,6 +48,7 @@ test("insert, update, delete on the account view", async () => {
 	const viewAfterUpdate = await lix.db
 		.selectFrom("account")
 		.orderBy("id")
+		.where("id", "in", ["account0", "account1"])
 		.select(["id", "name"])
 		.execute();
 
@@ -66,6 +68,7 @@ test("insert, update, delete on the account view", async () => {
 	const viewAfterDelete = await lix.db
 		.selectFrom("account")
 		.orderBy("id")
+		.where("id", "in", ["account0", "account1"])
 		.select(["id", "name"])
 		.execute();
 
@@ -134,12 +137,14 @@ test("account operations are version specific and isolated", async () => {
 	const accountsInVersionA = await lix.db
 		.selectFrom("account_all")
 		.where("lixcol_version_id", "=", versionA.id)
+		.where("id", "in", ["accountA", "accountB"])
 		.selectAll()
 		.execute();
 
 	const accountsInVersionB = await lix.db
 		.selectFrom("account_all")
 		.where("lixcol_version_id", "=", versionB.id)
+		.where("id", "in", ["accountA", "accountB"])
 		.selectAll()
 		.execute();
 
@@ -184,12 +189,14 @@ test("account operations are version specific and isolated", async () => {
 	// Verify deletion only affected version A
 	const remainingAccountsA = await lix.db
 		.selectFrom("account_all")
+		.where("id", "in", ["accountA", "accountB"])
 		.where("lixcol_version_id", "=", versionA.id)
 		.selectAll()
 		.execute();
 
 	const remainingAccountsB = await lix.db
 		.selectFrom("account_all")
+		.where("id", "in", ["accountA", "accountB"])
 		.where("lixcol_version_id", "=", versionB.id)
 		.selectAll()
 		.execute();

--- a/packages/lix-sdk/src/account/schema.ts
+++ b/packages/lix-sdk/src/account/schema.ts
@@ -1,4 +1,3 @@
-import type { Selectable } from "kysely";
 import type {
 	LixSchemaDefinition,
 	FromLixSchemaDefinition,
@@ -21,16 +20,67 @@ export function applyAccountDatabaseSchema(sqlite: SqliteWasmDatabase): void {
 		},
 	});
 
-	// Create session-specific temp table
+	// Create active_account as an entity view (similar to active_version)
+	// entity_id is the account id to support multiple active accounts
 	sqlite.exec(`
-		-- current account(s)
-		-- temp table because current accounts are session
-		-- specific and should not be persisted
-		CREATE TEMP TABLE IF NOT EXISTS active_account (
-			id TEXT PRIMARY KEY,
-			name TEXT NOT NULL
-			-- can't use foreign keys in temp tables... :(
-		) STRICT;
+		CREATE VIEW IF NOT EXISTS active_account AS
+		SELECT
+			entity_id AS id,
+			json_extract(snapshot_content, '$.name') AS name,
+			inherited_from_version_id AS lixcol_inherited_from_version_id,
+			created_at AS lixcol_created_at,
+			updated_at AS lixcol_updated_at,
+			file_id AS lixcol_file_id,
+			change_id AS lixcol_change_id,
+			untracked AS lixcol_untracked
+		FROM state_all
+		WHERE schema_key = 'lix_active_account' AND version_id = 'global';
+
+		CREATE TRIGGER IF NOT EXISTS active_account_insert
+		INSTEAD OF INSERT ON active_account
+		BEGIN
+			INSERT OR REPLACE INTO state_all (
+				entity_id,
+				schema_key,
+				file_id,
+				plugin_key,
+				snapshot_content,
+				schema_version,
+				version_id,
+				untracked
+			) VALUES (
+				NEW.id,
+				'lix_active_account',
+				'lix',
+				'lix_own_entity',
+				json_object('name', NEW.name),
+				'1.0',
+				'global',
+				1
+			);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS active_account_update
+		INSTEAD OF UPDATE ON active_account
+		BEGIN
+			UPDATE state_all
+			SET
+				snapshot_content = json_object('name', NEW.name),
+				untracked = 1
+			WHERE
+				entity_id = OLD.id
+				AND schema_key = 'lix_active_account'
+				AND version_id = 'global';
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS active_account_delete
+		INSTEAD OF DELETE ON active_account
+		BEGIN
+			DELETE FROM state_all
+			WHERE entity_id = OLD.id
+			AND schema_key = 'lix_active_account'
+			AND version_id = 'global';
+		END;
 	`);
 
 	const anonymousAccountName = `Anonymous ${humanId({
@@ -43,10 +93,16 @@ export function applyAccountDatabaseSchema(sqlite: SqliteWasmDatabase): void {
 		// Human ID uses plural, remove the last character to make it singular
 		.slice(0, -1)}`;
 
-	// Insert default account
+	// Insert default active account only if none exists
 	sqlite.exec(`
 		-- default to a new account
-		INSERT INTO active_account (id, name) values (nano_id(), '${anonymousAccountName}');
+		INSERT INTO active_account (id, name)
+		SELECT nano_id(), '${anonymousAccountName}'
+		WHERE NOT EXISTS (
+			SELECT 1 FROM state_all
+			WHERE schema_key = 'lix_active_account'
+			AND version_id = 'global'
+		);
 	`);
 }
 
@@ -67,10 +123,5 @@ LixAccountSchema satisfies LixSchemaDefinition;
 // Pure business logic type (inferred from schema)
 export type Account = FromLixSchemaDefinition<typeof LixAccountSchema>;
 
-// Active account table type (temp table)
-export type ActiveAccountTable = {
-	id: string;
-	name: string;
-};
-
-export type ActiveAccount = Selectable<ActiveAccountTable>;
+// Active account type using State
+export type ActiveAccount = Account;

--- a/packages/lix-sdk/src/change-author/schema.test.ts
+++ b/packages/lix-sdk/src/change-author/schema.test.ts
@@ -1,224 +1,196 @@
-import { describe, expect, test } from "vitest";
+import { expect, test } from "vitest";
 import { openLix } from "../lix/open-lix.js";
 import { createAccount } from "../account/create-account.js";
 
-describe("change_author", () => {
-	test("insert, update, delete on the change_author view", async () => {
-		const lix = await openLix({});
+test("insert, update, delete on the change_author view", async () => {
+	const lix = await openLix({});
 
-		// Create account
-		const account = await createAccount({
-			lix,
-			name: "Test Author",
-		});
+	// Create account
+	const account = await createAccount({
+		lix,
+		name: "Test Author",
+	});
 
-		// Create change
-		await lix.db
-			.insertInto("change")
-			.values({
-				id: "c0",
-				entity_id: "e0",
-				schema_key: "mock_schema",
-				schema_version: "1",
-				file_id: "f0",
-				plugin_key: "test_plugin",
-				snapshot_content: { id: "e0" },
-			})
-			.execute();
+	// Create change
+	await lix.db
+		.insertInto("change")
+		.values({
+			id: "c0",
+			entity_id: "e0",
+			schema_key: "mock_schema",
+			schema_version: "1",
+			file_id: "f0",
+			plugin_key: "test_plugin",
+			snapshot_content: { id: "e0" },
+		})
+		.execute();
 
-		await lix.db
-			.insertInto("change_author")
-			.values([
-				{
-					change_id: "c0",
-					account_id: account.id,
-				},
-			])
-			.execute();
-
-		const viewAfterInsert = await lix.db
-			.selectFrom("change_author")
-			.orderBy("change_id", "asc")
-			.selectAll()
-			.execute();
-
-		expect(viewAfterInsert).toMatchObject([
+	await lix.db
+		.insertInto("change_author")
+		.values([
 			{
 				change_id: "c0",
 				account_id: account.id,
 			},
-		]);
+		])
+		.execute();
 
-		await lix.db
-			.deleteFrom("change_author")
-			.where("change_id", "=", "c0")
-			.execute();
+	const viewAfterInsert = await lix.db
+		.selectFrom("change_author")
+		.orderBy("change_id", "asc")
+		.where("change_id", "=", "c0")
+		.selectAll()
+		.execute();
 
-		const viewAfterDelete = await lix.db
-			.selectFrom("change_author")
-			.orderBy("change_id", "asc")
-			.selectAll()
-			.execute();
+	expect(viewAfterInsert).toMatchObject([
+		{
+			change_id: "c0",
+			account_id: account.id,
+		},
+	]);
 
-		expect(viewAfterDelete).toEqual([]);
+	await lix.db
+		.deleteFrom("change_author")
+		.where("change_id", "=", "c0")
+		.execute();
 
-		// After delete, there should be no state records for the change_author
-		const allStates = await lix.db
-			.selectFrom("state_all")
-			.where("schema_key", "=", "lix_change_author")
-			.selectAll()
-			.execute();
+	const viewAfterDelete = await lix.db
+		.selectFrom("change_author")
+		.orderBy("change_id", "asc")
+		.where("change_id", "=", "c0")
+		.selectAll()
+		.execute();
 
-		expect(allStates).toHaveLength(0); // All records should be deleted
+	expect(viewAfterDelete).toEqual([]);
+});
+
+test("should enforce primary key constraint (change_id, account_id)", async () => {
+	const lix = await openLix({});
+
+	// Create account
+	const account = await createAccount({
+		lix,
+		name: "Test Author",
 	});
 
-	test("should enforce primary key constraint (change_id, account_id)", async () => {
-		const lix = await openLix({});
+	await lix.db
+		.insertInto("change")
+		.values({
+			id: "c1",
+			entity_id: "e1",
+			schema_key: "mock_schema",
+			schema_version: "1",
+			file_id: "f1",
+			plugin_key: "test_plugin",
+			snapshot_content: { id: "e1" },
+		})
+		.execute();
 
-		// Create account
-		const account = await createAccount({
-			lix,
-			name: "Test Author",
-		});
+	// Insert first change_author
+	await lix.db
+		.insertInto("change_author")
+		.values({
+			change_id: "c1",
+			account_id: account.id,
+		})
+		.execute();
 
-		await lix.db
-			.insertInto("change")
-			.values({
-				id: "c1",
-				entity_id: "e1",
-				schema_key: "mock_schema",
-				schema_version: "1",
-				file_id: "f1",
-				plugin_key: "test_plugin",
-				snapshot_content: { id: "e1" },
-			})
-			.execute();
-
-		// Insert first change_author
-		await lix.db
+	// Attempt duplicate insert with same primary key
+	await expect(
+		lix.db
 			.insertInto("change_author")
 			.values({
 				change_id: "c1",
 				account_id: account.id,
 			})
-			.execute();
+			.execute()
+	).rejects.toThrow(/Primary key constraint violation/i);
+});
 
-		// Attempt duplicate insert with same primary key
-		await expect(
-			lix.db
-				.insertInto("change_author")
-				.values({
-					change_id: "c1",
-					account_id: account.id,
-				})
-				.execute()
-		).rejects.toThrow(/Primary key constraint violation/i);
+test("should enforce foreign key constraint on change_id", async () => {
+	const lix = await openLix({});
+
+	// Create account (but NOT change)
+	const account = await createAccount({
+		lix,
+		name: "Test Author",
 	});
 
-	test("should enforce foreign key constraint on change_id", async () => {
-		const lix = await openLix({});
-
-		// Create account (but NOT change)
-		const account = await createAccount({
-			lix,
-			name: "Test Author",
-		});
-
-		// Attempt to insert with non-existent change_id
-		await expect(
-			lix.db
-				.insertInto("change_author")
-				.values({
-					change_id: "c_nonexistent",
-					account_id: account.id,
-				})
-				.execute()
-		).rejects.toThrow(
-			/Foreign key constraint violation.*change_id.*lix_change.id/i
-		);
-	});
-
-	test("should enforce foreign key constraint on account_id", async () => {
-		const lix = await openLix({});
-
-		await lix.db
-			.insertInto("change")
-			.values({
-				id: "c1",
-				entity_id: "e1",
-				schema_key: "mock_schema",
-				schema_version: "1",
-				file_id: "f1",
-				plugin_key: "test_plugin",
-				snapshot_content: { id: "e1" },
-			})
-			.execute();
-
-		// Attempt to insert with non-existent account_id
-		await expect(
-			lix.db
-				.insertInto("change_author")
-				.values({
-					change_id: "c1",
-					account_id: "account_nonexistent",
-				})
-				.execute()
-		).rejects.toThrow(
-			/Foreign key constraint violation.*account_id.*lix_account.id/i
-		);
-	});
-
-	test("should allow multiple authors for the same change", async () => {
-		const lix = await openLix({});
-
-		// Create accounts
-		const author1 = await createAccount({
-			lix,
-			name: "Author One",
-		});
-
-		const author2 = await createAccount({
-			lix,
-			name: "Author Two",
-		});
-
-		await lix.db
-			.insertInto("change")
-			.values({
-				id: "c1",
-				entity_id: "e1",
-				schema_key: "mock_schema",
-				schema_version: "1",
-				file_id: "f1",
-				plugin_key: "test_plugin",
-				snapshot_content: { id: "e1" },
-			})
-			.execute();
-
-		// Insert multiple authors for same change
-		await lix.db
+	// Attempt to insert with non-existent change_id
+	await expect(
+		lix.db
 			.insertInto("change_author")
-			.values([
-				{
-					change_id: "c1",
-					account_id: author1.id,
-				},
-				{
-					change_id: "c1",
-					account_id: author2.id,
-				},
-			])
-			.execute();
+			.values({
+				change_id: "c_nonexistent",
+				account_id: account.id,
+			})
+			.execute()
+	).rejects.toThrow(
+		/Foreign key constraint violation.*change_id.*lix_change.id/i
+	);
+});
 
-		const authors = await lix.db
-			.selectFrom("change_author")
-			.where("change_id", "=", "c1")
-			.orderBy("account_id", "asc")
-			.selectAll()
-			.execute();
+test("should enforce foreign key constraint on account_id", async () => {
+	const lix = await openLix({});
 
-		expect(authors).toHaveLength(2);
-		expect(authors).toMatchObject([
+	await lix.db
+		.insertInto("change")
+		.values({
+			id: "c1",
+			entity_id: "e1",
+			schema_key: "mock_schema",
+			schema_version: "1",
+			file_id: "f1",
+			plugin_key: "test_plugin",
+			snapshot_content: { id: "e1" },
+		})
+		.execute();
+
+	// Attempt to insert with non-existent account_id
+	await expect(
+		lix.db
+			.insertInto("change_author")
+			.values({
+				change_id: "c1",
+				account_id: "account_nonexistent",
+			})
+			.execute()
+	).rejects.toThrow(
+		/Foreign key constraint violation.*account_id.*lix_account.id/i
+	);
+});
+
+test("should allow multiple authors for the same change", async () => {
+	const lix = await openLix({});
+
+	// Create accounts
+	const author1 = await createAccount({
+		lix,
+		name: "Author One",
+	});
+
+	const author2 = await createAccount({
+		lix,
+		name: "Author Two",
+	});
+
+	await lix.db
+		.insertInto("change")
+		.values({
+			id: "c1",
+			entity_id: "e1",
+			schema_key: "mock_schema",
+			schema_version: "1",
+			file_id: "f1",
+			plugin_key: "test_plugin",
+			snapshot_content: { id: "e1" },
+		})
+		.execute();
+
+	// Insert multiple authors for same change
+	await lix.db
+		.insertInto("change_author")
+		.values([
 			{
 				change_id: "c1",
 				account_id: author1.id,
@@ -227,66 +199,66 @@ describe("change_author", () => {
 				change_id: "c1",
 				account_id: author2.id,
 			},
-		]);
+		])
+		.execute();
+
+	const authors = await lix.db
+		.selectFrom("change_author")
+		.where("change_id", "=", "c1")
+		.orderBy("account_id", "asc")
+		.selectAll()
+		.execute();
+
+	expect(authors).toHaveLength(2);
+	expect(authors).toMatchObject([
+		{
+			change_id: "c1",
+			account_id: author1.id,
+		},
+		{
+			change_id: "c1",
+			account_id: author2.id,
+		},
+	]);
+});
+
+test("should allow same author for multiple changes", async () => {
+	const lix = await openLix({});
+
+	// Create account
+	const author = await createAccount({
+		lix,
+		name: "Prolific Author",
 	});
 
-	test("should allow same author for multiple changes", async () => {
-		const lix = await openLix({});
+	await lix.db
+		.insertInto("change")
+		.values([
+			{
+				id: "c1",
+				entity_id: "e1",
+				schema_key: "mock_schema",
+				schema_version: "1",
+				file_id: "f1",
+				plugin_key: "test_plugin",
+				snapshot_content: { id: "e1" },
+			},
+			{
+				id: "c2",
+				entity_id: "e2",
+				schema_key: "mock_schema",
+				schema_version: "1",
+				file_id: "f2",
+				plugin_key: "test_plugin",
+				snapshot_content: { id: "e2" },
+			},
+		])
+		.execute();
 
-		// Create account
-		const author = await createAccount({
-			lix,
-			name: "Prolific Author",
-		});
-
-		await lix.db
-			.insertInto("change")
-			.values([
-				{
-					id: "c1",
-					entity_id: "e1",
-					schema_key: "mock_schema",
-					schema_version: "1",
-					file_id: "f1",
-					plugin_key: "test_plugin",
-					snapshot_content: { id: "e1" },
-				},
-				{
-					id: "c2",
-					entity_id: "e2",
-					schema_key: "mock_schema",
-					schema_version: "1",
-					file_id: "f2",
-					plugin_key: "test_plugin",
-					snapshot_content: { id: "e2" },
-				},
-			])
-			.execute();
-
-		// Insert same author for multiple changes
-		await lix.db
-			.insertInto("change_author")
-			.values([
-				{
-					change_id: "c1",
-					account_id: author.id,
-				},
-				{
-					change_id: "c2",
-					account_id: author.id,
-				},
-			])
-			.execute();
-
-		const authorChanges = await lix.db
-			.selectFrom("change_author")
-			.where("account_id", "=", author.id)
-			.orderBy("change_id", "asc")
-			.selectAll()
-			.execute();
-
-		expect(authorChanges).toHaveLength(2);
-		expect(authorChanges).toMatchObject([
+	// Insert same author for multiple changes
+	await lix.db
+		.insertInto("change_author")
+		.values([
 			{
 				change_id: "c1",
 				account_id: author.id,
@@ -295,6 +267,94 @@ describe("change_author", () => {
 				change_id: "c2",
 				account_id: author.id,
 			},
-		]);
+		])
+		.execute();
+
+	const authorChanges = await lix.db
+		.selectFrom("change_author")
+		.where("account_id", "=", author.id)
+		.orderBy("change_id", "asc")
+		.selectAll()
+		.execute();
+
+	expect(authorChanges).toHaveLength(2);
+	expect(authorChanges).toMatchObject([
+		{
+			change_id: "c1",
+			account_id: author.id,
+		},
+		{
+			change_id: "c2",
+			account_id: author.id,
+		},
+	]);
+});
+
+test("change authors are accessible during a transaction", async () => {
+	// Create a lix instance with an active account
+	const lix = await openLix({
+		account: {
+			id: "test-account",
+			name: "Test User",
+		},
+	});
+
+	await lix.db.transaction().execute(async (trx) => {
+		// Insert a key-value entity within the transaction
+		await trx
+			.insertInto("key_value")
+			.values({
+				key: "transaction_test_key",
+				value: "transaction_test_value",
+			})
+			.execute();
+
+		// The change should be created automatically with change_author records
+		// Let's verify we can access the change and its authors within the transaction
+		const changes = await trx
+			.selectFrom("change")
+			.where("entity_id", "=", "transaction_test_key")
+			.where("schema_key", "=", "lix_key_value")
+			.selectAll()
+			.execute();
+
+		expect(changes).toHaveLength(1);
+		const changeId = changes[0]!.id;
+
+		// Verify the change_author record is accessible within the transaction
+		const changeAuthors = await trx
+			.selectFrom("change_author")
+			.where("change_id", "=", changeId)
+			.selectAll()
+			.execute();
+
+		expect(changeAuthors).toHaveLength(1);
+		expect(changeAuthors[0]).toMatchObject({
+			change_id: changeId,
+			account_id: "test-account",
+		});
+	});
+
+	// Verify the change_author records are still accessible after the transaction commits
+	const changes = await lix.db
+		.selectFrom("change")
+		.where("entity_id", "=", "transaction_test_key")
+		.where("schema_key", "=", "lix_key_value")
+		.selectAll()
+		.execute();
+
+	expect(changes).toHaveLength(1);
+	const changeId = changes[0]!.id;
+
+	const changeAuthors = await lix.db
+		.selectFrom("change_author")
+		.where("change_id", "=", changeId)
+		.selectAll()
+		.execute();
+
+	expect(changeAuthors).toHaveLength(1);
+	expect(changeAuthors[0]).toMatchObject({
+		change_id: changeId,
+		account_id: "test-account",
 	});
 });

--- a/packages/lix-sdk/src/database/init-db.ts
+++ b/packages/lix-sdk/src/database/init-db.ts
@@ -79,10 +79,9 @@ export function initDb(args: {
 		args.hooks
 	);
 	applyChangeSetDatabaseSchema(args.sqlite);
-
 	applyStoredSchemaDatabaseSchema(args.sqlite);
-	applyAccountDatabaseSchema(args.sqlite);
 	applyVersionDatabaseSchema(args.sqlite);
+	applyAccountDatabaseSchema(args.sqlite);
 	applyKeyValueDatabaseSchema(args.sqlite);
 	applyChangeAuthorDatabaseSchema(args.sqlite);
 	applyLabelDatabaseSchema(args.sqlite);

--- a/packages/lix-sdk/src/database/init-db.ts
+++ b/packages/lix-sdk/src/database/init-db.ts
@@ -71,13 +71,13 @@ export function initDb(args: {
 	});
 
 	// Apply all database schemas first (tables, views, triggers)
+	applySnapshotDatabaseSchema(args.sqlite);
+	applyChangeDatabaseSchema(args.sqlite);
 	applyStateDatabaseSchema(
 		args.sqlite,
 		db as unknown as Kysely<LixInternalDatabaseSchema>,
 		args.hooks
 	);
-	applySnapshotDatabaseSchema(args.sqlite);
-	applyChangeDatabaseSchema(args.sqlite);
 	applyChangeSetDatabaseSchema(args.sqlite);
 
 	applyStoredSchemaDatabaseSchema(args.sqlite);

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -23,10 +23,7 @@ import type {
 import type { StateHistoryView } from "../state-history/schema.js";
 import { LixFileDescriptorSchema } from "../file/schema.js";
 import { LixLogSchema } from "../log/schema.js";
-import {
-	LixAccountSchema,
-	type ActiveAccountTable,
-} from "../account/schema.js";
+import { LixAccountSchema, type ActiveAccount } from "../account/schema.js";
 import { LixChangeAuthorSchema } from "../change-author/schema.js";
 import { LixLabelSchema } from "../label/schema.js";
 import {
@@ -69,18 +66,14 @@ export const LixSchemaViewMap: Record<string, LixSchemaDefinition> = {
 };
 
 export type LixDatabaseSchema = {
+	active_account: ToKysely<ActiveAccount>;
+	active_version: ToKysely<ActiveVersion>;
+
 	state: StateView;
 	state_all: StateAllView;
 	state_history: StateHistoryView;
-	// account
-	active_account: ActiveAccountTable;
 
 	change: ChangeView;
-
-	// // change proposal
-	// // change_proposal: ChangeProposalTable;
-
-	active_version: ToKysely<ActiveVersion>;
 } & EntityViews<
 	typeof LixKeyValueSchema,
 	"key_value",

--- a/packages/lix-sdk/src/lix/open-lix.test.ts
+++ b/packages/lix-sdk/src/lix/open-lix.test.ts
@@ -57,7 +57,7 @@ test("providing an account should be possible", async () => {
 
 	const accounts = await lix.db
 		.selectFrom("active_account")
-		.selectAll()
+		.select(["id", "name"])
 		.execute();
 
 	expect(accounts, "to be the provided account").toContainEqual(mockAccount);

--- a/packages/lix-sdk/src/lix/open-lix.ts
+++ b/packages/lix-sdk/src/lix/open-lix.ts
@@ -174,13 +174,9 @@ export async function openLix(args: {
 
 	if (accountToSet) {
 		await db.transaction().execute(async (trx) => {
-			// delete the default inserted active account from `initDb`
+			// delete the existing active account
 			await trx.deleteFrom("active_account").execute();
-			await trx
-				.insertInto("active_account")
-				.values(accountToSet)
-				.onConflict((oc) => oc.doUpdateSet(() => ({ ...accountToSet })))
-				.execute();
+			await trx.insertInto("active_account").values(accountToSet).execute();
 		});
 	}
 
@@ -214,6 +210,11 @@ export async function openLix(args: {
 
 	// Apply file and account schemas now that we have the full lix object with plugins
 	applyFileDatabaseSchema(lix);
+
+	// Set up storage persistence if the adapter supports it
+	if (storage.setupPersistence) {
+		storage.setupPersistence(lix);
+	}
 
 	return lix;
 }

--- a/packages/lix-sdk/src/lix/open-lix.ts
+++ b/packages/lix-sdk/src/lix/open-lix.ts
@@ -66,11 +66,6 @@ export type Lix = {
  * the database is initialized with that data. If a database is provided,
  * uses that database directly.
  *
- * TODO: Add storage abstraction to support:
- *   - OPFS storage (persistent in browser)
- *   - Node.js filesystem storage
- *   - Custom storage adapters
- *
  * @example
  * ```ts
  * // In-memory (default)
@@ -79,9 +74,11 @@ export type Lix = {
  * // From existing data
  * const lix = await openLix({ blob: existingLixFile })
  *
- * // With custom database (current approach)
- * const db = await createInMemoryDatabase({ readOnly: false })
- * const lix = await openLix({ database: db })
+ * // With custom storage adapter
+ * import { MyCustomStorage } from "./my-custom-storage.js"
+ * const lix = await openLix({
+ *   storage: new MyCustomStorage()
+ * })
  * ```
  */
 export async function openLix(args: {
@@ -191,10 +188,6 @@ export async function openLix(args: {
 		getAll: async () => plugins,
 		getAllSync: () => plugins,
 	};
-
-	// await initFileQueueProcess({ lix: { db, plugin, sqlite: args.database } });
-
-	// await initSyncProcess({ lix: { db, plugin, sqlite: args.database } });
 
 	captureOpened({ db });
 

--- a/packages/lix-sdk/src/lix/storage/lix-storage-adapter.ts
+++ b/packages/lix-sdk/src/lix/storage/lix-storage-adapter.ts
@@ -2,6 +2,7 @@
  * Storage adapter interface for Lix.
  */
 import type { SqliteWasmDatabase } from "sqlite-wasm-kysely";
+import type { Account } from "../../account/schema.js";
 
 export interface LixStorageAdapter {
 	open(): Promise<SqliteWasmDatabase>;
@@ -13,4 +14,9 @@ export interface LixStorageAdapter {
 	 * Optional method for storage adapters that want to persist on state changes.
 	 */
 	onStateCommit?(): void;
+	/**
+	 * Gets the persisted active accounts.
+	 * Optional method for storage adapters that want to persist active accounts.
+	 */
+	getActiveAccounts?(): Pick<Account, "id" | "name">[] | undefined;
 }

--- a/packages/lix-sdk/src/lix/storage/lix-storage-adapter.ts
+++ b/packages/lix-sdk/src/lix/storage/lix-storage-adapter.ts
@@ -10,38 +10,41 @@ export interface LixStorageAdapter {
 	 * Opens and returns the database instance.
 	 */
 	open(): Promise<SqliteWasmDatabase>;
-	
+
 	/**
 	 * Closes the database and cleans up resources.
 	 */
 	close(): Promise<void>;
-	
+
 	/**
 	 * Imports data from a blob into the storage.
 	 */
 	import(blob: Blob): Promise<void>;
-	
+
 	/**
 	 * Exports the current storage state as a blob.
 	 */
 	export(): Promise<Blob>;
-	
+
 	/**
 	 * Called after the Lix instance is fully initialized.
 	 * Allows storage adapters to set up observers, hooks, etc.
-	 * 
+	 *
 	 * @param args - Object containing the Lix instance and future options
 	 */
 	connect?(args: { lix: Lix }): void;
-	
+
 	/**
 	 * Returns any persisted state that should be restored.
 	 * Called during Lix initialization to restore saved state.
-	 * 
+	 *
 	 * @returns Promise resolving to persisted state, or undefined if none
 	 */
-	getPersistedState?(): Promise<{
-		activeAccounts?: Pick<Account, "id" | "name">[];
-		// Future: Add more persisted state here
-	} | undefined>;
+	getPersistedState?(): Promise<
+		| {
+				activeAccounts?: Pick<Account, "id" | "name">[];
+				// Future: Add more persisted state here
+		  }
+		| undefined
+	>;
 }

--- a/packages/lix-sdk/src/lix/storage/lix-storage-adapter.ts
+++ b/packages/lix-sdk/src/lix/storage/lix-storage-adapter.ts
@@ -6,24 +6,42 @@ import type { Account } from "../../account/schema.js";
 import type { Lix } from "../open-lix.js";
 
 export interface LixStorageAdapter {
+	/**
+	 * Opens and returns the database instance.
+	 */
 	open(): Promise<SqliteWasmDatabase>;
+	
+	/**
+	 * Closes the database and cleans up resources.
+	 */
 	close(): Promise<void>;
+	
+	/**
+	 * Imports data from a blob into the storage.
+	 */
 	import(blob: Blob): Promise<void>;
+	
+	/**
+	 * Exports the current storage state as a blob.
+	 */
 	export(): Promise<Blob>;
+	
 	/**
-	 * Called when state commits happen.
-	 * Optional method for storage adapters that want to persist on state changes.
-	 */
-	onStateCommit?(): void;
-	/**
-	 * Gets the persisted active accounts.
-	 * Optional method for storage adapters that want to persist active accounts.
-	 */
-	getActiveAccounts?(): Pick<Account, "id" | "name">[] | undefined;
-	/**
-	 * Sets up persistence observers for the storage adapter.
 	 * Called after the Lix instance is fully initialized.
-	 * Optional method for storage adapters that need to observe specific state changes.
+	 * Allows storage adapters to set up observers, hooks, etc.
+	 * 
+	 * @param args - Object containing the Lix instance and future options
 	 */
-	setupPersistence?(lix: Lix): void;
+	connect?(args: { lix: Lix }): void;
+	
+	/**
+	 * Returns any persisted state that should be restored.
+	 * Called during Lix initialization to restore saved state.
+	 * 
+	 * @returns Promise resolving to persisted state, or undefined if none
+	 */
+	getPersistedState?(): Promise<{
+		activeAccounts?: Pick<Account, "id" | "name">[];
+		// Future: Add more persisted state here
+	} | undefined>;
 }

--- a/packages/lix-sdk/src/lix/storage/lix-storage-adapter.ts
+++ b/packages/lix-sdk/src/lix/storage/lix-storage-adapter.ts
@@ -3,6 +3,7 @@
  */
 import type { SqliteWasmDatabase } from "sqlite-wasm-kysely";
 import type { Account } from "../../account/schema.js";
+import type { Lix } from "../open-lix.js";
 
 export interface LixStorageAdapter {
 	open(): Promise<SqliteWasmDatabase>;
@@ -19,4 +20,10 @@ export interface LixStorageAdapter {
 	 * Optional method for storage adapters that want to persist active accounts.
 	 */
 	getActiveAccounts?(): Pick<Account, "id" | "name">[] | undefined;
+	/**
+	 * Sets up persistence observers for the storage adapter.
+	 * Called after the Lix instance is fully initialized.
+	 * Optional method for storage adapters that need to observe specific state changes.
+	 */
+	setupPersistence?(lix: Lix): void;
 }

--- a/packages/lix-sdk/src/lix/storage/opfs.test.ts
+++ b/packages/lix-sdk/src/lix/storage/opfs.test.ts
@@ -29,16 +29,14 @@ class MockOPFS {
 				if (typeof data === "string") {
 					return Promise.resolve({
 						text: vi.fn().mockResolvedValue(data),
-						arrayBuffer: vi.fn().mockResolvedValue(
-							new TextEncoder().encode(data).buffer
-						),
+						arrayBuffer: vi
+							.fn()
+							.mockResolvedValue(new TextEncoder().encode(data).buffer),
 					});
 				} else {
 					const bytes = data || new Uint8Array(0);
 					return Promise.resolve({
-						text: vi.fn().mockResolvedValue(
-							new TextDecoder().decode(bytes)
-						),
+						text: vi.fn().mockResolvedValue(new TextDecoder().decode(bytes)),
 						arrayBuffer: vi.fn().mockResolvedValue(bytes.buffer),
 					});
 				}
@@ -310,11 +308,14 @@ describe("OpfsStorage", () => {
 		const lix = await openLix({ storage, account });
 
 		// Spy on the saveActiveAccounts method
-		const saveActiveAccountsSpy = vi.spyOn(storage as any, "saveActiveAccounts");
+		const saveActiveAccountsSpy = vi.spyOn(
+			storage as any,
+			"saveActiveAccounts"
+		);
 
 		// Wait a bit for the initial save from the observer
 		await new Promise((resolve) => setTimeout(resolve, 50));
-		
+
 		// Clear the spy to ignore the initial save
 		saveActiveAccountsSpy.mockClear();
 
@@ -350,29 +351,32 @@ describe("OpfsStorage", () => {
 		// Create some files in OPFS
 		const storage1 = new OpfsStorage({ path: "file1.lix" });
 		const storage2 = new OpfsStorage({ path: "file2.lix" });
-		
+
 		// Open and create files
 		await openLix({ storage: storage1 });
 		await openLix({ storage: storage2 });
-		
+
 		// Also create an active accounts file
-		const lix3 = await openLix({ 
+		const lix3 = await openLix({
 			storage: new OpfsStorage({ path: "file3.lix" }),
-			account: { id: "test-clean", name: "Clean Test" }
+			account: { id: "test-clean", name: "Clean Test" },
 		});
 		await lix3.close();
-		
+
 		// Mock the OPFS directory structure for clean()
 		const mockFiles = new Map([
 			["file1.lix", { kind: "file", name: "file1.lix" }],
 			["file2.lix", { kind: "file", name: "file2.lix" }],
 			["file3.lix", { kind: "file", name: "file3.lix" }],
-			["lix_active_accounts.json", { kind: "file", name: "lix_active_accounts.json" }],
+			[
+				"lix_active_accounts.json",
+				{ kind: "file", name: "lix_active_accounts.json" },
+			],
 			["some-dir", { kind: "directory", name: "some-dir" }],
 		]);
-		
+
 		const removeEntrySpy = vi.fn();
-		
+
 		// Override getDirectory for clean() to return our mock structure
 		vi.mocked(navigator.storage.getDirectory).mockResolvedValueOnce({
 			values: vi.fn().mockImplementation(function* () {
@@ -382,17 +386,19 @@ describe("OpfsStorage", () => {
 			}),
 			removeEntry: removeEntrySpy,
 		} as any);
-		
+
 		// Call clean()
 		await OpfsStorage.clean();
-		
+
 		// Verify all files and directories were removed
 		expect(removeEntrySpy).toHaveBeenCalledTimes(5);
 		expect(removeEntrySpy).toHaveBeenCalledWith("file1.lix");
 		expect(removeEntrySpy).toHaveBeenCalledWith("file2.lix");
 		expect(removeEntrySpy).toHaveBeenCalledWith("file3.lix");
 		expect(removeEntrySpy).toHaveBeenCalledWith("lix_active_accounts.json");
-		expect(removeEntrySpy).toHaveBeenCalledWith("some-dir", { recursive: true });
+		expect(removeEntrySpy).toHaveBeenCalledWith("some-dir", {
+			recursive: true,
+		});
 	});
 
 	test("clean() throws error if OPFS is not supported", async () => {

--- a/packages/lix-sdk/src/state/handle-state-mutation.test.ts
+++ b/packages/lix-sdk/src/state/handle-state-mutation.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "vitest";
 import { openLix } from "../lix/open-lix.js";
 import type { ChangeSetEdge } from "../change-set/schema.js";
+import { switchAccount } from "../account/switch-account.js";
+import { changeSetIsAncestorOf } from "../query-filter/change-set-is-ancestor-of.js";
 
 test("creates a new change set and updates the version's change set id for mutations", async () => {
 	const lix = await openLix({});
@@ -93,11 +95,18 @@ test("creates a new change set and updates the version's change set id for mutat
 //
 // The workaround of using sqlite3_commit_hook is not possible because
 // SQLite forbids mutations in the commit hook https://www.sqlite.org/c3ref/commit_hook.html
-test("groups changes of a transaction into the same change set", async () => {
+test("groups changes of a transaction into the same change set for the given version", async () => {
 	const lix = await openLix({});
 
-	const edgesBeforeTransaction = await lix.db
-		.selectFrom("change_set_edge")
+	const activeVersion = await lix.db
+		.selectFrom("active_version")
+		.innerJoin("version", "version.id", "active_version.version_id")
+		.selectAll("version")
+		.executeTakeFirstOrThrow();
+
+	const changeSetsAncestryBefore = await lix.db
+		.selectFrom("change_set")
+		.where(changeSetIsAncestorOf({ id: activeVersion.change_set_id }))
 		.selectAll()
 		.execute();
 
@@ -119,12 +128,23 @@ test("groups changes of a transaction into the same change set", async () => {
 			.execute();
 	});
 
-	const edgesAfterTransaction = await lix.db
-		.selectFrom("change_set_edge")
+	const activeVersionAfterTransaction = await lix.db
+		.selectFrom("active_version")
+		.innerJoin("version", "version.id", "active_version.version_id")
+		.selectAll("version")
+		.executeTakeFirstOrThrow();
+
+	const changeSetsAncestryAfter = await lix.db
+		.selectFrom("change_set")
+		.where(
+			changeSetIsAncestorOf({ id: activeVersionAfterTransaction.change_set_id })
+		)
 		.selectAll()
 		.execute();
 
-	expect(edgesAfterTransaction).toHaveLength(edgesBeforeTransaction.length + 1);
+	expect(changeSetsAncestryAfter).toHaveLength(
+		changeSetsAncestryBefore.length + 1
+	);
 });
 
 test("should throw error when version_id is null", async () => {
@@ -758,4 +778,122 @@ test("working change set elements are separated per version", async () => {
 
 	expect(mainCrossCheck).toHaveLength(0);
 	expect(newCrossCheck).toHaveLength(0);
+});
+
+test("creates change_author records for insert, update, and delete operations", async () => {
+	const lix = await openLix({});
+
+	// Create test accounts
+	await lix.db
+		.insertInto("account")
+		.values([
+			{ id: "test-account-1", name: "Test User 1" },
+			{ id: "test-account-2", name: "Test User 2" },
+		])
+		.execute();
+
+	// Switch to single active account for insert
+	await switchAccount({
+		lix,
+		to: [{ id: "test-account-1", name: "Test User 1" }],
+	});
+
+	// INSERT: Create initial entity
+	await lix.db
+		.insertInto("key_value")
+		.values({
+			key: "crud_test_key",
+			value: "initial_value",
+		})
+		.execute();
+
+	// Switch to multiple active accounts for update
+	await switchAccount({
+		lix,
+		to: [
+			{ id: "test-account-1", name: "Test User 1" },
+			{ id: "test-account-2", name: "Test User 2" },
+		],
+	});
+
+	// UPDATE: Modify the entity
+	await lix.db
+		.updateTable("key_value")
+		.where("key", "=", "crud_test_key")
+		.set({ value: "updated_value" })
+		.execute();
+
+	// Switch back to single account for delete
+	await switchAccount({
+		lix,
+		to: [{ id: "test-account-2", name: "Test User 2" }],
+	});
+
+	// DELETE: Remove the entity
+	await lix.db
+		.deleteFrom("key_value")
+		.where("key", "=", "crud_test_key")
+		.execute();
+
+	// Get all changes for this entity
+	const changes = await lix.db
+		.selectFrom("change")
+		.where("entity_id", "=", "crud_test_key")
+		.where("schema_key", "=", "lix_key_value")
+		.orderBy("created_at", "asc")
+		.select(["id"])
+		.execute();
+
+	expect(changes).toHaveLength(3); // Insert + Update + Delete
+
+	const insertChangeId = changes[0]!.id;
+	const updateChangeId = changes[1]!.id;
+	const deleteChangeId = changes[2]!.id;
+
+	// Verify change_author records for INSERT (single account)
+	const insertAuthors = await lix.db
+		.selectFrom("change_author")
+		.where("change_id", "=", insertChangeId)
+		.selectAll()
+		.execute();
+
+	expect(insertAuthors).toHaveLength(1);
+	expect(insertAuthors[0]).toMatchObject({
+		change_id: insertChangeId,
+		account_id: "test-account-1",
+	});
+
+	// Verify change_author records for UPDATE (multiple accounts)
+	const updateAuthors = await lix.db
+		.selectFrom("change_author")
+		.where("change_id", "=", updateChangeId)
+		.selectAll()
+		.execute();
+
+	expect(updateAuthors).toHaveLength(2);
+	
+	// Check that both accounts are represented
+	const updateAccountIds = updateAuthors.map(author => author.account_id);
+	expect(updateAccountIds).toContain("test-account-1");
+	expect(updateAccountIds).toContain("test-account-2");
+	
+	// Check that all records have the correct change_id
+	updateAuthors.forEach(author => {
+		expect(author).toMatchObject({
+			change_id: updateChangeId,
+		});
+	});
+
+	// Verify change_author records for DELETE (single account)
+	const deleteAuthors = await lix.db
+		.selectFrom("change_author")
+		.where("change_id", "=", deleteChangeId)
+		.selectAll()
+		.execute();
+
+	expect(deleteAuthors).toHaveLength(1);
+	expect(deleteAuthors[0]).toMatchObject({
+		change_id: deleteChangeId,
+		account_id: "test-account-2",
+	});
 });

--- a/packages/lix-sdk/src/state/handle-state-mutation.test.ts
+++ b/packages/lix-sdk/src/state/handle-state-mutation.test.ts
@@ -871,14 +871,14 @@ test("creates change_author records for insert, update, and delete operations", 
 		.execute();
 
 	expect(updateAuthors).toHaveLength(2);
-	
+
 	// Check that both accounts are represented
-	const updateAccountIds = updateAuthors.map(author => author.account_id);
+	const updateAccountIds = updateAuthors.map((author) => author.account_id);
 	expect(updateAccountIds).toContain("test-account-1");
 	expect(updateAccountIds).toContain("test-account-2");
-	
+
 	// Check that all records have the correct change_id
-	updateAuthors.forEach(author => {
+	updateAuthors.forEach((author) => {
 		expect(author).toMatchObject({
 			change_id: updateChangeId,
 		});

--- a/packages/lix-sdk/src/state/handle-state-mutation.ts
+++ b/packages/lix-sdk/src/state/handle-state-mutation.ts
@@ -3,8 +3,9 @@ import type { SqliteWasmDatabase } from "sqlite-wasm-kysely";
 import type { LixInternalDatabaseSchema } from "../database/schema.js";
 import { executeSync } from "../database/execute-sync.js";
 import type { Change } from "../change/schema.js";
-
 import type { NewStateRow } from "./schema.js";
+import { uuidV7 } from "../database/index.js";
+import { LixChangeAuthorSchema } from "../change-author/schema.js";
 
 export function handleStateMutation(
 	sqlite: SqliteWasmDatabase,
@@ -273,6 +274,13 @@ export function createChangeWithSnapshot(args: {
 		});
 	}
 
+	// Create change_author records for all active accounts
+	createChangeAuthorRecords({
+		sqlite: args.sqlite,
+		db: args.db,
+		change_id: change.id,
+	});
+
 	return change;
 }
 
@@ -415,4 +423,90 @@ function updateStateCache(args: {
 					})
 			),
 	});
+}
+
+function createChangeAuthorRecords(args: {
+	sqlite: SqliteWasmDatabase;
+	db: Kysely<LixInternalDatabaseSchema>;
+	change_id: string;
+}): void {
+	try {
+		// Get all active accounts using sqlite.exec since we're in the virtual table context
+		const activeAccounts = args.sqlite.exec({
+			sql: "SELECT id, name FROM active_account",
+			returnValue: "resultRows",
+		});
+
+		// Create change_author records for each active account
+		if (activeAccounts && activeAccounts.length > 0) {
+			for (const account of activeAccounts) {
+				const accountId = account[0] as string;
+				const accountName = account[1] as string;
+
+				// First ensure the account exists in global version
+				const [existingAccount] = executeSync({
+					lix: { sqlite: args.sqlite },
+					query: args.db
+						.selectFrom("account_all")
+						.where("id", "=", accountId)
+						.selectAll(),
+				});
+
+				if (!existingAccount) {
+					executeSync({
+						lix: { sqlite: args.sqlite },
+						query: args.db.insertInto("account_all").values({
+							id: accountId,
+							name: accountName,
+							lixcol_version_id: "global",
+						}),
+					});
+				}
+
+				// Create change_author snapshot content
+				const changeAuthorSnapshot = {
+					change_id: args.change_id,
+					account_id: accountId,
+				};
+
+				const currentTime = new Date().toISOString();
+				const changeAuthorId = uuidV7();
+
+				// Write directly to internal_change_in_transaction to avoid infinite recursion
+				executeSync({
+					lix: { sqlite: args.sqlite },
+					query: args.db.insertInto("internal_change_in_transaction").values({
+						id: changeAuthorId,
+						entity_id: `${args.change_id}-${accountId}`, // Unique entity ID for change_author
+						schema_key: LixChangeAuthorSchema["x-lix-key"],
+						schema_version: LixChangeAuthorSchema["x-lix-version"],
+						file_id: "lix",
+						plugin_key: "lix",
+						version_id: "global",
+						snapshot_content: sql`jsonb(${JSON.stringify(changeAuthorSnapshot)})`,
+						created_at: currentTime,
+					}),
+				});
+
+				// Update state cache directly
+				updateStateCache({
+					sqlite: args.sqlite,
+					db: args.db,
+					entity_id: `${args.change_id}-${accountId}`,
+					schema_key: "lix_change_author",
+					file_id: "lix",
+					version_id: "global",
+					plugin_key: "lix",
+					snapshot_content: JSON.stringify(changeAuthorSnapshot),
+					schema_version: "1.0",
+					timestamp: currentTime,
+					change_id: changeAuthorId,
+				});
+			}
+		}
+	} catch (error) {
+		// If active_account table doesn't exist, skip change_author creation
+		// This can happen in some test contexts or during initialization
+		console.log("Could not create change_author records:", error);
+	}
 }

--- a/packages/lix-sdk/src/state/handle-state-mutation.ts
+++ b/packages/lix-sdk/src/state/handle-state-mutation.ts
@@ -219,7 +219,6 @@ export function createChangeWithSnapshot(args: {
 	// 		.returning(["id", "schema_key", "file_id", "entity_id"]),
 	// });
 
-	// we don't need the created snapshot
 	const [change] = executeSync({
 		lix: { sqlite: args.sqlite },
 		query: args.db
@@ -472,12 +471,11 @@ function createChangeAuthorRecords(args: {
 				const currentTime = new Date().toISOString();
 				const changeAuthorId = uuidV7();
 
-				// Write directly to internal_change_in_transaction to avoid infinite recursion
 				executeSync({
 					lix: { sqlite: args.sqlite },
 					query: args.db.insertInto("internal_change_in_transaction").values({
 						id: changeAuthorId,
-						entity_id: `${args.change_id}-${accountId}`, // Unique entity ID for change_author
+						entity_id: `${args.change_id}::${accountId}`,
 						schema_key: LixChangeAuthorSchema["x-lix-key"],
 						schema_version: LixChangeAuthorSchema["x-lix-version"],
 						file_id: "lix",
@@ -492,13 +490,13 @@ function createChangeAuthorRecords(args: {
 				updateStateCache({
 					sqlite: args.sqlite,
 					db: args.db,
-					entity_id: `${args.change_id}-${accountId}`,
-					schema_key: "lix_change_author",
+					entity_id: `${args.change_id}::${accountId}`,
+					schema_key: LixChangeAuthorSchema["x-lix-key"],
+					schema_version: LixChangeAuthorSchema["x-lix-version"],
 					file_id: "lix",
 					version_id: "global",
 					plugin_key: "lix",
 					snapshot_content: JSON.stringify(changeAuthorSnapshot),
-					schema_version: "1.0",
 					timestamp: currentTime,
 					change_id: changeAuthorId,
 				});

--- a/packages/lix-sdk/src/state/schema.ts
+++ b/packages/lix-sdk/src/state/schema.ts
@@ -71,26 +71,6 @@ export function applyStateDatabaseSchema(
 		return loggingInitialized;
 	};
 
-	const create_temp_change_table_sql = `
-  -- add a table we use within the transaction
-  CREATE TEMP TABLE IF NOT EXISTS internal_change_in_transaction (
-    id TEXT PRIMARY KEY DEFAULT (uuid_v7()),
-    entity_id TEXT NOT NULL,
-    schema_key TEXT NOT NULL,
-    schema_version TEXT NOT NULL,
-    file_id TEXT NOT NULL,
-    plugin_key TEXT NOT NULL,
-	  version_id TEXT NOT NULL,
-    snapshot_content BLOB,
-    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL CHECK (created_at LIKE '%Z'),
-	--- NOTE schena_key must be unique per entity_id and file_id
-	UNIQUE(entity_id, file_id, schema_key, version_id)
-  ) STRICT;
-
-`;
-
-	sqlite.exec(create_temp_change_table_sql);
-
 	module.installMethods(
 		{
 			xCreate: (db: any, _pAux: any, _argc: number, _argv: any, pVTab: any) => {

--- a/packages/lix/plugins/prosemirror/example/src/App.tsx
+++ b/packages/lix/plugins/prosemirror/example/src/App.tsx
@@ -11,10 +11,17 @@ import { initLixInspector } from "@lix-js/inspector";
 import { LixProvider } from "@lix-js/react-utils";
 
 // Initialize Lix
-const lix = await openLix({
-	providePlugins: [prosemirrorPlugin],
-	storage: new OpfsStorage({ path: "example.lix" }),
-});
+let lix;
+try {
+	lix = await openLix({
+		providePlugins: [prosemirrorPlugin],
+		storage: new OpfsStorage({ path: "example.lix" }),
+	});
+} catch (error) {
+	console.error("Failed to open Lix, cleaning OPFS and reloading:", error);
+	await OpfsStorage.clean();
+	window.location.reload();
+}
 
 // dev tool for debugging
 initLixInspector({ lix });

--- a/packages/lix/plugins/prosemirror/example/src/components/AccountSelector.tsx
+++ b/packages/lix/plugins/prosemirror/example/src/components/AccountSelector.tsx
@@ -10,7 +10,6 @@ import {
 
 const AccountSelector: React.FC = () => {
 	const lix = useLix();
-	const [isOpen, setIsOpen] = useState(false);
 	const [showCreateDialog, setShowCreateDialog] = useState(false);
 	const [newAccountName, setNewAccountName] = useState("");
 
@@ -23,16 +22,18 @@ const AccountSelector: React.FC = () => {
 	);
 
 	const handleAccountSelect = async (account: Account) => {
-		setIsOpen(false);
 		await switchAccount({
 			lix,
 			to: [account],
 		});
+		// Close dropdown by removing focus
+		(document.activeElement as HTMLElement)?.blur();
 	};
 
 	const handleCreateAccountClick = () => {
-		setIsOpen(false);
 		setShowCreateDialog(true);
+		// Close dropdown by removing focus
+		(document.activeElement as HTMLElement)?.blur();
 	};
 
 	const handleCreateAccount = async () => {
@@ -60,18 +61,15 @@ const AccountSelector: React.FC = () => {
 
 	// Avatar component with wireframe style
 	const Avatar = ({ name }: { name: string }) => (
-		<div className="w-6 h-6 rounded-full bg-base-300 border border-base-300 flex items-center justify-center text-xs font-bold text-base-content mr-2 flex-shrink-0">
+		<div className="w-6 h-6 rounded-full bg-base-300 flex items-center justify-center text-xs font-bold text-base-content mr-2 flex-shrink-0">
 			{getInitials(name)}
 		</div>
 	);
 
 	// Loading state or display account
 	return (
-		<div className="relative inline-block">
-			<button
-				onClick={() => setIsOpen(!isOpen)}
-				className="btn btn-outline justify-between normal-case"
-			>
+		<div className="dropdown dropdown-end">
+			<label tabIndex={0} className="btn btn-ghost border border-base-300">
 				<div className="flex items-center">
 					{activeAccount ? (
 						<>
@@ -82,44 +80,45 @@ const AccountSelector: React.FC = () => {
 						</>
 					) : (
 						<>
-							<div className="w-6 h-6 bg-base-300 border border-base-300 rounded-full mr-2 flex items-center justify-center text-xs font-bold flex-shrink-0"></div>
+							<div className="w-6 h-6 bg-base-300 rounded-full mr-2 flex items-center justify-center text-xs font-bold flex-shrink-0"></div>
 							<span>Loading...</span>
 						</>
 					)}
 				</div>
 				<ChevronDown size={16} className="ml-2" />
-			</button>
+			</label>
 
-			{isOpen && (
-				<div className="absolute top-full right-0 min-w-full w-auto max-w-[200px] bg-white border border-base-300 rounded-b-md shadow-md z-10 max-h-[300px] overflow-y-auto">
-					{allAccounts.map((account) => (
-						<div
-							key={account.id}
+			<ul
+				tabIndex={0}
+				className="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-52 mt-1"
+			>
+				{allAccounts.map((account) => (
+					<li key={account.id}>
+						<a
 							onClick={() => handleAccountSelect(account)}
-							className={`p-3 cursor-pointer border-b border-base-200 flex items-center ${
-								activeAccount && account.id === activeAccount.id
-									? "bg-base-200"
-									: "bg-white"
+							className={`flex items-center ${
+								activeAccount && account.id === activeAccount.id ? "active" : ""
 							}`}
 						>
 							<Avatar name={account.name} />
 							<span className="overflow-hidden text-ellipsis whitespace-nowrap">
 								{account.name}
 							</span>
-						</div>
-					))}
-					{/* Create new account option */}
-					<div
-						onClick={handleCreateAccountClick}
-						className="p-3 cursor-pointer border-t border-base-200 bg-base-100 flex items-center"
-					>
-						<div className="w-6 h-6 bg-base-200 border border-base-300 rounded-full mr-2 flex items-center justify-center text-xs font-bold">
+						</a>
+					</li>
+				))}
+				{/* Divider */}
+				<div className="divider my-1"></div>
+				{/* Create new account option */}
+				<li>
+					<a onClick={handleCreateAccountClick} className="flex items-center">
+						<div className="w-6 h-6 bg-base-300 rounded-full mr-2 flex items-center justify-center text-xs font-bold">
 							+
 						</div>
 						<span>Create new account</span>
-					</div>
-				</div>
-			)}
+					</a>
+				</li>
+			</ul>
 
 			{/* Create account dialog */}
 			{showCreateDialog && (

--- a/packages/lix/plugins/prosemirror/example/src/queries.ts
+++ b/packages/lix/plugins/prosemirror/example/src/queries.ts
@@ -123,7 +123,12 @@ export function selectThreads(
 			jsonArrayFrom(
 				eb
 					.selectFrom("thread_comment")
-					// .innerJoin("account", "account.id", "change_author.account_id")
+					.innerJoin(
+						"change_author",
+						"thread_comment.lixcol_change_id",
+						"change_author.change_id",
+					)
+					.innerJoin("account", "account.id", "change_author.account_id")
 					.select([
 						"thread_comment.id",
 						"thread_comment.body",
@@ -132,7 +137,7 @@ export function selectThreads(
 						"thread_comment.lixcol_created_at",
 						"thread_comment.lixcol_updated_at",
 					])
-					.select((eb) => eb.val("TODO username").as("author_name"))
+					.select("account.name as author_name")
 					.orderBy("thread_comment.lixcol_created_at", "asc")
 					.whereRef("thread_comment.thread_id", "=", "thread.id"),
 			).as("comments"),


### PR DESCRIPTION
Changes are now creating change_authors. Closes https://github.com/opral/lix-sdk/issues/319

Not all changes have authors. system changes like updating the version change set id for example does not. 

We can add more author changes as requested by users. For now, this PR gives us blame on entities like markdown_paragraph, etc. 

To achieve this change authors, I had to 

- refactor the active_account to be a view over the state api for subscriptions

- refactor the `internal_change_in_transaction` to be defined in the change schema itself to adjust the `change` view to be a UNION of changes + change sin transaction 

- updated the OPFS adapter to persist the active account. 