### PR TITLE
Remove LIX branding from HTML Diff landing page

### DIFF
--- a/packages/lix/lix-html-diff/docs/index.md
+++ b/packages/lix/lix-html-diff/docs/index.md
@@ -2,7 +2,7 @@
 pageType: home
 
 hero:
-  name: Lix HTML Diff
+  name: HTML Diff
   text: Build a diff view in your app
   tagline: Universal HTML diffing for any app UI - works with React, Vue, Svelte, Angular, and more
   actions:

--- a/packages/lix/lix-html-diff/index.html
+++ b/packages/lix/lix-html-diff/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Lix HTML Diff</title>
+    <title>HTML Diff</title>
     <script type="module" src="/website/main.tsx"></script>
     <link rel="stylesheet" href="/website/index.css">
     <link rel="stylesheet" href="/src/default.css">

--- a/packages/lix/lix-html-diff/rspress.config.ts
+++ b/packages/lix/lix-html-diff/rspress.config.ts
@@ -5,7 +5,7 @@ import mermaid from "rspress-plugin-mermaid";
 export default defineConfig({
   root: path.join(__dirname, "docs"),
   outDir: "docs_build",
-  title: "Lix HTML Diff",
+  title: "HTML Diff",
   description: "Build a diff view in your app with this HTML differ",
   icon: "/rspress-icon.png",
   globalStyles: path.join(__dirname, "docs/styles/index.css"),


### PR DESCRIPTION
## Summary
- tweak landing page title and hero text to drop LIX brand
- update docs site config

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68895689b5c8832693e6d8f2c2d9edcf