### PR TITLE
fix: prevent doc anchor scroll

### DIFF
--- a/inlang/packages/website/src/pages/blog/@id/+Page.tsx
+++ b/inlang/packages/website/src/pages/blog/@id/+Page.tsx
@@ -133,12 +133,23 @@ export default function Page(props: PageProps) {
 
 function Markdown(props: { markdown: string }) {
 	return (
-		<article
-			class="pt-24 pb-24 md:pt-10 prose w-full mx-auto max-w-3xl prose-code:py-0.5 prose-code:px-1 prose-code:bg-secondary-container prose-code:text-on-secondary-container prose-code:font-medium prose-code:rounded prose-code:before:hidden prose-code:after:hidden prose-p:text-base prose-sm prose-slate prose-li:py-1 prose-li:text-base prose-headings:font-semibold prose-headings:text-active-info prose-p:leading-7 prose-p:opacity-90 prose-h1:text-4xl prose-h2:text-2xl prose-h2:border-t prose-h2:border-surface-3 prose-h2:pt-8 prose-h2:pb-4 prose-h3:text-[19px] prose-h3:pb-2 prose-table:text-base"
-			// eslint-disable-next-line solid/no-innerhtml
-			innerHTML={props.markdown}
-		/>
-	);
+                <article
+                        class="pt-24 pb-24 md:pt-10 prose w-full mx-auto max-w-3xl prose-code:py-0.5 prose-code:px-1 prose-code:bg-secondary-container prose-code:text-on-secondary-container prose-code:font-medium prose-code:rounded prose-code:before:hidden prose-code:after:hidden prose-p:text-base prose-sm prose-slate prose-li:py-1 prose-li:text-base prose-headings:font-semibold prose-headings:text-active-info prose-p:leading-7 prose-p:opacity-90 prose-h1:text-4xl prose-h2:text-2xl prose-h2:border-t prose-h2:border-surface-3 prose-h2:pt-8 prose-h2:pb-4 prose-h3:text-[19px] prose-h3:pb-2 prose-table:text-base"
+                        // eslint-disable-next-line solid/no-innerhtml
+                        innerHTML={props.markdown}
+                        onMouseDown={(e) => {
+                                const anchor = (e.target as HTMLElement).closest("a");
+                                if (
+                                        anchor &&
+                                        anchor.getAttribute("href")?.startsWith("#")
+                                ) {
+                                        // Prevent smooth-scroll when selecting text near hash anchors
+                                        // which otherwise triggers an annoying scroll bug
+                                        e.preventDefault();
+                                }
+                        }}
+                />
+        );
 }
 
 function findPageBySlug(slug: string, tableOfContents: any[]) {

--- a/inlang/packages/website/src/pages/g/@uid/@id/+Page.tsx
+++ b/inlang/packages/website/src/pages/g/@uid/@id/+Page.tsx
@@ -201,13 +201,24 @@ export default function Page(props: PageProps) {
 
 function Markdown(props: { markdown: string; fullWidth?: boolean }) {
 	return (
-		<article
-			class={
-				"w-full rounded-lg col-span-1 " +
-				(props.fullWidth ? "md:col-span-4" : "md:col-span-3")
-			}
-			// eslint-disable-next-line solid/no-innerhtml
-			innerHTML={props.markdown}
-		/>
-	);
+                <article
+                        class={
+                                "w-full rounded-lg col-span-1 " +
+                                (props.fullWidth ? "md:col-span-4" : "md:col-span-3")
+                        }
+                        // eslint-disable-next-line solid/no-innerhtml
+                        innerHTML={props.markdown}
+                        onMouseDown={(e) => {
+                                const anchor = (e.target as HTMLElement).closest("a");
+                                if (
+                                        anchor &&
+                                        anchor.getAttribute("href")?.startsWith("#")
+                                ) {
+                                        // Prevent smooth-scroll when selecting text near hash anchors
+                                        // to avoid the scroll bug during text selection
+                                        e.preventDefault();
+                                }
+                        }}
+                />
+        );
 }

--- a/inlang/packages/website/src/pages/m/+Page.tsx
+++ b/inlang/packages/website/src/pages/m/+Page.tsx
@@ -109,8 +109,24 @@ export default function Page(props: PageProps) {
 						>
 							<DeprecationBanner manifest={props.manifest} />
 							{/* eslint-disable-next-line solid/no-innerhtml */}
-							<article class="w-full my-12" innerHTML={props.markdown} />
-						</InlangDoclayout>
+                                                        <article
+                                                                class="w-full my-12"
+                                                                innerHTML={props.markdown}
+                                                                onMouseDown={(e) => {
+                                                                        const anchor = (e.target as HTMLElement).closest("a");
+                                                                        if (
+                                                                                anchor &&
+                                                                                anchor
+                                                                                        .getAttribute("href")
+                                                                                        ?.startsWith("#")
+                                                                        ) {
+                                                                                // Prevent smooth-scroll when selecting text near hash anchors
+                                                                                // which triggers the scroll bug during text selection
+                                                                                e.preventDefault();
+                                                                        }
+                                                                }}
+                                                        />
+                                                </InlangDoclayout>
 						<div class="mt-20">
 							<GetHelp text="Do you have questions?" />
 						</div>


### PR DESCRIPTION
## Summary
- stop hash anchors from triggering smooth scroll when beginning text selection on docs
- document workaround with comments referencing scroll bug

## Testing
- `pnpm --filter @inlang/website _test` *(fails: Cannot find modules & TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a80e8b23c08326893d6d1469e91963