### PR TITLE
Remove unnecessary doc callout and improve text selection handling

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/docs/strategy.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/strategy.md
@@ -194,11 +194,9 @@ compile({
 });
 ```
 
-<doc-callout type="info">
 **Why the wildcard pattern always resolves**: In this configuration, the pattern `/:path(.*)?` matches **any** path. When a user visits `/about` (without a locale prefix), it matches the English pattern `/:path(.*)?` and resolves to the `en` locale. This is why the URL strategy acts as an "end condition" - it will always find a match when using wildcards.
 
-**This is also the default behavior** if you don't specify `urlPatterns` at all.
-</doc-callout>
+This is also the default behavior if you don't specify `urlPatterns` at all.
 
 #### Translated pathnames
 

--- a/inlang/packages/website/src/interface/components/doc-layout-solid/doc-layout-meta.tsx
+++ b/inlang/packages/website/src/interface/components/doc-layout-solid/doc-layout-meta.tsx
@@ -1,7 +1,7 @@
 import Link from "#src/renderer/Link.jsx";
 import { currentPageContext } from "#src/renderer/state.js";
 import type { MarketplaceManifest } from "@inlang/marketplace-manifest";
-import { Show, createEffect, createSignal, onMount, For } from "solid-js";
+import { Show, createEffect, createSignal, onMount, onCleanup, For } from "solid-js";
 // import MaterialSymbolsWarningOutlineRounded from "~icons/material-symbols/warning-outline-rounded"
 import { Chip } from "../Chip.jsx";
 import { getGithubLink } from "#src/pages/m/helper/getGithubLink.js";
@@ -43,7 +43,11 @@ const InlangDocMeta = (props: {
 
 	const findHeadlineElements = (elements: HTMLCollection) => {
 		const myHeadlines: Headlines = [];
-		for (const element of elements) {
+		if (!elements || elements.length === 0) {
+			return myHeadlines;
+		}
+		for (let i = 0; i < elements.length; i++) {
+			const element = elements[i];
 			// Check if the element is an h1 or h2
 			if (
 				element &&
@@ -194,7 +198,14 @@ const InlangDocMeta = (props: {
 			</div>
 			<Show when={props.manifest.pricing}>
 				<div
-					onClick={() => {
+					onClick={(e) => {
+						// Prevent scroll if text is selected
+						const selection = window.getSelection();
+						if (selection && selection.toString().length > 0) {
+							e.preventDefault();
+							e.stopPropagation();
+							return;
+						}
 						if (
 							headlines() &&
 							headlines().some((h) => h.anchor === "pricing")
@@ -255,9 +266,22 @@ const InlangDocMeta = (props: {
 			</Show>
 
 			<Show when={headlines() && headlines()![0]}>
-				<div
-					class={`hover:text-primary flex items-center gap-[6px] text-surface-600 cursor-pointer`}
-					onClick={() => {
+				<button
+					type="button"
+					class={`hover:text-primary flex items-center gap-[6px] text-surface-600 cursor-pointer bg-transparent border-none p-0 font-inherit`}
+					onClick={(e) => {
+						// Prevent scroll if text is selected
+						const selection = window.getSelection();
+						if (selection && selection.toString().length > 0) {
+							e.preventDefault();
+							e.stopPropagation();
+							return;
+						}
+						// Double-check we're not in the middle of a drag
+						if (e.detail === 0) {
+							// This is a programmatic click, ignore it
+							return;
+						}
 						scrollToAnchor(headlines()![0]!.anchor, "smooth");
 					}}
 				>
@@ -273,7 +297,7 @@ const InlangDocMeta = (props: {
 							d="M11 16h2v-4.2l1.6 1.6L16 12l-4-4l-4 4l1.4 1.4l1.6-1.6zm1 6q-2.075 0-3.9-.788t-3.175-2.137T2.788 15.9T2 12t.788-3.9t2.137-3.175T8.1 2.788T12 2t3.9.788t3.175 2.137T21.213 8.1T22 12t-.788 3.9t-2.137 3.175t-3.175 2.138T12 22m0-2q3.35 0 5.675-2.325T20 12t-2.325-5.675T12 4T6.325 6.325T4 12t2.325 5.675T12 20m0-8"
 						/>
 					</svg>
-				</div>
+				</button>
 			</Show>
 		</div>
 	);

--- a/inlang/packages/website/src/pages/blog/@id/+Page.tsx
+++ b/inlang/packages/website/src/pages/blog/@id/+Page.tsx
@@ -137,17 +137,6 @@ function Markdown(props: { markdown: string }) {
                         class="pt-24 pb-24 md:pt-10 prose w-full mx-auto max-w-3xl prose-code:py-0.5 prose-code:px-1 prose-code:bg-secondary-container prose-code:text-on-secondary-container prose-code:font-medium prose-code:rounded prose-code:before:hidden prose-code:after:hidden prose-p:text-base prose-sm prose-slate prose-li:py-1 prose-li:text-base prose-headings:font-semibold prose-headings:text-active-info prose-p:leading-7 prose-p:opacity-90 prose-h1:text-4xl prose-h2:text-2xl prose-h2:border-t prose-h2:border-surface-3 prose-h2:pt-8 prose-h2:pb-4 prose-h3:text-[19px] prose-h3:pb-2 prose-table:text-base"
                         // eslint-disable-next-line solid/no-innerhtml
                         innerHTML={props.markdown}
-                        onMouseDown={(e) => {
-                                const anchor = (e.target as HTMLElement).closest("a");
-                                if (
-                                        anchor &&
-                                        anchor.getAttribute("href")?.startsWith("#")
-                                ) {
-                                        // Prevent smooth-scroll when selecting text near hash anchors
-                                        // which otherwise triggers an annoying scroll bug
-                                        e.preventDefault();
-                                }
-                        }}
                 />
         );
 }

--- a/inlang/packages/website/src/pages/g/@uid/@id/+Page.tsx
+++ b/inlang/packages/website/src/pages/g/@uid/@id/+Page.tsx
@@ -208,17 +208,6 @@ function Markdown(props: { markdown: string; fullWidth?: boolean }) {
                         }
                         // eslint-disable-next-line solid/no-innerhtml
                         innerHTML={props.markdown}
-                        onMouseDown={(e) => {
-                                const anchor = (e.target as HTMLElement).closest("a");
-                                if (
-                                        anchor &&
-                                        anchor.getAttribute("href")?.startsWith("#")
-                                ) {
-                                        // Prevent smooth-scroll when selecting text near hash anchors
-                                        // to avoid the scroll bug during text selection
-                                        e.preventDefault();
-                                }
-                        }}
                 />
         );
 }

--- a/inlang/packages/website/src/renderer/app.css
+++ b/inlang/packages/website/src/renderer/app.css
@@ -82,9 +82,15 @@
 	background: var(--sl-color-neutral-300);
 }
 
-/* Scroll Offset for Anchor Links */
-article :target {
-	scroll-margin-top: -256px;
+/* Scroll Offset for Anchor Links - Using scroll-margin-top which doesn't interfere with text selection */
+/* Only apply to headings with IDs (anchor targets), not the entire article */
+article h1[id],
+article h2[id],
+article h3[id],
+article h4[id],
+article h5[id],
+article h6[id] {
+	scroll-margin-top: 200px; /* Offset for sticky header including app name bar */
 }
 
 /* Scroll Offset for Anchor Links */
@@ -315,9 +321,15 @@ sl-dialog.video-dialog::part(body) {
 	padding-top: 0;
 }
 
-/* ugly quickfix for https://github.com/opral/inlang.com/issues/117. likely breaks other parts of the UI :/ */
-html {
-  scroll-padding-top: 28rem; 
+/* Scroll Offset for Anchor Links - Using scroll-margin-top which doesn't interfere with text selection */
+/* Only apply to headings with IDs (anchor targets), not the entire article */
+article h1[id],
+article h2[id],
+article h3[id],
+article h4[id],
+article h5[id],
+article h6[id] {
+	scroll-margin-top: 200px; /* Offset for sticky header including app name bar */
 }
 
 .DocSearch-Modal {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1863,6 +1863,8 @@ importers:
         specifier: 2.1.8
         version: 2.1.8(@types/node@20.5.9)(@vitest/browser@2.1.8)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@20.5.9)(typescript@5.8.3))(sass-embedded@1.89.2)(terser@5.36.0)
 
+  inlang/packages/website/dist/server: {}
+
   inlang/packages/website/tailwind-color-plugin:
     dependencies:
       '@ctrl/tinycolor':


### PR DESCRIPTION
Eliminate a doc callout that was redundant and enhance the user experience by preventing scroll issues during text selection. Adjustments to anchor link offsets ensure smoother navigation.