### PR TITLE
docs: explain change proposal term

### DIFF
--- a/packages/lix-docs/docs/guide/features/change-proposals.mdx
+++ b/packages/lix-docs/docs/guide/features/change-proposals.mdx
@@ -6,6 +6,9 @@ import exampleSrcCode from "../../examples/change-proposals.ts?raw";
 
 Change proposals let you build review and approval workflows for into your application. This allows users and AI agents to safely suggest, discuss, and approve edits before they are merged.
 
+> [!NOTE]
+> Lix uses the term "change proposal" instead of "pull request" because many non-technical users aren't familiar with Git terminology. "Change proposal" clearly describes the act of proposing changes.
+
 ![Change Proposals](/change-proposal.svg)
 
 ## Examples

--- a/packages/lix-docs/docs/guide/features/change-proposals.mdx
+++ b/packages/lix-docs/docs/guide/features/change-proposals.mdx
@@ -6,10 +6,10 @@ import exampleSrcCode from "../../examples/change-proposals.ts?raw";
 
 Change proposals let you build review and approval workflows for into your application. This allows users and AI agents to safely suggest, discuss, and approve edits before they are merged.
 
-> [!NOTE]
-> Lix uses the term "change proposal" instead of "pull request" because many non-technical users aren't familiar with Git terminology. "Change proposal" clearly describes the act of proposing changes.
-
 ![Change Proposals](/change-proposal.svg)
+
+> [!INFO]
+> Lix uses the term "change proposal" instead of "pull request" because many non-technical users aren't familiar with Git terminology. "Change proposal" clearly describes the act of proposing changes.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- clarify why Lix uses the term "change proposal" instead of "pull request" in docs

## Testing
- `pnpm --filter @lix-js/docs test` *(fails: Failed to resolve entry for package "@opral/zettel-ast")*

------
https://chatgpt.com/codex/tasks/task_e_6893f3ad43b08326907710a45522787b