### PR TITLE
feat: redirect lint-rules to lix issue

### DIFF
--- a/inlang/packages/website/src/server/router.ts
+++ b/inlang/packages/website/src/server/router.ts
@@ -96,6 +96,10 @@ router.get("/c/svelte", (request, response) => {
 	);
 });
 
+router.get("/c/lint-rules", (request, response) => {
+	return response.redirect(301, "https://github.com/opral/lix-sdk/issues/239");
+});
+
 router.get("m/osslbuzt*", (request, response) => {
 	return response.redirect(
 		301,


### PR DESCRIPTION
## Summary
- redirect `/c/lint-rules` to Github issue 239

## Testing
- `pnpm exec nx lint @inlang/website` *(fails: Cannot find configuration for task @inlang/website:lint)*
- `pnpm exec nx test @inlang/website` *(fails: Cannot find configuration for task @inlang/website:test)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fd5928288326aab40156137eb93c