### PR TITLE
fix: escape curly braces in message format

### DIFF
--- a/inlang/packages/plugins/inlang-message-format/src/import-export/exportFiles.ts
+++ b/inlang/packages/plugins/inlang-message-format/src/import-export/exportFiles.ts
@@ -123,14 +123,14 @@ function serializeVariants(
 function serializePattern(pattern: Variant["pattern"]): string {
 	let result = "";
 
-	for (const part of pattern) {
-		if (part.type === "text") {
-			result += part.value;
-		} else if (part.arg.type === "variable-reference") {
-			result += `{${part.arg.name}}`;
-		} else {
-			throw new Error("Unsupported expression type");
-		}
+        for (const part of pattern) {
+                if (part.type === "text") {
+                        result += part.value.replace(/([\\{}])/g, "\\$1");
+                } else if (part.arg.type === "variable-reference") {
+                        result += `{${part.arg.name}}`;
+                } else {
+                        throw new Error("Unsupported expression type");
+                }
 	}
 	return result;
 }

--- a/inlang/packages/plugins/inlang-message-format/src/import-export/roundtrip.test.ts
+++ b/inlang/packages/plugins/inlang-message-format/src/import-export/roundtrip.test.ts
@@ -73,7 +73,19 @@ test("it handles variable expressions in patterns", async () => {
 			type: "text",
 			value: " designers and translators",
 		},
-	] satisfies Pattern);
+        ] satisfies Pattern);
+});
+
+test("it handles escaped curly braces", async () => {
+        const imported = await runImportFiles({
+                braces: "Escape \\{ and \\}",
+        });
+        expect(await runExportFilesParsed(imported)).toMatchObject({
+                braces: "Escape \\{ and \\}",
+        });
+        expect(imported.variants[0]?.pattern).toStrictEqual([
+                { type: "text", value: "Escape { and }" },
+        ]);
 });
 
 test("it adds the $schema property", async () => {


### PR DESCRIPTION
## Summary
- support escaping `{` and `}` in message format parser
- re-escape braces on export
- add test for escaped braces

## Testing
- `pnpm --filter @inlang/plugin-message-format exec vitest run src/import-export/roundtrip.test.ts`
- `pnpm --filter @inlang/plugin-message-format exec vitest run` *(fails: createMessageV1 is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6894ea8671a48326bcfbdcfb80d78427