### PR TITLE
Fix TypeDoc generation order and improve organization

### DIFF
--- a/packages/lix-docs/rspress-plugins/typedoc-plugin.ts
+++ b/packages/lix-docs/rspress-plugins/typedoc-plugin.ts
@@ -139,11 +139,11 @@ export function generateApiSidebar(docsRoot: string) {
 
   // Define the categories we want to show
   const categories = [
-    { dir: "classes", title: "Classes", collapsed: false },
-    { dir: "interfaces", title: "Interfaces", collapsed: false },
     { dir: "functions", title: "Functions", collapsed: true },
     { dir: "types", title: "Type Aliases", collapsed: true },
     { dir: "variables", title: "Variables", collapsed: true },
+    { dir: "classes", title: "Classes", collapsed: true },
+    { dir: "interfaces", title: "Interfaces", collapsed: true },
   ];
 
   categories.forEach((category) => {

--- a/packages/lix-docs/rspress.config.ts
+++ b/packages/lix-docs/rspress.config.ts
@@ -2,9 +2,23 @@ import * as path from "node:path";
 import { defineConfig } from "rspress/config";
 import mermaid from "rspress-plugin-mermaid";
 import {
-  customTypeDocPlugin,
+  generateApiDocs,
   generateApiSidebar,
 } from "./rspress-plugins/typedoc-plugin";
+
+// Generate API docs before creating the config
+// We need to generate the API docs at the top level (before defineConfig) because
+// the sidebar generation function (generateApiSidebar) runs synchronously during
+// config evaluation. If we used a plugin instead, the API docs would be generated
+// asynchronously after the sidebar tries to read them, resulting in an empty sidebar.
+console.log("Generating API Reference documentation...");
+await generateApiDocs({
+  entryPoints: [path.join(__dirname, "../lix-sdk/src/index.ts")],
+  tsconfig: path.join(__dirname, "../lix-sdk/tsconfig.json"),
+  docRoot: path.join(__dirname, "docs"),
+  title: "Lix",
+});
+console.log("✅ API Reference documentation generated successfully.");
 
 export default defineConfig({
   root: path.join(__dirname, "docs"),
@@ -36,13 +50,7 @@ export default defineConfig({
       },
     },
   },
-  plugins: [
-    mermaid(),
-    customTypeDocPlugin({
-      entryPoints: [path.join(__dirname, "../lix-sdk/src/index.ts")],
-      tsconfig: path.join(__dirname, "../lix-sdk/tsconfig.json"),
-    }),
-  ],
+  plugins: [mermaid()],
   themeConfig: {
     darkMode: false,
     nav: [


### PR DESCRIPTION
Ensure TypeDoc documentation is generated before the build process and reorganize function definitions for better readability.