### PR TITLE
Remove examples section from header navigation

### DIFF
--- a/packages/lix-docs/rspress.config.ts
+++ b/packages/lix-docs/rspress.config.ts
@@ -66,7 +66,6 @@ export default defineConfig({
     darkMode: false,
     nav: [
       { text: "Guide", link: "/guide/getting-started" },
-      { text: "Examples", link: "/examples/" },
       { text: "Plugins", link: "/plugins/" },
       { text: "Reference", link: "/api/" },
     ],


### PR DESCRIPTION
## Summary
- Remove "Examples" navigation item from the lix.dev header

## Problem
Users reported that clicking the "Examples" link in the header navigation leads to a 404 page, causing confusion and poor user experience.

## Solution
Remove the Examples navigation item from the header in `packages/lix-docs/rspress.config.ts` to prevent users from encountering the 404 error.

## Test plan
- [ ] Verify the Examples link no longer appears in the header navigation
- [ ] Confirm remaining navigation items (Guide, Plugins, Reference) still work correctly
- [ ] Test that the site builds and deploys successfully

🤖 Generated with [Claude Code](https://claude.ai/code)