### PR TITLE
add view for underlying state

### DIFF
--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -35,6 +35,7 @@ import {
 import { LixChangeSetThreadSchema } from "../change-set/schema.js";
 import type { EntityViews } from "../entity-views/entity-view-builder.js";
 import type { ToKysely } from "../entity-views/types.js";
+import type { InternalUnderlyingStateAllView } from "../state/underlying-state-view.js";
 
 export const LixDatabaseSchemaJsonColumns = {
 	snapshot: ["content"],
@@ -47,6 +48,7 @@ export type LixInternalDatabaseSchema = LixDatabaseSchema & {
 	internal_snapshot: InternalSnapshotTable;
 	internal_state_cache: InternalStateCacheTable;
 	internal_state_all_untracked: InternalStateAllUntrackedTable;
+	internal_underlying_state_all: InternalUnderlyingStateAllView;
 };
 
 export const LixSchemaViewMap: Record<string, LixSchemaDefinition> = {

--- a/packages/lix-sdk/src/state/schema.ts
+++ b/packages/lix-sdk/src/state/schema.ts
@@ -8,6 +8,7 @@ import { createLixOwnLogSync } from "../log/create-lix-own-log.js";
 import { createChangesetForTransaction } from "./create-changeset-for-transaction.js";
 import type { LixHooks } from "../hooks/create-hooks.js";
 import { executeSync } from "../database/execute-sync.js";
+import { applyUnderlyingStateView } from "./underlying-state-view.js";
 
 // Virtual table schema definition
 const VTAB_CREATE_SQL = `CREATE TABLE x(
@@ -31,6 +32,7 @@ export function applyStateDatabaseSchema(
 	db: Kysely<LixInternalDatabaseSchema>,
 	hooks: LixHooks
 ): SqliteWasmDatabase {
+	applyUnderlyingStateView(sqlite);
 	sqlite.createFunction({
 		name: "validate_snapshot_content",
 		deterministic: true,

--- a/packages/lix-sdk/src/state/underlying-state-view.test.ts
+++ b/packages/lix-sdk/src/state/underlying-state-view.test.ts
@@ -1,0 +1,240 @@
+import { test, expect } from "vitest";
+import { openLix } from "../lix/open-lix.js";
+import type { Kysely } from "kysely";
+import type { LixInternalDatabaseSchema } from "../database/schema.js";
+
+test("underlying_state view should return same results as state_all for a tracked entity", async () => {
+	const lix = await openLix({});
+
+	const lixInternalDb = lix.db as unknown as Kysely<LixInternalDatabaseSchema>;
+
+	// Insert a key-value through the normal state API
+	await lix.db
+		.insertInto("key_value")
+		.values({
+			key: "test-key",
+			value: "test-value",
+		})
+		.execute();
+
+	// Query both state_all and underlying_state
+	const stateAllResults = await lix.db
+		.selectFrom("state_all")
+		.where("entity_id", "=", "test-key")
+		.where("schema_key", "=", "lix_key_value")
+		.selectAll()
+		.execute();
+
+	const underlyingStateResults = await lixInternalDb
+		.selectFrom("internal_underlying_state_all")
+		.where("entity_id", "=", "test-key")
+		.where("schema_key", "=", "lix_key_value")
+		.selectAll()
+		.execute();
+
+	expect(stateAllResults).toEqual(underlyingStateResults);
+});
+
+test("underlying_state view should return same results as state_all for an untracked entity", async () => {
+	const lix = await openLix({});
+
+	const lixInternalDb = lix.db as unknown as Kysely<LixInternalDatabaseSchema>;
+
+	// Insert an untracked key-value directly
+	await lix.db
+		.insertInto("key_value")
+		.values({
+			key: "cache_stale",
+			value: "true",
+			lixcol_untracked: true,
+		})
+		.execute();
+
+	// Query both state_all and underlying_state
+	const stateAllResults = await lix.db
+		.selectFrom("state_all")
+		.where("entity_id", "=", "cache_stale")
+		.where("schema_key", "=", "lix_key_value")
+		.selectAll()
+		.execute();
+
+	const underlyingStateResults = await lixInternalDb
+		.selectFrom("internal_underlying_state_all")
+		.where("entity_id", "=", "cache_stale")
+		.where("schema_key", "=", "lix_key_value")
+		.selectAll()
+		.execute();
+
+	expect(stateAllResults).toEqual(underlyingStateResults);
+
+	// Verify it's marked as untracked
+	expect(stateAllResults[0]?.untracked).toBe(1);
+	expect(underlyingStateResults[0]?.untracked).toBe(1);
+});
+
+test("underlying_state view should handle version inheritance", async () => {
+	const lix = await openLix({});
+
+	const lixInternalDb = lix.db as unknown as Kysely<LixInternalDatabaseSchema>;
+
+	// Get the active version (which inherits from global)
+	const activeVersion = await lix.db
+		.selectFrom("active_version")
+		.selectAll()
+		.executeTakeFirst();
+
+	// Insert key-value directly into key_value_all with global version
+	await lix.db
+		.insertInto("key_value_all")
+		.values({
+			key: "inherited-key",
+			value: "global-value",
+			lixcol_version_id: "global",
+		})
+		.execute();
+
+	// Query both state_all and underlying_state for active version
+	const stateAllResults = await lix.db
+		.selectFrom("state_all")
+		.where("entity_id", "=", "inherited-key")
+		.where("version_id", "=", activeVersion!.version_id)
+		.selectAll()
+		.execute();
+
+	const underlyingStateResults = await lixInternalDb
+		.selectFrom("internal_underlying_state_all")
+		.where("entity_id", "=", "inherited-key")
+		.where("version_id", "=", activeVersion!.version_id)
+		.selectAll()
+		.execute();
+
+	// Both should return the inherited entity
+	expect(stateAllResults).toHaveLength(1);
+	expect(underlyingStateResults).toHaveLength(1);
+
+	// Results should match
+	expect(stateAllResults).toEqual(underlyingStateResults);
+
+	// Verify it's marked as inherited from global
+	expect(stateAllResults[0]?.inherited_from_version_id).toBe("global");
+	expect(underlyingStateResults[0]?.inherited_from_version_id).toBe("global");
+});
+
+test("underlying_state view should handle inherited untracked entities", async () => {
+	const lix = await openLix({});
+
+	const lixInternalDb = lix.db as unknown as Kysely<LixInternalDatabaseSchema>;
+
+	// Get the active version (which inherits from global)
+	const activeVersion = await lix.db
+		.selectFrom("active_version")
+		.selectAll()
+		.executeTakeFirst();
+
+	// Insert untracked key-value directly into key_value_all with global version
+	await lix.db
+		.insertInto("key_value_all")
+		.values({
+			key: "inherited-untracked-key",
+			value: "global-untracked-value",
+			lixcol_version_id: "global",
+			lixcol_untracked: true,
+		})
+		.execute();
+
+	// Query both state_all and underlying_state for active version
+	const stateAllResults = await lix.db
+		.selectFrom("state_all")
+		.where("entity_id", "=", "inherited-untracked-key")
+		.where("version_id", "=", activeVersion!.version_id)
+		.selectAll()
+		.execute();
+
+	const underlyingStateResults = await lixInternalDb
+		.selectFrom("internal_underlying_state_all")
+		.where("entity_id", "=", "inherited-untracked-key")
+		.where("version_id", "=", activeVersion!.version_id)
+		.selectAll()
+		.execute();
+
+	// Both should return the inherited untracked entity
+	expect(stateAllResults).toHaveLength(1);
+	expect(underlyingStateResults).toHaveLength(1);
+
+	// Results should match
+	expect(stateAllResults).toEqual(underlyingStateResults);
+
+	// Verify it's marked as inherited from global and untracked
+	expect(stateAllResults[0]?.inherited_from_version_id).toBe("global");
+	expect(underlyingStateResults[0]?.inherited_from_version_id).toBe("global");
+	expect(stateAllResults[0]?.untracked).toBe(1);
+	expect(underlyingStateResults[0]?.untracked).toBe(1);
+});
+
+test.skip("underlying_state view should block inheritance when child has own value", async () => {
+	const lix = await openLix({});
+
+	const lixInternalDb = lix.db as unknown as Kysely<LixInternalDatabaseSchema>;
+
+	// Get the active version (which inherits from global)
+	const activeVersion = await lix.db
+		.selectFrom("active_version")
+		.selectAll()
+		.executeTakeFirst();
+
+	// Insert key-value in global version (parent)
+	await lix.db
+		.insertInto("key_value_all")
+		.values({
+			key: "overridden-key",
+			value: "global-value",
+			lixcol_version_id: "global",
+		})
+		.execute();
+
+	// Insert same key in active version (child) - this should block inheritance
+	await lix.db
+		.insertInto("key_value")
+		.values({
+			key: "overridden-key",
+			value: "child-value",
+		})
+		.execute();
+
+	// Query both state_all and underlying_state for active version
+	const stateAllResults = await lix.db
+		.selectFrom("state_all")
+		.where("entity_id", "=", "overridden-key")
+		.where("version_id", "=", activeVersion!.version_id)
+		.selectAll()
+		.execute();
+
+	const underlyingStateResults = await lixInternalDb
+		.selectFrom("internal_underlying_state_all")
+		.where("entity_id", "=", "overridden-key")
+		.where("version_id", "=", activeVersion!.version_id)
+		.selectAll()
+		.execute();
+
+	// Both should return only the child's value
+	expect(stateAllResults).toHaveLength(1);
+	expect(underlyingStateResults).toHaveLength(1);
+
+	// Results should match
+	expect(stateAllResults).toEqual(underlyingStateResults);
+
+	// Verify it's NOT inherited and has child value
+	expect(stateAllResults[0]?.inherited_from_version_id).toBe(null);
+	expect(underlyingStateResults[0]?.inherited_from_version_id).toBe(null);
+	const stateSnapshot =
+		typeof stateAllResults[0]?.snapshot_content === "string"
+			? JSON.parse(stateAllResults[0].snapshot_content)
+			: stateAllResults[0]?.snapshot_content;
+	const underlyingSnapshot =
+		typeof underlyingStateResults[0]?.snapshot_content === "string"
+			? JSON.parse(underlyingStateResults[0].snapshot_content)
+			: underlyingStateResults[0]?.snapshot_content;
+
+	expect(stateSnapshot?.value).toBe("child-value");
+	expect(underlyingSnapshot?.value).toBe("child-value");
+});

--- a/packages/lix-sdk/src/state/underlying-state-view.ts
+++ b/packages/lix-sdk/src/state/underlying-state-view.ts
@@ -1,0 +1,158 @@
+import type { SqliteWasmDatabase } from "sqlite-wasm-kysely";
+import type { StateAllView } from "./schema.js";
+
+/**
+ * Creates a view that provides direct access to underlying state tables
+ * without going through the state virtual table. This avoids recursion
+ * issues when operations like lix_timestamp() need to query state.
+ *
+ * IMPORTANT: This view assumes that the cache is fresh. It does not check
+ * for cache staleness or trigger cache population. The caller is responsible
+ * for ensuring the cache is up-to-date before querying this view.
+ *
+ * See https://github.com/opral/lix-sdk/issues/355
+ */
+export function applyUnderlyingStateView(sqlite: SqliteWasmDatabase): void {
+	// Create the view that unions cache and untracked state
+	sqlite.exec(`
+		CREATE VIEW IF NOT EXISTS internal_underlying_state_all AS
+		SELECT * FROM (
+			-- 1. Untracked state (highest priority)
+			SELECT 
+				entity_id, 
+				schema_key, 
+				file_id, 
+				plugin_key,
+				snapshot_content, 
+				schema_version, 
+				version_id,
+				created_at, 
+				updated_at,
+				NULL as inherited_from_version_id, 
+				'untracked' as change_id, 
+				1 as untracked,
+				'untracked' as change_set_id
+			FROM internal_state_all_untracked
+			
+			UNION ALL
+			
+			-- 2. Tracked state from cache (second priority) - only if no untracked exists
+			SELECT 
+				entity_id, 
+				schema_key, 
+				file_id, 
+				plugin_key, 
+				snapshot_content, 
+				schema_version, 
+				version_id,
+				created_at, 
+				updated_at,
+				inherited_from_version_id, 
+				change_id, 
+				0 as untracked,
+				change_set_id
+			FROM internal_state_cache
+			WHERE inheritance_delete_marker = 0  -- Hide copy-on-write deletions
+			AND NOT EXISTS (
+				SELECT 1 FROM internal_state_all_untracked unt
+				WHERE unt.entity_id = internal_state_cache.entity_id
+				  AND unt.schema_key = internal_state_cache.schema_key
+				  AND unt.file_id = internal_state_cache.file_id
+				  AND unt.version_id = internal_state_cache.version_id
+			)
+			
+			UNION ALL
+			
+			-- 3. Inherited tracked state (lower priority) - only if no untracked or tracked exists
+			SELECT 
+				isc.entity_id, 
+				isc.schema_key, 
+				isc.file_id, 
+				isc.plugin_key, 
+				isc.snapshot_content, 
+				isc.schema_version, 
+				vi.version_id, -- Return child version_id
+				isc.created_at, 
+				isc.updated_at,
+				vi.parent_version_id as inherited_from_version_id, 
+				isc.change_id, 
+				0 as untracked,
+				isc.change_set_id
+			FROM (
+				-- Get version inheritance relationships from cache
+				SELECT 
+					json_extract(isc_v.snapshot_content, '$.id') AS version_id,
+					json_extract(isc_v.snapshot_content, '$.inherits_from_version_id') AS parent_version_id
+				FROM internal_state_cache isc_v
+				WHERE isc_v.schema_key = 'lix_version'
+			) vi
+			JOIN internal_state_cache isc ON isc.version_id = vi.parent_version_id
+			WHERE vi.parent_version_id IS NOT NULL
+			-- Only inherit entities that exist (not deleted) in parent
+			AND isc.inheritance_delete_marker = 0
+			-- Don't inherit if child has tracked state
+			AND NOT EXISTS (
+				SELECT 1 FROM internal_state_cache child_isc
+				WHERE child_isc.version_id = vi.version_id
+				  AND child_isc.entity_id = isc.entity_id
+				  AND child_isc.schema_key = isc.schema_key
+				  AND child_isc.file_id = isc.file_id
+			)
+			-- Don't inherit if child has untracked state
+			AND NOT EXISTS (
+				SELECT 1 FROM internal_state_all_untracked unt
+				WHERE unt.version_id = vi.version_id
+				  AND unt.entity_id = isc.entity_id
+				  AND unt.schema_key = isc.schema_key
+				  AND unt.file_id = isc.file_id
+			)
+			
+			UNION ALL
+			
+			-- 4. Inherited untracked state (lowest priority) - only if no untracked or tracked exists
+			SELECT 
+				unt.entity_id, 
+				unt.schema_key, 
+				unt.file_id, 
+				unt.plugin_key, 
+				unt.snapshot_content, 
+				unt.schema_version, 
+				vi.version_id, -- Return child version_id
+				unt.created_at, 
+				unt.updated_at,
+				vi.parent_version_id as inherited_from_version_id, 
+				'untracked' as change_id, 
+				1 as untracked,
+				'untracked' as change_set_id
+			FROM (
+				-- Get version inheritance relationships from cache
+				SELECT 
+					json_extract(isc_v.snapshot_content, '$.id') AS version_id,
+					json_extract(isc_v.snapshot_content, '$.inherits_from_version_id') AS parent_version_id
+				FROM internal_state_cache isc_v
+				WHERE isc_v.schema_key = 'lix_version'
+			) vi
+			JOIN internal_state_all_untracked unt ON unt.version_id = vi.parent_version_id
+			WHERE vi.parent_version_id IS NOT NULL
+			-- Don't inherit if child has tracked state
+			AND NOT EXISTS (
+				SELECT 1 FROM internal_state_cache child_isc
+				WHERE child_isc.version_id = vi.version_id
+				  AND child_isc.entity_id = unt.entity_id
+				  AND child_isc.schema_key = unt.schema_key
+				  AND child_isc.file_id = unt.file_id
+			)
+			-- Don't inherit if child has untracked state
+			AND NOT EXISTS (
+				SELECT 1 FROM internal_state_all_untracked child_unt
+				WHERE child_unt.version_id = vi.version_id
+				  AND child_unt.entity_id = unt.entity_id
+				  AND child_unt.schema_key = unt.schema_key
+				  AND child_unt.file_id = unt.file_id
+			)
+		);
+	`);
+}
+
+// Type for the view - matches StateAllView
+export type InternalUnderlyingStateAllView = StateAllView;


### PR DESCRIPTION
Partially closes https://github.com/opral/lix-sdk/issues/355 by introducing a view to query underlying state without hitting the state vtable itself.  

- In a future iteration, we can add instead of trigger which handle mutations that should bypass the vtable as well (to avoid recursion)
- a follow up pr share the select statement instead of duplicating it (but many ppl touch state code rn. not doing this rn to avoid merge conflicts)