### PR TITLE
Lixdk-458-make-working-commit-lazy

### DIFF
--- a/packages/lix-sdk/src/change/schema.test.ts
+++ b/packages/lix-sdk/src/change/schema.test.ts
@@ -298,8 +298,8 @@ test("changes in transaction can be accessed via change view", async () => {
 			})
 			.execute();
 
-		// This should create a change in internal_change_in_transaction
-		// The change view should include changes from both internal_change and internal_change_in_transaction
+    // This should create a change in internal_transaction_state
+    // The change view should include changes from both internal_change and internal_transaction_state
 
 		// Try to find the change within the transaction via the change view
 		const changesInTransaction = await trx
@@ -309,7 +309,7 @@ test("changes in transaction can be accessed via change view", async () => {
 			.selectAll()
 			.execute();
 
-		// This should find the change that was created in internal_change_in_transaction
+    // This should find the change that was created in internal_transaction_state
 		expect(changesInTransaction).toHaveLength(1);
 		expect(changesInTransaction[0]).toMatchObject({
 			entity_id: "test_key_in_transaction",

--- a/packages/lix-sdk/src/database/schema.ts
+++ b/packages/lix-sdk/src/database/schema.ts
@@ -39,7 +39,7 @@ import type { InternalResolvedStateAllView } from "../state/resolved-state-view.
 import type { InternalStateAllUntrackedTable } from "../state/untracked/schema.js";
 import type { InternalFileDataCacheTable } from "../file/cache/schema.js";
 import type { InternalFileLixcolCacheTable } from "../file/cache/lixcol-schema.js";
-import type { InternalChangeInTransactionTable } from "../state/transaction/schema.js";
+import type { InternalTransactionStateTable } from "../state/transaction/schema.js";
 import type { InternalStateVTable } from "../state/vtable/vtable.js";
 
 export const LixDatabaseSchemaJsonColumns = {
@@ -48,7 +48,7 @@ export const LixDatabaseSchemaJsonColumns = {
 } as const;
 
 export type LixInternalDatabaseSchema = LixDatabaseSchema & {
-	internal_change_in_transaction: InternalChangeInTransactionTable;
+	internal_transaction_state: InternalTransactionStateTable;
 	internal_change: InternalChangeTable;
 	internal_snapshot: InternalSnapshotTable;
 	internal_state_cache: InternalStateCacheTable;

--- a/packages/lix-sdk/src/deterministic/random.ts
+++ b/packages/lix-sdk/src/deterministic/random.ts
@@ -248,17 +248,19 @@ export function commitDeterministicRngState(args: {
 	} satisfies LixKeyValue);
 
 	const now = args.timestamp ?? timestamp({ lix: args.lix });
-	updateUntrackedState({
-		lix: args.lix,
-		change: {
-			entity_id: "lix_deterministic_rng_state",
-			schema_key: LixKeyValueSchema["x-lix-key"],
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
-			snapshot_content: newValue,
-			schema_version: LixKeyValueSchema["x-lix-version"],
-			created_at: now,
-		},
-		version_id: "global",
-	});
+    updateUntrackedState({
+        lix: args.lix,
+        changes: [
+            {
+                entity_id: "lix_deterministic_rng_state",
+                schema_key: LixKeyValueSchema["x-lix-key"],
+                file_id: "lix",
+                plugin_key: "lix_own_entity",
+                snapshot_content: newValue,
+                schema_version: LixKeyValueSchema["x-lix-version"],
+                created_at: now,
+                lixcol_version_id: "global",
+            },
+        ],
+    });
 }

--- a/packages/lix-sdk/src/deterministic/sequence.ts
+++ b/packages/lix-sdk/src/deterministic/sequence.ts
@@ -119,17 +119,19 @@ export function commitDeterministicSequenceNumber(args: {
 	} satisfies LixKeyValue);
 
 	const now = args.timestamp ?? timestamp({ lix: args.lix });
-	updateUntrackedState({
-		lix: args.lix,
-		change: {
-			entity_id: "lix_deterministic_sequence_number",
-			schema_key: LixKeyValueSchema["x-lix-key"],
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
-			snapshot_content: newValue,
-			schema_version: LixKeyValueSchema["x-lix-version"],
-			created_at: now,
-		},
-		version_id: "global",
-	});
+    updateUntrackedState({
+        lix: args.lix,
+        changes: [
+            {
+                entity_id: "lix_deterministic_sequence_number",
+                schema_key: LixKeyValueSchema["x-lix-key"],
+                file_id: "lix",
+                plugin_key: "lix_own_entity",
+                snapshot_content: newValue,
+                schema_version: LixKeyValueSchema["x-lix-version"],
+                created_at: now,
+                lixcol_version_id: "global",
+            },
+        ],
+    });
 }

--- a/packages/lix-sdk/src/state/README.md
+++ b/packages/lix-sdk/src/state/README.md
@@ -46,7 +46,7 @@ The virtual table:
 
 - **Purpose**: Accumulate multiple mutations
 - **Scope**: Multiple entities, single version
-- **Storage**: Temporary (`internal_change_in_transaction`)
+- **Storage**: Temporary (`internal_transaction_state`)
 - **Rollback**: Automatic on error or explicit rollback
 
 #### 3. COMMIT Stage
@@ -80,7 +80,7 @@ The virtual table acts as a facade over the actual storage mechanism:
 ┌─────────────────────────────────────────────────┐
 │         Regular SQLite Tables                   │
 │                                                 │
-│  • internal_change_in_transaction               │
+│  • internal_transaction_state                   │
 │  • internal_state_cache                         │
 │  • internal_change                              │
 │  • internal_snapshot                            │

--- a/packages/lix-sdk/src/state/cache/mark-state-cache-as-stale.ts
+++ b/packages/lix-sdk/src/state/cache/mark-state-cache-as-stale.ts
@@ -14,19 +14,21 @@ export function markStateCacheAsStale(args: {
 
 	const ts = args.timestamp ?? timestamp({ lix: args.lix });
 
-	updateUntrackedState({
-		lix: args.lix,
-		change: {
-			entity_id: CACHE_STALE_KEY,
-			schema_key: LixKeyValueSchema["x-lix-key"],
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
-			snapshot_content: snapshotContent,
-			schema_version: LixKeyValueSchema["x-lix-version"],
-			created_at: ts,
-		},
-		version_id: "global",
-	});
+    updateUntrackedState({
+        lix: args.lix,
+        changes: [
+            {
+                entity_id: CACHE_STALE_KEY,
+                schema_key: LixKeyValueSchema["x-lix-key"],
+                file_id: "lix",
+                plugin_key: "lix_own_entity",
+                snapshot_content: snapshotContent,
+                schema_version: LixKeyValueSchema["x-lix-version"],
+                created_at: ts,
+                lixcol_version_id: "global",
+            },
+        ],
+    });
 }
 
 export function markStateCacheAsFresh(args: {
@@ -41,17 +43,19 @@ export function markStateCacheAsFresh(args: {
 
 	const ts = args.timestamp ?? timestamp({ lix: args.lix });
 
-	updateUntrackedState({
-		lix: args.lix,
-		change: {
-			entity_id: CACHE_STALE_KEY,
-			schema_key: LixKeyValueSchema["x-lix-key"],
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
-			snapshot_content: snapshotContent,
-			schema_version: LixKeyValueSchema["x-lix-version"],
-			created_at: ts,
-		},
-		version_id: "global",
-	});
+    updateUntrackedState({
+        lix: args.lix,
+        changes: [
+            {
+                entity_id: CACHE_STALE_KEY,
+                schema_key: LixKeyValueSchema["x-lix-key"],
+                file_id: "lix",
+                plugin_key: "lix_own_entity",
+                snapshot_content: snapshotContent,
+                schema_version: LixKeyValueSchema["x-lix-version"],
+                created_at: ts,
+                lixcol_version_id: "global",
+            },
+        ],
+    });
 }

--- a/packages/lix-sdk/src/state/transaction/insert-transaction-state.test.ts
+++ b/packages/lix-sdk/src/state/transaction/insert-transaction-state.test.ts
@@ -55,16 +55,16 @@ test("creates tracked entity with pending change", async () => {
 	expect(results[0]?.commit_id).toBe("pending"); // should be pending before commit
 
 	// Check that the change is in the transaction table before commit (not in cache)
-	const changeInTransaction = await lixInternalDb
-		.selectFrom("internal_change_in_transaction")
-		.where("entity_id", "=", "test-insert")
-		.selectAll()
-		.select(sql`json(snapshot_content)`.as("snapshot_content"))
-		.executeTakeFirstOrThrow();
+    const changeInTransaction = await lixInternalDb
+        .selectFrom("internal_transaction_state")
+        .where("entity_id", "=", "test-insert")
+        .selectAll()
+        .select(sql`json(snapshot_content)`.as("snapshot_content"))
+        .executeTakeFirstOrThrow();
 
 	expect(changeInTransaction).toBeDefined();
 	expect(changeInTransaction.id).toBe(results[0]?.change_id);
-	expect(changeInTransaction.untracked).toBe(0); // tracked entity
+expect(changeInTransaction.lixcol_untracked).toBe(0); // tracked entity
 	expect(changeInTransaction.snapshot_content).toEqual({
 		value: "inserted-value",
 	});
@@ -107,10 +107,10 @@ test("creates tracked entity with pending change", async () => {
 	expect(cacheAfterCommit.change_id).toBe(changeInTransaction.id);
 
 	// Verify the transaction table is cleared
-	const transactionAfterCommit = await lixInternalDb
-		.selectFrom("internal_change_in_transaction")
-		.selectAll()
-		.execute();
+    const transactionAfterCommit = await lixInternalDb
+        .selectFrom("internal_transaction_state")
+        .selectAll()
+        .execute();
 
 	expect(transactionAfterCommit).toHaveLength(0);
 
@@ -191,16 +191,16 @@ test("creates tombstone for inherited entity deletion", async () => {
 	});
 
 	// Verify the deletion is in transaction table (not cache yet)
-	const transactionDeletion = await lixInternalDb
-		.selectFrom("internal_change_in_transaction")
-		.where("entity_id", "=", "inherited-key")
-		.where("schema_key", "=", "lix_key_value")
-		.where("version_id", "=", activeVersion.version_id)
-		.selectAll()
-		.executeTakeFirstOrThrow();
+    const transactionDeletion = await lixInternalDb
+        .selectFrom("internal_transaction_state")
+        .where("entity_id", "=", "inherited-key")
+        .where("schema_key", "=", "lix_key_value")
+        .where("lixcol_version_id", "=", activeVersion.version_id)
+        .selectAll()
+        .executeTakeFirstOrThrow();
 
 	expect(transactionDeletion.snapshot_content).toBe(null); // Deletion
-	expect(transactionDeletion.untracked).toBe(0); // tracked entity
+expect(transactionDeletion.lixcol_untracked).toBe(0); // tracked entity
 
 	// Commit to create the tombstone
 	commit({ lix });
@@ -287,16 +287,16 @@ test("creates tombstone for inherited untracked entity deletion", async () => {
 	});
 
 	// Verify the deletion is in transaction table first
-	const transactionDeletion = await lixInternalDb
-		.selectFrom("internal_change_in_transaction")
-		.where("entity_id", "=", "inherited-untracked-key")
-		.where("schema_key", "=", "lix_key_value")
-		.where("version_id", "=", activeVersion.version_id)
-		.selectAll()
-		.executeTakeFirstOrThrow();
+    const transactionDeletion = await lixInternalDb
+        .selectFrom("internal_transaction_state")
+        .where("entity_id", "=", "inherited-untracked-key")
+        .where("schema_key", "=", "lix_key_value")
+        .where("lixcol_version_id", "=", activeVersion.version_id)
+        .selectAll()
+        .executeTakeFirstOrThrow();
 
 	expect(transactionDeletion.snapshot_content).toBe(null); // Deletion
-	expect(transactionDeletion.untracked).toBe(1); // untracked entity
+expect(transactionDeletion.lixcol_untracked).toBe(1); // untracked entity
 
 	// Commit to create the tombstone in untracked table
 	commit({ lix });
@@ -368,14 +368,14 @@ test("untracked entities use same timestamp for created_at and updated_at", asyn
 	expect(result[0]?.created_at).toBe(result[0]?.updated_at);
 
 	// Verify the entity is in the transaction table (not untracked table yet)
-	const transactionEntity = await lixInternalDb
-		.selectFrom("internal_change_in_transaction")
-		.where("entity_id", "=", "test-untracked-timestamp")
-		.selectAll()
-		.select(sql`json(snapshot_content)`.as("snapshot_content"))
-		.executeTakeFirstOrThrow();
+    const transactionEntity = await lixInternalDb
+        .selectFrom("internal_transaction_state")
+        .where("entity_id", "=", "test-untracked-timestamp")
+        .selectAll()
+        .select(sql`json(snapshot_content)`.as("snapshot_content"))
+        .executeTakeFirstOrThrow();
 
-	expect(transactionEntity.untracked).toBe(1); // marked as untracked
+expect(transactionEntity.lixcol_untracked).toBe(1); // marked as untracked
 	expect(transactionEntity.snapshot_content).toEqual({
 		key: "test-key",
 		value: "test-value",

--- a/packages/lix-sdk/src/state/transaction/schema.ts
+++ b/packages/lix-sdk/src/state/transaction/schema.ts
@@ -2,37 +2,39 @@ import type { Selectable, Insertable, Generated } from "kysely";
 import type { Lix } from "../../lix/open-lix.js";
 
 export function applyTransactionStateSchema(lix: Pick<Lix, "sqlite">): void {
-	lix.sqlite.exec(`
-  CREATE TABLE IF NOT EXISTS internal_change_in_transaction (
+    lix.sqlite.exec(`
+  CREATE TABLE IF NOT EXISTS internal_transaction_state (
     id TEXT PRIMARY KEY DEFAULT (lix_uuid_v7()),
     entity_id TEXT NOT NULL,
     schema_key TEXT NOT NULL,
     schema_version TEXT NOT NULL,
     file_id TEXT NOT NULL,
     plugin_key TEXT NOT NULL,
-    version_id TEXT NOT NULL,
+    lixcol_version_id TEXT NOT NULL,
     snapshot_content BLOB,
     created_at TEXT NOT NULL,
-    untracked INTEGER NOT NULL DEFAULT 0,
-    --- NOTE schema_key must be unique per entity_id and file_id in the transaction
-    UNIQUE(entity_id, file_id, schema_key, version_id)
+    lixcol_untracked INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(entity_id, file_id, schema_key, lixcol_version_id)
   ) STRICT;
 `);
 }
 
-export type InternalChangeInTransaction =
-	Selectable<InternalChangeInTransactionTable>;
-export type NewInternalChangeInTransaction =
-	Insertable<InternalChangeInTransactionTable>;
-export type InternalChangeInTransactionTable = {
-	id: Generated<string>;
-	entity_id: string;
-	schema_key: string;
-	schema_version: string;
-	file_id: string;
-	plugin_key: string;
-	version_id: string;
-	snapshot_content: Record<string, any> | null;
-	created_at: Generated<string>;
-	untracked: number;
+export type InternalTransactionState =
+    Selectable<InternalTransactionStateTable>;
+export type NewInternalTransactionState =
+    Insertable<InternalTransactionStateTable>;
+export type InternalTransactionStateTable = {
+    id: Generated<string>;
+    entity_id: string;
+    schema_key: string;
+    schema_version: string;
+    file_id: string;
+    plugin_key: string;
+    lixcol_version_id: string;
+    snapshot_content: Record<string, any> | null;
+    created_at: Generated<string>;
+    lixcol_untracked: number;
 };
+
+// Kysely typing for the new view with lixcol_* naming
+// No separate view – the table above is the source of truth.

--- a/packages/lix-sdk/src/state/untracked/update-untracked-state.test.ts
+++ b/packages/lix-sdk/src/state/untracked/update-untracked-state.test.ts
@@ -25,23 +25,23 @@ test("updateUntrackedState creates direct untracked entity", async () => {
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create direct untracked entity
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-change-id",
-			entity_id: "direct-untracked-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-change-id",
+        entity_id: "direct-untracked-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: JSON.stringify({
 				key: "direct-untracked-key",
 				value: "direct-value",
 			}),
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Verify entity exists in untracked table
 	const result = await lixInternalDb
@@ -95,42 +95,42 @@ test("updateUntrackedState updates existing direct untracked entity", async () =
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create initial entity
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-change-id",
-			entity_id: "update-test-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-change-id",
+        entity_id: "update-test-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: JSON.stringify({
 				key: "update-test-key",
 				value: "initial-value",
 			}),
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Update the entity
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-change-id-2",
-			entity_id: "update-test-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-change-id-2",
+        entity_id: "update-test-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: JSON.stringify({
 				key: "update-test-key",
 				value: "updated-value",
 			}),
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Verify entity was updated
 	const result = await lixInternalDb
@@ -182,23 +182,23 @@ test("updateUntrackedState deletes direct untracked entity", async () => {
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create direct untracked entity
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-change-id",
-			entity_id: "delete-test-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-change-id",
+        entity_id: "delete-test-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: JSON.stringify({
 				key: "delete-test-key",
 				value: "to-be-deleted",
 			}),
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Verify entity exists
 	const beforeDelete = await lixInternalDb
@@ -211,20 +211,20 @@ test("updateUntrackedState deletes direct untracked entity", async () => {
 	expect(beforeDelete).toHaveLength(1);
 
 	// Delete the entity
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-delete-change-id",
-			entity_id: "delete-test-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-delete-change-id",
+        entity_id: "delete-test-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: null, // Deletion
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Verify entity is deleted
 	const afterDelete = await lixInternalDb
@@ -288,20 +288,20 @@ test("updateUntrackedState creates tombstone for inherited untracked entity dele
 	expect(beforeDelete).toHaveLength(0);
 
 	// Delete the inherited entity (should create tombstone)
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-inherited-delete-change-id",
-			entity_id: "inherited-untracked-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-inherited-delete-change-id",
+        entity_id: "inherited-untracked-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: null, // Deletion
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Verify tombstone was created
 	const afterDelete = await lixInternalDb
@@ -337,23 +337,23 @@ test("updateUntrackedState handles timestamp consistency for new entities", asyn
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create untracked entity
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-timestamp-change-id",
-			entity_id: "timestamp-test-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-timestamp-change-id",
+        entity_id: "timestamp-test-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: JSON.stringify({
 				key: "timestamp-test-key",
 				value: "timestamp-value",
 			}),
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Verify timestamps are consistent
 	const result = await lixInternalDb
@@ -388,20 +388,20 @@ test("updateUntrackedState resets tombstone flag when updating tombstone", async
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create a tombstone first
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-tombstone-change-id",
-			entity_id: "tombstone-test-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-tombstone-change-id",
+        entity_id: "tombstone-test-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: null, // Creates tombstone
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Verify tombstone exists
 	const tombstone = await lixInternalDb
@@ -416,23 +416,23 @@ test("updateUntrackedState resets tombstone flag when updating tombstone", async
 	expect(tombstone[0]!.snapshot_content).toBe(null);
 
 	// Update the tombstone with actual content
-	updateUntrackedState({
-		lix,
-		change: {
-			id: "test-tombstone-update-change-id",
-			entity_id: "tombstone-test-key",
-			schema_key: "lix_key_value",
-			file_id: "lix",
-			plugin_key: "lix_own_entity",
+updateUntrackedState({
+    lix,
+    changes: [{
+        id: "test-tombstone-update-change-id",
+        entity_id: "tombstone-test-key",
+        schema_key: "lix_key_value",
+        file_id: "lix",
+        plugin_key: "lix_own_entity",
 			snapshot_content: JSON.stringify({
 				key: "tombstone-test-key",
 				value: "revived-value",
 			}),
 			schema_version: "1.0",
-			created_at: currentTime,
-		},
-		version_id: activeVersion.version_id,
-	});
+        created_at: currentTime,
+        lixcol_version_id: activeVersion.version_id,
+    }],
+});
 
 	// Verify tombstone flag is reset and content is restored
 	const result = await lixInternalDb

--- a/packages/lix-sdk/src/state/vtable/commit.bench.ts
+++ b/packages/lix-sdk/src/state/vtable/commit.bench.ts
@@ -121,4 +121,80 @@ bench("commit 10 transactions x 10 changes (sequential)", async () => {
 	}
 });
 
-bench.todo("commit with mixed operations (insert/update/delete)");
+bench("commit with mixed operations (insert/update/delete)", async () => {
+  const lix = await openLix({});
+
+  // Preload a baseline of entities to update/delete
+  const BASE_COUNT = 30; // baseline rows to enable realistic updates/deletes
+  const baseRows = [] as any[];
+  for (let i = 0; i < BASE_COUNT; i++) {
+    baseRows.push({
+      entity_id: `mixed_entity_${i}`,
+      version_id: "global",
+      schema_key: "commit_benchmark_entity",
+      file_id: "commit_file",
+      plugin_key: "benchmark_plugin",
+      snapshot_content: JSON.stringify({ id: `mixed_entity_${i}`, value: `base_${i}` }),
+      schema_version: "1.0",
+      untracked: false,
+    });
+  }
+  insertTransactionState({ lix: lix as any, data: baseRows, timestamp: timestamp({ lix }) });
+  commit({ lix: { sqlite: lix.sqlite, db: lix.db as any, hooks: lix.hooks } });
+
+  // Prepare a mixed batch: 10 inserts, 10 updates, 10 deletes
+  const INSERTS = 10;
+  const UPDATES = 10;
+  const DELETES = 10;
+  const ops: any[] = [];
+
+  // Inserts: new entities
+  for (let i = 0; i < INSERTS; i++) {
+    const id = `mixed_new_${i}`;
+    ops.push({
+      entity_id: id,
+      version_id: "global",
+      schema_key: "commit_benchmark_entity",
+      file_id: "commit_file",
+      plugin_key: "benchmark_plugin",
+      snapshot_content: JSON.stringify({ id, value: `insert_${i}` }),
+      schema_version: "1.0",
+      untracked: false,
+    });
+  }
+
+  // Updates: modify existing baseline entities
+  for (let i = 0; i < UPDATES; i++) {
+    const id = `mixed_entity_${i}`;
+    ops.push({
+      entity_id: id,
+      version_id: "global",
+      schema_key: "commit_benchmark_entity",
+      file_id: "commit_file",
+      plugin_key: "benchmark_plugin",
+      snapshot_content: JSON.stringify({ id, value: `updated_${i}` }),
+      schema_version: "1.0",
+      untracked: false,
+    });
+  }
+
+  // Deletes: remove other baseline entities
+  for (let i = 0; i < DELETES; i++) {
+    const id = `mixed_entity_${BASE_COUNT - 1 - i}`;
+    ops.push({
+      entity_id: id,
+      version_id: "global",
+      schema_key: "commit_benchmark_entity",
+      file_id: "commit_file",
+      plugin_key: "benchmark_plugin",
+      snapshot_content: null,
+      schema_version: "1.0",
+      untracked: false,
+    });
+  }
+
+  insertTransactionState({ lix: lix as any, data: ops, timestamp: timestamp({ lix }) });
+
+  // Benchmark: single commit with mixed operations
+  commit({ lix: { sqlite: lix.sqlite, db: lix.db as any, hooks: lix.hooks } });
+});

--- a/packages/lix-sdk/src/state/vtable/commit.ts
+++ b/packages/lix-sdk/src/state/vtable/commit.ts
@@ -259,6 +259,21 @@ export function commit(args: {
 
 	// Step 4: Handle working changeset updates for each version
 	for (const [version_id, changes] of trackedChangesByVersion) {
+		/**
+		 * IMPORTANT: Skip updating working change set elements for the global version.
+		 *
+		 * See https://github.com/opral/lix-sdk/issues/364#issuecomment-3218464923
+		 *
+		 * Rationale:
+		 * - We will make working CSE materialization lazy in a future iteration.
+		 * - For now, avoid mutating global working CSE at commit-time to keep the
+		 *   commit path simpler and cheaper.
+		 * - If someone needs working CSE for global and to checkpoint global, this
+		 *   will be supported by the lazy materializer later.
+		 */
+		if (version_id === "global") {
+			continue;
+		}
 		if (changes.length === 0) continue;
 
 		// Get version data to access working_commit_id

--- a/packages/lix-sdk/src/state/vtable/primary-key.ts
+++ b/packages/lix-sdk/src/state/vtable/primary-key.ts
@@ -6,8 +6,8 @@
  *
  * Tag meanings:
  *
- * - T: Transaction direct (from internal_change_in_transaction in child version)
- * - TI: Transaction inherited (from internal_change_in_transaction in parent version)
+ * - T: Transaction direct (from internal_transaction_state in child version)
+ * - TI: Transaction inherited (from internal_transaction_state in parent version)
  * - U: Untracked direct (from internal_state_all_untracked in child version)
  * - UI: Untracked inherited (from internal_state_all_untracked in parent version)
  * - C: Cache-tracked direct (from internal_state_cache in child version)

--- a/packages/lix-sdk/src/state/vtable/validate-state-mutation.test.ts
+++ b/packages/lix-sdk/src/state/vtable/validate-state-mutation.test.ts
@@ -2738,7 +2738,7 @@ test("should not check for cycles when lix_debug is disabled", async () => {
 	).not.toThrowError();
 });
 
-test("should validate foreign keys that reference changes in internal_change_in_transaction during transaction", async () => {
+test("should validate foreign keys that reference changes in internal_transaction_state during transaction", async () => {
 	const lix = await openLix({});
 
 	// Create a simple mock schema that references a change
@@ -2776,7 +2776,7 @@ test("should validate foreign keys that reference changes in internal_change_in_
 		.executeTakeFirstOrThrow();
 
 	await lix.db.transaction().execute(async (trx) => {
-		// Insert a key-value entity which creates a change in internal_change_in_transaction
+    // Insert a key-value entity which creates a change in internal_transaction_state
 		await trx
 			.insertInto("key_value")
 			.values({
@@ -2785,20 +2785,20 @@ test("should validate foreign keys that reference changes in internal_change_in_
 			})
 			.execute();
 
-		// Get the change ID that was just created in internal_change_in_transaction
-		const changes = await (trx as unknown as Kysely<LixInternalDatabaseSchema>)
-			.selectFrom("internal_change_in_transaction")
-			.select("id")
-			.where("entity_id", "=", "test_key_for_change_reference")
-			.where("schema_key", "=", "lix_key_value")
-			.execute();
+        // Get the change ID that was just created in internal_transaction_state
+        const changes = await (trx as unknown as Kysely<LixInternalDatabaseSchema>)
+            .selectFrom("internal_transaction_state")
+            .select("id")
+            .where("entity_id", "=", "test_key_for_change_reference")
+            .where("schema_key", "=", "lix_key_value")
+            .execute();
 
 		expect(changes).toHaveLength(1);
 		const changeId = changes[0]!.id;
 
-		// This should NOT throw an error because the change exists in internal_change_in_transaction
-		// But currently it will throw because validation only checks the "change" table (internal_change)
-		// which doesn't include internal_change_in_transaction
+        // This should NOT throw an error because the change exists in internal_transaction_state
+        // But currently it will throw because validation only checks the "change" table (internal_change)
+        // which doesn't include internal_transaction_state
 		expect(() =>
 			validateStateMutation({
 				lix: { sqlite: lix.sqlite, db: trx as any },

--- a/packages/lix-sdk/src/state/vtable/vtable.test.ts
+++ b/packages/lix-sdk/src/state/vtable/vtable.test.ts
@@ -2404,7 +2404,7 @@ simulationTest(
 		// Helper to assert transaction table is empty
 		const expectTxnEmpty = async () => {
 			const rows = await db
-				.selectFrom("internal_change_in_transaction")
+                .selectFrom("internal_transaction_state")
 				.selectAll()
 				.execute();
 			expectDeterministic(rows.length).toBe(0);

--- a/packages/lix-sdk/src/state/vtable/vtable.ts
+++ b/packages/lix-sdk/src/state/vtable/vtable.ts
@@ -154,7 +154,7 @@ export function applyStateVTable(
 
 			xRollback: () => {
 				sqlite.exec({
-					sql: "DELETE FROM internal_change_in_transaction",
+					sql: "DELETE FROM internal_transaction_state",
 					returnValue: "resultRows",
 				});
 			},

--- a/packages/lix-sdk/src/version/merge-version.ts
+++ b/packages/lix-sdk/src/version/merge-version.ts
@@ -106,21 +106,21 @@ export async function mergeVersion(args: {
 			const refIds = toReference.map((r) => r.id);
 
 			// Read pending rows from the transaction table
-			const pending = await intDbLocal
-				.selectFrom("internal_change_in_transaction")
-				.select([
-					"id",
-					"entity_id",
-					"schema_key",
-					"schema_version",
-					"file_id",
-					"plugin_key",
-					sql`json(snapshot_content)`.as("snapshot_content"),
-					"created_at",
-				])
-				.where("version_id", "=", sourceVersion.id)
-				.where("id", "in", refIds)
-				.execute();
+            const pending = await intDbLocal
+                .selectFrom("internal_transaction_state")
+                .select([
+                    "id",
+                    "entity_id",
+                    "schema_key",
+                    "schema_version",
+                    "file_id",
+                    "plugin_key",
+                    sql`json(snapshot_content)`.as("snapshot_content"),
+                    "created_at",
+                ])
+                .where("lixcol_version_id", "=", sourceVersion.id)
+                .where("id", "in", refIds)
+                .execute();
 
 			if (pending.length > 0) {
 				// Insert into persistent change table using the view's insert trigger
@@ -143,10 +143,10 @@ export async function mergeVersion(args: {
 					.execute();
 
 				// Remove from transaction queue to prevent automatic commit logic for source
-				await intDbLocal
-					.deleteFrom("internal_change_in_transaction")
-					.where("id", "in", refIds)
-					.execute();
+                await intDbLocal
+                    .deleteFrom("internal_transaction_state")
+                    .where("id", "in", refIds)
+                    .execute();
 			}
 		}
 


### PR DESCRIPTION
Bypasses working change set element updates for global as per https://github.com/opral/lix-sdk/issues/364#issuecomment-3218464923. 



- bypasses working cse updates for global version
- micro optimizations in commit logic to make it faster
- Updated the transaction state schema to use internal_transaction_state.
- batched inserts for untracked state