### PR TITLE
feat(opral-website): add X link

### DIFF
--- a/packages/opral-website/index.html
+++ b/packages/opral-website/index.html
@@ -118,16 +118,17 @@
 			</ul>
 		</div>
 
-		<div class="footer">
-			<div class="footer-links">
-				<a href="https://opral.substack.com/" target="_blank">Blog</a>
-				<a href="https://github.com/opral/monorepo/tree/main/careers">Careers</a>
-				<a href="https://github.com/opral/monorepo">GitHub</a>
-				<a href="mailto:hello@opral.com">Contact</a>
-			</div>
-			<div class="footer-note">
-				PS Nothing is broken about this page. It's simple on purpose :)
-			</div>
-		</div>
-	</body>
+                <div class="footer">
+                        <div class="footer-links">
+                                <a href="https://opral.substack.com/" target="_blank">Blog</a>
+                                <a href="https://github.com/opral/monorepo/tree/main/careers">Careers</a>
+                                <a href="https://github.com/opral/monorepo">GitHub</a>
+                                <a href="https://x.com/opralHQ" target="_blank">X</a>
+                                <a href="mailto:hello@opral.com">Contact</a>
+                        </div>
+                        <div class="footer-note">
+                                PS Nothing is broken about this page. It's simple on purpose :)
+                        </div>
+                </div>
+        </body>
 </html>


### PR DESCRIPTION
## Summary
- add link to Opral's X (Twitter) profile in website footer

## Testing
- `pnpm lint packages/opral-website` *(fails: The value of "setMaxListeners" is out of range. It must be >= 0. Received NaN)*
- `pnpm test packages/opral-website` *(fails: The value of "setMaxListeners" is out of range. It must be >= 0. Received NaN)*

------
https://chatgpt.com/codex/tasks/task_e_689618db99708326bbf1b6b469f5b386