### PR TITLE
Lixdk-425-opfs-adapter-findbyname-and-openbyid-etc

### DIFF
--- a/packages/lix-sdk/src/change/schema.test.ts
+++ b/packages/lix-sdk/src/change/schema.test.ts
@@ -298,8 +298,8 @@ test("changes in transaction can be accessed via change view", async () => {
 			})
 			.execute();
 
-    // This should create a change in internal_transaction_state
-    // The change view should include changes from both internal_change and internal_transaction_state
+		// This should create a change in internal_transaction_state
+		// The change view should include changes from both internal_change and internal_transaction_state
 
 		// Try to find the change within the transaction via the change view
 		const changesInTransaction = await trx
@@ -309,7 +309,7 @@ test("changes in transaction can be accessed via change view", async () => {
 			.selectAll()
 			.execute();
 
-    // This should find the change that was created in internal_transaction_state
+		// This should find the change that was created in internal_transaction_state
 		expect(changesInTransaction).toHaveLength(1);
 		expect(changesInTransaction[0]).toMatchObject({
 			entity_id: "test_key_in_transaction",

--- a/packages/lix-sdk/src/deterministic/random.ts
+++ b/packages/lix-sdk/src/deterministic/random.ts
@@ -248,19 +248,19 @@ export function commitDeterministicRngState(args: {
 	} satisfies LixKeyValue);
 
 	const now = args.timestamp ?? timestamp({ lix: args.lix });
-    updateUntrackedState({
-        lix: args.lix,
-        changes: [
-            {
-                entity_id: "lix_deterministic_rng_state",
-                schema_key: LixKeyValueSchema["x-lix-key"],
-                file_id: "lix",
-                plugin_key: "lix_own_entity",
-                snapshot_content: newValue,
-                schema_version: LixKeyValueSchema["x-lix-version"],
-                created_at: now,
-                lixcol_version_id: "global",
-            },
-        ],
-    });
+	updateUntrackedState({
+		lix: args.lix,
+		changes: [
+			{
+				entity_id: "lix_deterministic_rng_state",
+				schema_key: LixKeyValueSchema["x-lix-key"],
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: newValue,
+				schema_version: LixKeyValueSchema["x-lix-version"],
+				created_at: now,
+				lixcol_version_id: "global",
+			},
+		],
+	});
 }

--- a/packages/lix-sdk/src/deterministic/sequence.ts
+++ b/packages/lix-sdk/src/deterministic/sequence.ts
@@ -119,19 +119,19 @@ export function commitDeterministicSequenceNumber(args: {
 	} satisfies LixKeyValue);
 
 	const now = args.timestamp ?? timestamp({ lix: args.lix });
-    updateUntrackedState({
-        lix: args.lix,
-        changes: [
-            {
-                entity_id: "lix_deterministic_sequence_number",
-                schema_key: LixKeyValueSchema["x-lix-key"],
-                file_id: "lix",
-                plugin_key: "lix_own_entity",
-                snapshot_content: newValue,
-                schema_version: LixKeyValueSchema["x-lix-version"],
-                created_at: now,
-                lixcol_version_id: "global",
-            },
-        ],
-    });
+	updateUntrackedState({
+		lix: args.lix,
+		changes: [
+			{
+				entity_id: "lix_deterministic_sequence_number",
+				schema_key: LixKeyValueSchema["x-lix-key"],
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: newValue,
+				schema_version: LixKeyValueSchema["x-lix-version"],
+				created_at: now,
+				lixcol_version_id: "global",
+			},
+		],
+	});
 }

--- a/packages/lix-sdk/src/lix/new-lix.ts
+++ b/packages/lix-sdk/src/lix/new-lix.ts
@@ -218,21 +218,21 @@ export async function newLixFile(args?: {
 	)?.entity_id;
 
 	// Set active version using updateUntrackedState for proper inheritance handling
-    updateUntrackedState({
-        lix: { sqlite, db },
-        changes: [
-            {
-                entity_id: "active",
-                schema_key: "lix_active_version",
-                file_id: "lix",
-                plugin_key: "lix_own_entity",
-                snapshot_content: JSON.stringify({ version_id: initialVersionId }),
-                schema_version: "1.0",
-                created_at: created_at,
-                lixcol_version_id: "global",
-            },
-        ],
-    });
+	updateUntrackedState({
+		lix: { sqlite, db },
+		changes: [
+			{
+				entity_id: "active",
+				schema_key: "lix_active_version",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({ version_id: initialVersionId }),
+				schema_version: "1.0",
+				created_at: created_at,
+				lixcol_version_id: "global",
+			},
+		],
+	});
 
 	// Create anonymous account as untracked for deterministic behavior
 	const activeAccountId = generateNanoid();
@@ -242,70 +242,70 @@ export async function newLixFile(args?: {
 	const anonymousAccountName = `Anonymous ${humanName}`;
 
 	// Create the anonymous account as untracked
-    updateUntrackedState({
-        lix: { sqlite, db },
-        changes: [
-            {
-                entity_id: activeAccountId,
-                schema_key: LixAccountSchema["x-lix-key"],
-                file_id: "lix",
-                plugin_key: "lix_own_entity",
-                snapshot_content: JSON.stringify({
-                    id: activeAccountId,
-                    name: anonymousAccountName,
-                } satisfies LixAccount),
-                schema_version: LixAccountSchema["x-lix-version"],
-                created_at: created_at,
-                lixcol_version_id: "global",
-            },
-        ],
-    });
+	updateUntrackedState({
+		lix: { sqlite, db },
+		changes: [
+			{
+				entity_id: activeAccountId,
+				schema_key: LixAccountSchema["x-lix-key"],
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({
+					id: activeAccountId,
+					name: anonymousAccountName,
+				} satisfies LixAccount),
+				schema_version: LixAccountSchema["x-lix-version"],
+				created_at: created_at,
+				lixcol_version_id: "global",
+			},
+		],
+	});
 
 	// Set it as the active account
-    updateUntrackedState({
-        lix: { sqlite, db },
-        changes: [
-            {
-                entity_id: `active_${activeAccountId}`,
-                schema_key: LixActiveAccountSchema["x-lix-key"],
-                file_id: "lix",
-                plugin_key: "lix_own_entity",
-                snapshot_content: JSON.stringify({
-                    account_id: activeAccountId,
-                } satisfies LixActiveAccount),
-                schema_version: LixActiveAccountSchema["x-lix-version"],
-                created_at: created_at,
-                lixcol_version_id: "global",
-            },
-        ],
-    });
+	updateUntrackedState({
+		lix: { sqlite, db },
+		changes: [
+			{
+				entity_id: `active_${activeAccountId}`,
+				schema_key: LixActiveAccountSchema["x-lix-key"],
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({
+					account_id: activeAccountId,
+				} satisfies LixActiveAccount),
+				schema_version: LixActiveAccountSchema["x-lix-version"],
+				created_at: created_at,
+				lixcol_version_id: "global",
+			},
+		],
+	});
 
 	// Handle other untracked key values
 	const untrackedKeyValues = args?.keyValues?.filter(
 		(kv) => kv.lixcol_untracked === true
 	);
 	if (untrackedKeyValues) {
-        for (const kv of untrackedKeyValues) {
-            const versionId = kv.lixcol_version_id ?? "global";
-            updateUntrackedState({
-                lix: { sqlite, db },
-                changes: [
-                    {
-                        entity_id: kv.key,
-                        schema_key: "lix_key_value",
-                        file_id: "lix",
-                        plugin_key: "lix_own_entity",
-                        snapshot_content: JSON.stringify({
-                            key: kv.key,
-                            value: kv.value,
-                        }),
-                        schema_version: LixKeyValueSchema["x-lix-version"],
-                        created_at: created_at,
-                        lixcol_version_id: versionId,
-                    },
-                ],
-            });
-        }
+		for (const kv of untrackedKeyValues) {
+			const versionId = kv.lixcol_version_id ?? "global";
+			updateUntrackedState({
+				lix: { sqlite, db },
+				changes: [
+					{
+						entity_id: kv.key,
+						schema_key: "lix_key_value",
+						file_id: "lix",
+						plugin_key: "lix_own_entity",
+						snapshot_content: JSON.stringify({
+							key: kv.key,
+							value: kv.value,
+						}),
+						schema_version: LixKeyValueSchema["x-lix-version"],
+						created_at: created_at,
+						lixcol_version_id: versionId,
+					},
+				],
+			});
+		}
 	}
 
 	try {

--- a/packages/lix-sdk/src/lix/storage/opfs.test.ts
+++ b/packages/lix-sdk/src/lix/storage/opfs.test.ts
@@ -182,10 +182,10 @@ describe("OpfsStorage", () => {
 	});
 
 	test("persists data automatically on state mutations", async () => {
-		const path = "e2e-persist-test";
+		const id = "e2e-persist-test";
 
 		// Open lix with OPFS storage by id
-		const lix1 = await openLix({ storage: OpfsStorage.byId(path) });
+		const lix1 = await openLix({ storage: OpfsStorage.byId(id) });
 
 		// Insert some data
 		await lix1.db
@@ -202,7 +202,7 @@ describe("OpfsStorage", () => {
 		await lix1.close();
 
 		// Open the persisted blob to verify the data
-		const lix2 = await openLix({ storage: OpfsStorage.byId(path) });
+		const lix2 = await openLix({ storage: OpfsStorage.byId(id) });
 
 		// Verify the data persisted correctly
 		const result = await lix2.db

--- a/packages/lix-sdk/src/lix/storage/opfs.ts
+++ b/packages/lix-sdk/src/lix/storage/opfs.ts
@@ -292,10 +292,12 @@ export class OpfsStorage implements LixStorageAdapter {
 
 			if (this.mode?.type === "byName" && dbId && this.opfsRoot) {
 				// Update index to point name -> dbId (do not mutate DB name)
+				const desiredName = this.mode.name;
+				const root = this.opfsRoot;
 				void (async () => {
-					const index = await OpfsStorage.readIndexFile(this.opfsRoot!);
-					index.names[this.mode!.name] = dbId;
-					await OpfsStorage.writeIndexFile(this.opfsRoot!, index);
+					const index = await OpfsStorage.readIndexFile(root);
+					index.names[desiredName] = dbId;
+					await OpfsStorage.writeIndexFile(root, index);
 				})();
 			}
 		} catch (e) {

--- a/packages/lix-sdk/src/state/cache/mark-state-cache-as-stale.ts
+++ b/packages/lix-sdk/src/state/cache/mark-state-cache-as-stale.ts
@@ -14,21 +14,21 @@ export function markStateCacheAsStale(args: {
 
 	const ts = args.timestamp ?? timestamp({ lix: args.lix });
 
-    updateUntrackedState({
-        lix: args.lix,
-        changes: [
-            {
-                entity_id: CACHE_STALE_KEY,
-                schema_key: LixKeyValueSchema["x-lix-key"],
-                file_id: "lix",
-                plugin_key: "lix_own_entity",
-                snapshot_content: snapshotContent,
-                schema_version: LixKeyValueSchema["x-lix-version"],
-                created_at: ts,
-                lixcol_version_id: "global",
-            },
-        ],
-    });
+	updateUntrackedState({
+		lix: args.lix,
+		changes: [
+			{
+				entity_id: CACHE_STALE_KEY,
+				schema_key: LixKeyValueSchema["x-lix-key"],
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: snapshotContent,
+				schema_version: LixKeyValueSchema["x-lix-version"],
+				created_at: ts,
+				lixcol_version_id: "global",
+			},
+		],
+	});
 }
 
 export function markStateCacheAsFresh(args: {
@@ -43,19 +43,19 @@ export function markStateCacheAsFresh(args: {
 
 	const ts = args.timestamp ?? timestamp({ lix: args.lix });
 
-    updateUntrackedState({
-        lix: args.lix,
-        changes: [
-            {
-                entity_id: CACHE_STALE_KEY,
-                schema_key: LixKeyValueSchema["x-lix-key"],
-                file_id: "lix",
-                plugin_key: "lix_own_entity",
-                snapshot_content: snapshotContent,
-                schema_version: LixKeyValueSchema["x-lix-version"],
-                created_at: ts,
-                lixcol_version_id: "global",
-            },
-        ],
-    });
+	updateUntrackedState({
+		lix: args.lix,
+		changes: [
+			{
+				entity_id: CACHE_STALE_KEY,
+				schema_key: LixKeyValueSchema["x-lix-key"],
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: snapshotContent,
+				schema_version: LixKeyValueSchema["x-lix-version"],
+				created_at: ts,
+				lixcol_version_id: "global",
+			},
+		],
+	});
 }

--- a/packages/lix-sdk/src/state/transaction/insert-transaction-state.test.ts
+++ b/packages/lix-sdk/src/state/transaction/insert-transaction-state.test.ts
@@ -55,16 +55,16 @@ test("creates tracked entity with pending change", async () => {
 	expect(results[0]?.commit_id).toBe("pending"); // should be pending before commit
 
 	// Check that the change is in the transaction table before commit (not in cache)
-    const changeInTransaction = await lixInternalDb
-        .selectFrom("internal_transaction_state")
-        .where("entity_id", "=", "test-insert")
-        .selectAll()
-        .select(sql`json(snapshot_content)`.as("snapshot_content"))
-        .executeTakeFirstOrThrow();
+	const changeInTransaction = await lixInternalDb
+		.selectFrom("internal_transaction_state")
+		.where("entity_id", "=", "test-insert")
+		.selectAll()
+		.select(sql`json(snapshot_content)`.as("snapshot_content"))
+		.executeTakeFirstOrThrow();
 
 	expect(changeInTransaction).toBeDefined();
 	expect(changeInTransaction.id).toBe(results[0]?.change_id);
-expect(changeInTransaction.lixcol_untracked).toBe(0); // tracked entity
+	expect(changeInTransaction.lixcol_untracked).toBe(0); // tracked entity
 	expect(changeInTransaction.snapshot_content).toEqual({
 		value: "inserted-value",
 	});
@@ -107,10 +107,10 @@ expect(changeInTransaction.lixcol_untracked).toBe(0); // tracked entity
 	expect(cacheAfterCommit.change_id).toBe(changeInTransaction.id);
 
 	// Verify the transaction table is cleared
-    const transactionAfterCommit = await lixInternalDb
-        .selectFrom("internal_transaction_state")
-        .selectAll()
-        .execute();
+	const transactionAfterCommit = await lixInternalDb
+		.selectFrom("internal_transaction_state")
+		.selectAll()
+		.execute();
 
 	expect(transactionAfterCommit).toHaveLength(0);
 
@@ -191,16 +191,16 @@ test("creates tombstone for inherited entity deletion", async () => {
 	});
 
 	// Verify the deletion is in transaction table (not cache yet)
-    const transactionDeletion = await lixInternalDb
-        .selectFrom("internal_transaction_state")
-        .where("entity_id", "=", "inherited-key")
-        .where("schema_key", "=", "lix_key_value")
-        .where("lixcol_version_id", "=", activeVersion.version_id)
-        .selectAll()
-        .executeTakeFirstOrThrow();
+	const transactionDeletion = await lixInternalDb
+		.selectFrom("internal_transaction_state")
+		.where("entity_id", "=", "inherited-key")
+		.where("schema_key", "=", "lix_key_value")
+		.where("lixcol_version_id", "=", activeVersion.version_id)
+		.selectAll()
+		.executeTakeFirstOrThrow();
 
 	expect(transactionDeletion.snapshot_content).toBe(null); // Deletion
-expect(transactionDeletion.lixcol_untracked).toBe(0); // tracked entity
+	expect(transactionDeletion.lixcol_untracked).toBe(0); // tracked entity
 
 	// Commit to create the tombstone
 	commit({ lix });
@@ -287,16 +287,16 @@ test("creates tombstone for inherited untracked entity deletion", async () => {
 	});
 
 	// Verify the deletion is in transaction table first
-    const transactionDeletion = await lixInternalDb
-        .selectFrom("internal_transaction_state")
-        .where("entity_id", "=", "inherited-untracked-key")
-        .where("schema_key", "=", "lix_key_value")
-        .where("lixcol_version_id", "=", activeVersion.version_id)
-        .selectAll()
-        .executeTakeFirstOrThrow();
+	const transactionDeletion = await lixInternalDb
+		.selectFrom("internal_transaction_state")
+		.where("entity_id", "=", "inherited-untracked-key")
+		.where("schema_key", "=", "lix_key_value")
+		.where("lixcol_version_id", "=", activeVersion.version_id)
+		.selectAll()
+		.executeTakeFirstOrThrow();
 
 	expect(transactionDeletion.snapshot_content).toBe(null); // Deletion
-expect(transactionDeletion.lixcol_untracked).toBe(1); // untracked entity
+	expect(transactionDeletion.lixcol_untracked).toBe(1); // untracked entity
 
 	// Commit to create the tombstone in untracked table
 	commit({ lix });
@@ -368,14 +368,14 @@ test("untracked entities use same timestamp for created_at and updated_at", asyn
 	expect(result[0]?.created_at).toBe(result[0]?.updated_at);
 
 	// Verify the entity is in the transaction table (not untracked table yet)
-    const transactionEntity = await lixInternalDb
-        .selectFrom("internal_transaction_state")
-        .where("entity_id", "=", "test-untracked-timestamp")
-        .selectAll()
-        .select(sql`json(snapshot_content)`.as("snapshot_content"))
-        .executeTakeFirstOrThrow();
+	const transactionEntity = await lixInternalDb
+		.selectFrom("internal_transaction_state")
+		.where("entity_id", "=", "test-untracked-timestamp")
+		.selectAll()
+		.select(sql`json(snapshot_content)`.as("snapshot_content"))
+		.executeTakeFirstOrThrow();
 
-expect(transactionEntity.lixcol_untracked).toBe(1); // marked as untracked
+	expect(transactionEntity.lixcol_untracked).toBe(1); // marked as untracked
 	expect(transactionEntity.snapshot_content).toEqual({
 		key: "test-key",
 		value: "test-value",

--- a/packages/lix-sdk/src/state/transaction/insert-transaction-state.ts
+++ b/packages/lix-sdk/src/state/transaction/insert-transaction-state.ts
@@ -78,40 +78,40 @@ export function insertTransactionState(args: {
 		change_id: uuidV7({ lix: args.lix as any }),
 	}));
 
-    // Batch insert into internal_transaction_state
-    const transactionRows = dataWithChangeIds.map((data) => ({
-        id: data.change_id,
-        entity_id: data.entity_id,
-        schema_key: data.schema_key,
-        file_id: data.file_id,
-        plugin_key: data.plugin_key,
-        snapshot_content: data.snapshot_content
-            ? sql`jsonb(${data.snapshot_content})`
-            : null,
-        schema_version: data.schema_version,
-        lixcol_version_id: data.version_id,
-        created_at: _timestamp,
-        lixcol_untracked: data.untracked === true ? 1 : 0,
-    }));
+	// Batch insert into internal_transaction_state
+	const transactionRows = dataWithChangeIds.map((data) => ({
+		id: data.change_id,
+		entity_id: data.entity_id,
+		schema_key: data.schema_key,
+		file_id: data.file_id,
+		plugin_key: data.plugin_key,
+		snapshot_content: data.snapshot_content
+			? sql`jsonb(${data.snapshot_content})`
+			: null,
+		schema_version: data.schema_version,
+		lixcol_version_id: data.version_id,
+		created_at: _timestamp,
+		lixcol_untracked: data.untracked === true ? 1 : 0,
+	}));
 
-    executeSync({
-        lix: args.lix,
-        query: (args.lix.db as unknown as Kysely<LixInternalDatabaseSchema>)
-            .insertInto("internal_transaction_state")
-            .values(transactionRows)
-            .onConflict((oc) =>
-                oc
-                    .columns(["entity_id", "file_id", "schema_key", "lixcol_version_id"])
-                    .doUpdateSet((eb) => ({
-                        id: eb.ref("excluded.id"),
-                        plugin_key: eb.ref("excluded.plugin_key"),
-                        snapshot_content: eb.ref("excluded.snapshot_content"),
-                        schema_version: eb.ref("excluded.schema_version"),
-                        created_at: eb.ref("excluded.created_at"),
-                        lixcol_untracked: eb.ref("excluded.lixcol_untracked"),
-                    }))
-            ),
-    });
+	executeSync({
+		lix: args.lix,
+		query: (args.lix.db as unknown as Kysely<LixInternalDatabaseSchema>)
+			.insertInto("internal_transaction_state")
+			.values(transactionRows)
+			.onConflict((oc) =>
+				oc
+					.columns(["entity_id", "file_id", "schema_key", "lixcol_version_id"])
+					.doUpdateSet((eb) => ({
+						id: eb.ref("excluded.id"),
+						plugin_key: eb.ref("excluded.plugin_key"),
+						snapshot_content: eb.ref("excluded.snapshot_content"),
+						schema_version: eb.ref("excluded.schema_version"),
+						created_at: eb.ref("excluded.created_at"),
+						lixcol_untracked: eb.ref("excluded.lixcol_untracked"),
+					}))
+			),
+	});
 
 	// Return results for all data
 	return dataWithChangeIds.map((data) => ({

--- a/packages/lix-sdk/src/state/transaction/schema.ts
+++ b/packages/lix-sdk/src/state/transaction/schema.ts
@@ -2,7 +2,7 @@ import type { Selectable, Insertable, Generated } from "kysely";
 import type { Lix } from "../../lix/open-lix.js";
 
 export function applyTransactionStateSchema(lix: Pick<Lix, "sqlite">): void {
-    lix.sqlite.exec(`
+	lix.sqlite.exec(`
   CREATE TABLE IF NOT EXISTS internal_transaction_state (
     id TEXT PRIMARY KEY DEFAULT (lix_uuid_v7()),
     entity_id TEXT NOT NULL,
@@ -20,20 +20,20 @@ export function applyTransactionStateSchema(lix: Pick<Lix, "sqlite">): void {
 }
 
 export type InternalTransactionState =
-    Selectable<InternalTransactionStateTable>;
+	Selectable<InternalTransactionStateTable>;
 export type NewInternalTransactionState =
-    Insertable<InternalTransactionStateTable>;
+	Insertable<InternalTransactionStateTable>;
 export type InternalTransactionStateTable = {
-    id: Generated<string>;
-    entity_id: string;
-    schema_key: string;
-    schema_version: string;
-    file_id: string;
-    plugin_key: string;
-    lixcol_version_id: string;
-    snapshot_content: Record<string, any> | null;
-    created_at: Generated<string>;
-    lixcol_untracked: number;
+	id: Generated<string>;
+	entity_id: string;
+	schema_key: string;
+	schema_version: string;
+	file_id: string;
+	plugin_key: string;
+	lixcol_version_id: string;
+	snapshot_content: Record<string, any> | null;
+	created_at: Generated<string>;
+	lixcol_untracked: number;
 };
 
 // Kysely typing for the new view with lixcol_* naming

--- a/packages/lix-sdk/src/state/untracked/update-untracked-state.test.ts
+++ b/packages/lix-sdk/src/state/untracked/update-untracked-state.test.ts
@@ -25,23 +25,25 @@ test("updateUntrackedState creates direct untracked entity", async () => {
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create direct untracked entity
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-change-id",
-        entity_id: "direct-untracked-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: JSON.stringify({
-				key: "direct-untracked-key",
-				value: "direct-value",
-			}),
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-change-id",
+				entity_id: "direct-untracked-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({
+					key: "direct-untracked-key",
+					value: "direct-value",
+				}),
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Verify entity exists in untracked table
 	const result = await lixInternalDb
@@ -95,42 +97,46 @@ test("updateUntrackedState updates existing direct untracked entity", async () =
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create initial entity
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-change-id",
-        entity_id: "update-test-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: JSON.stringify({
-				key: "update-test-key",
-				value: "initial-value",
-			}),
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-change-id",
+				entity_id: "update-test-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({
+					key: "update-test-key",
+					value: "initial-value",
+				}),
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Update the entity
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-change-id-2",
-        entity_id: "update-test-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: JSON.stringify({
-				key: "update-test-key",
-				value: "updated-value",
-			}),
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-change-id-2",
+				entity_id: "update-test-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({
+					key: "update-test-key",
+					value: "updated-value",
+				}),
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Verify entity was updated
 	const result = await lixInternalDb
@@ -182,23 +188,25 @@ test("updateUntrackedState deletes direct untracked entity", async () => {
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create direct untracked entity
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-change-id",
-        entity_id: "delete-test-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: JSON.stringify({
-				key: "delete-test-key",
-				value: "to-be-deleted",
-			}),
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-change-id",
+				entity_id: "delete-test-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({
+					key: "delete-test-key",
+					value: "to-be-deleted",
+				}),
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Verify entity exists
 	const beforeDelete = await lixInternalDb
@@ -211,20 +219,22 @@ updateUntrackedState({
 	expect(beforeDelete).toHaveLength(1);
 
 	// Delete the entity
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-delete-change-id",
-        entity_id: "delete-test-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: null, // Deletion
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-delete-change-id",
+				entity_id: "delete-test-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: null, // Deletion
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Verify entity is deleted
 	const afterDelete = await lixInternalDb
@@ -288,20 +298,22 @@ test("updateUntrackedState creates tombstone for inherited untracked entity dele
 	expect(beforeDelete).toHaveLength(0);
 
 	// Delete the inherited entity (should create tombstone)
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-inherited-delete-change-id",
-        entity_id: "inherited-untracked-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: null, // Deletion
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-inherited-delete-change-id",
+				entity_id: "inherited-untracked-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: null, // Deletion
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Verify tombstone was created
 	const afterDelete = await lixInternalDb
@@ -337,23 +349,25 @@ test("updateUntrackedState handles timestamp consistency for new entities", asyn
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create untracked entity
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-timestamp-change-id",
-        entity_id: "timestamp-test-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: JSON.stringify({
-				key: "timestamp-test-key",
-				value: "timestamp-value",
-			}),
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-timestamp-change-id",
+				entity_id: "timestamp-test-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({
+					key: "timestamp-test-key",
+					value: "timestamp-value",
+				}),
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Verify timestamps are consistent
 	const result = await lixInternalDb
@@ -388,20 +402,22 @@ test("updateUntrackedState resets tombstone flag when updating tombstone", async
 	const currentTime = timestamp({ lix: lix as any });
 
 	// Create a tombstone first
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-tombstone-change-id",
-        entity_id: "tombstone-test-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: null, // Creates tombstone
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-tombstone-change-id",
+				entity_id: "tombstone-test-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: null, // Creates tombstone
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Verify tombstone exists
 	const tombstone = await lixInternalDb
@@ -416,23 +432,25 @@ updateUntrackedState({
 	expect(tombstone[0]!.snapshot_content).toBe(null);
 
 	// Update the tombstone with actual content
-updateUntrackedState({
-    lix,
-    changes: [{
-        id: "test-tombstone-update-change-id",
-        entity_id: "tombstone-test-key",
-        schema_key: "lix_key_value",
-        file_id: "lix",
-        plugin_key: "lix_own_entity",
-			snapshot_content: JSON.stringify({
-				key: "tombstone-test-key",
-				value: "revived-value",
-			}),
-			schema_version: "1.0",
-        created_at: currentTime,
-        lixcol_version_id: activeVersion.version_id,
-    }],
-});
+	updateUntrackedState({
+		lix,
+		changes: [
+			{
+				id: "test-tombstone-update-change-id",
+				entity_id: "tombstone-test-key",
+				schema_key: "lix_key_value",
+				file_id: "lix",
+				plugin_key: "lix_own_entity",
+				snapshot_content: JSON.stringify({
+					key: "tombstone-test-key",
+					value: "revived-value",
+				}),
+				schema_version: "1.0",
+				created_at: currentTime,
+				lixcol_version_id: activeVersion.version_id,
+			},
+		],
+	});
 
 	// Verify tombstone flag is reset and content is restored
 	const result = await lixInternalDb

--- a/packages/lix-sdk/src/state/untracked/update-untracked-state.ts
+++ b/packages/lix-sdk/src/state/untracked/update-untracked-state.ts
@@ -10,9 +10,9 @@ import type { Lix } from "../../lix/open-lix.js";
  * the change ID is not required.
  */
 export type UntrackedChangeData = Omit<LixChangeRaw, "id"> & {
-    id?: string;
-    /** target version for the untracked update (column maps to version_id) */
-    lixcol_version_id: string;
+	id?: string;
+	/** target version for the untracked update (column maps to version_id) */
+	lixcol_version_id: string;
 };
 
 /**
@@ -35,147 +35,149 @@ export type UntrackedChangeData = Omit<LixChangeRaw, "id"> & {
  * @param args.version_id - Version ID to update
  */
 export function updateUntrackedState(args: {
-    lix: Pick<Lix, "sqlite" | "db">;
-    changes: UntrackedChangeData[];
+	lix: Pick<Lix, "sqlite" | "db">;
+	changes: UntrackedChangeData[];
 }): void {
-    const { lix, changes } = args;
-    if (!changes || changes.length === 0) return;
+	const { lix, changes } = args;
+	if (!changes || changes.length === 0) return;
 
-    const intDb = lix.db as unknown as Kysely<LixInternalDatabaseSchema>;
+	const intDb = lix.db as unknown as Kysely<LixInternalDatabaseSchema>;
 
-    // Split into deletions and non-deletions
-    const deletions = changes.filter((c) => c.snapshot_content == null);
-    const inserts = changes.filter((c) => c.snapshot_content != null);
+	// Split into deletions and non-deletions
+	const deletions = changes.filter((c) => c.snapshot_content == null);
+	const inserts = changes.filter((c) => c.snapshot_content != null);
 
-    // 1) Handle deletions first (delete direct or create tombstones for inherited)
-    if (deletions.length > 0) {
-        // Group by version for efficient lookups
-        const byVersion = new Map<string, UntrackedChangeData[]>();
-        for (const c of deletions) {
-            const v = c.lixcol_version_id;
-            if (!byVersion.has(v)) byVersion.set(v, []);
-            byVersion.get(v)!.push(c);
-        }
+	// 1) Handle deletions first (delete direct or create tombstones for inherited)
+	if (deletions.length > 0) {
+		// Group by version for efficient lookups
+		const byVersion = new Map<string, UntrackedChangeData[]>();
+		for (const c of deletions) {
+			const v = c.lixcol_version_id;
+			if (!byVersion.has(v)) byVersion.set(v, []);
+			byVersion.get(v)!.push(c);
+		}
 
-        for (const [versionId, list] of byVersion) {
-            // Build compact IN filters and intersect in JS to find direct entries
-            const desired = new Set<string>();
-            const ent = new Set<string>();
-            const sch = new Set<string>();
-            const fil = new Set<string>();
-            for (const c of list) {
-                desired.add(`${c.entity_id}|${c.schema_key}|${c.file_id}`);
-                ent.add(c.entity_id);
-                sch.add(c.schema_key);
-                fil.add(c.file_id);
-            }
+		for (const [versionId, list] of byVersion) {
+			// Build compact IN filters and intersect in JS to find direct entries
+			const desired = new Set<string>();
+			const ent = new Set<string>();
+			const sch = new Set<string>();
+			const fil = new Set<string>();
+			for (const c of list) {
+				desired.add(`${c.entity_id}|${c.schema_key}|${c.file_id}`);
+				ent.add(c.entity_id);
+				sch.add(c.schema_key);
+				fil.add(c.file_id);
+			}
 
-            let sel = intDb
-                .selectFrom("internal_state_all_untracked")
-                .where("version_id", "=", versionId);
-            const entArr = Array.from(ent);
-            const schArr = Array.from(sch);
-            const filArr = Array.from(fil);
-            if (entArr.length > 0) sel = sel.where("entity_id", "in", entArr);
-            if (schArr.length > 0) sel = sel.where("schema_key", "in", schArr);
-            if (filArr.length > 0) sel = sel.where("file_id", "in", filArr);
+			let sel = intDb
+				.selectFrom("internal_state_all_untracked")
+				.where("version_id", "=", versionId);
+			const entArr = Array.from(ent);
+			const schArr = Array.from(sch);
+			const filArr = Array.from(fil);
+			if (entArr.length > 0) sel = sel.where("entity_id", "in", entArr);
+			if (schArr.length > 0) sel = sel.where("schema_key", "in", schArr);
+			if (filArr.length > 0) sel = sel.where("file_id", "in", filArr);
 
-            const existing = executeSync({
-                lix,
-                query: sel.select(["entity_id", "schema_key", "file_id"]),
-            });
-            const existingSet = new Set<string>(
-                existing.map((r) => `${r.entity_id}|${r.schema_key}|${r.file_id}`)
-            );
+			const existing = executeSync({
+				lix,
+				query: sel.select(["entity_id", "schema_key", "file_id"]),
+			});
+			const existingSet = new Set<string>(
+				existing.map((r) => `${r.entity_id}|${r.schema_key}|${r.file_id}`)
+			);
 
-            // Direct deletes (per-row to keep selection precise)
-            for (const c of list) {
-                const key = `${c.entity_id}|${c.schema_key}|${c.file_id}`;
-                if (existingSet.has(key)) {
-                    executeSync({
-                        lix,
-                        query: intDb
-                            .deleteFrom("internal_state_all_untracked")
-                            .where("entity_id", "=", c.entity_id)
-                            .where("schema_key", "=", c.schema_key)
-                            .where("file_id", "=", c.file_id)
-                            .where("version_id", "=", versionId),
-                    });
-                }
-            }
+			// Direct deletes (per-row to keep selection precise)
+			for (const c of list) {
+				const key = `${c.entity_id}|${c.schema_key}|${c.file_id}`;
+				if (existingSet.has(key)) {
+					executeSync({
+						lix,
+						query: intDb
+							.deleteFrom("internal_state_all_untracked")
+							.where("entity_id", "=", c.entity_id)
+							.where("schema_key", "=", c.schema_key)
+							.where("file_id", "=", c.file_id)
+							.where("version_id", "=", versionId),
+					});
+				}
+			}
 
-            // Tombstones for inherited (non-existing) entries via batched upsert
-            const tombstoneValues = list
-                .filter((c) => !existingSet.has(`${c.entity_id}|${c.schema_key}|${c.file_id}`))
-                .map((c) => ({
-                    entity_id: c.entity_id,
-                    schema_key: c.schema_key,
-                    file_id: c.file_id,
-                    version_id: versionId,
-                    plugin_key: c.plugin_key,
-                    snapshot_content: null as null,
-                    schema_version: c.schema_version,
-                    created_at: c.created_at,
-                    updated_at: c.created_at,
-                    inherited_from_version_id: null as null,
-                    inheritance_delete_marker: 1,
-                }));
+			// Tombstones for inherited (non-existing) entries via batched upsert
+			const tombstoneValues = list
+				.filter(
+					(c) => !existingSet.has(`${c.entity_id}|${c.schema_key}|${c.file_id}`)
+				)
+				.map((c) => ({
+					entity_id: c.entity_id,
+					schema_key: c.schema_key,
+					file_id: c.file_id,
+					version_id: versionId,
+					plugin_key: c.plugin_key,
+					snapshot_content: null as null,
+					schema_version: c.schema_version,
+					created_at: c.created_at,
+					updated_at: c.created_at,
+					inherited_from_version_id: null as null,
+					inheritance_delete_marker: 1,
+				}));
 
-            if (tombstoneValues.length > 0) {
-                executeSync({
-                    lix,
-                    query: intDb
-                        .insertInto("internal_state_all_untracked")
-                        .values(tombstoneValues)
-                        .onConflict((oc) =>
-                            oc
-                                .columns(["entity_id", "schema_key", "file_id", "version_id"])
-                                .doUpdateSet((eb) => ({
-                                    snapshot_content: eb.val(null),
-                                    updated_at: eb.ref("excluded.updated_at"),
-                                    inheritance_delete_marker: eb.val(1),
-                                    plugin_key: eb.ref("excluded.plugin_key"),
-                                    schema_version: eb.ref("excluded.schema_version"),
-                                }))
-                        ),
-                });
-            }
-        }
-    }
+			if (tombstoneValues.length > 0) {
+				executeSync({
+					lix,
+					query: intDb
+						.insertInto("internal_state_all_untracked")
+						.values(tombstoneValues)
+						.onConflict((oc) =>
+							oc
+								.columns(["entity_id", "schema_key", "file_id", "version_id"])
+								.doUpdateSet((eb) => ({
+									snapshot_content: eb.val(null),
+									updated_at: eb.ref("excluded.updated_at"),
+									inheritance_delete_marker: eb.val(1),
+									plugin_key: eb.ref("excluded.plugin_key"),
+									schema_version: eb.ref("excluded.schema_version"),
+								}))
+						),
+				});
+			}
+		}
+	}
 
-    // 2) Handle non-deletions: upsert actual content rows in batch using a prepared stmt
-    if (inserts.length > 0) {
-        for (const c of inserts) {
-            const content: any = c.snapshot_content as any;
-            executeSync({
-                lix,
-                query: intDb
-                    .insertInto("internal_state_all_untracked")
-                    .values({
-                        entity_id: c.entity_id,
-                        schema_key: c.schema_key,
-                        file_id: c.file_id,
-                        version_id: c.lixcol_version_id,
-                        plugin_key: c.plugin_key,
-                        snapshot_content: sql`jsonb(${content})`,
-                        schema_version: c.schema_version,
-                        created_at: c.created_at,
-                        updated_at: c.created_at,
-                        inherited_from_version_id: null,
-                        inheritance_delete_marker: 0,
-                    })
-                    .onConflict((oc) =>
-                        oc
-                            .columns(["entity_id", "schema_key", "file_id", "version_id"])
-                            .doUpdateSet({
-                                plugin_key: c.plugin_key,
-                                snapshot_content: sql`jsonb(${content})`,
-                                schema_version: c.schema_version,
-                                updated_at: c.created_at,
-                                inheritance_delete_marker: 0,
-                            })
-                    ),
-            });
-        }
-    }
+	// 2) Handle non-deletions: upsert actual content rows in batch using a prepared stmt
+	if (inserts.length > 0) {
+		for (const c of inserts) {
+			const content: any = c.snapshot_content as any;
+			executeSync({
+				lix,
+				query: intDb
+					.insertInto("internal_state_all_untracked")
+					.values({
+						entity_id: c.entity_id,
+						schema_key: c.schema_key,
+						file_id: c.file_id,
+						version_id: c.lixcol_version_id,
+						plugin_key: c.plugin_key,
+						snapshot_content: sql`jsonb(${content})`,
+						schema_version: c.schema_version,
+						created_at: c.created_at,
+						updated_at: c.created_at,
+						inherited_from_version_id: null,
+						inheritance_delete_marker: 0,
+					})
+					.onConflict((oc) =>
+						oc
+							.columns(["entity_id", "schema_key", "file_id", "version_id"])
+							.doUpdateSet({
+								plugin_key: c.plugin_key,
+								snapshot_content: sql`jsonb(${content})`,
+								schema_version: c.schema_version,
+								updated_at: c.created_at,
+								inheritance_delete_marker: 0,
+							})
+					),
+			});
+		}
+	}
 }

--- a/packages/lix-sdk/src/state/vtable/commit.bench.ts
+++ b/packages/lix-sdk/src/state/vtable/commit.bench.ts
@@ -122,79 +122,90 @@ bench("commit 10 transactions x 10 changes (sequential)", async () => {
 });
 
 bench("commit with mixed operations (insert/update/delete)", async () => {
-  const lix = await openLix({});
+	const lix = await openLix({});
 
-  // Preload a baseline of entities to update/delete
-  const BASE_COUNT = 30; // baseline rows to enable realistic updates/deletes
-  const baseRows = [] as any[];
-  for (let i = 0; i < BASE_COUNT; i++) {
-    baseRows.push({
-      entity_id: `mixed_entity_${i}`,
-      version_id: "global",
-      schema_key: "commit_benchmark_entity",
-      file_id: "commit_file",
-      plugin_key: "benchmark_plugin",
-      snapshot_content: JSON.stringify({ id: `mixed_entity_${i}`, value: `base_${i}` }),
-      schema_version: "1.0",
-      untracked: false,
-    });
-  }
-  insertTransactionState({ lix: lix as any, data: baseRows, timestamp: timestamp({ lix }) });
-  commit({ lix: { sqlite: lix.sqlite, db: lix.db as any, hooks: lix.hooks } });
+	// Preload a baseline of entities to update/delete
+	const BASE_COUNT = 30; // baseline rows to enable realistic updates/deletes
+	const baseRows = [] as any[];
+	for (let i = 0; i < BASE_COUNT; i++) {
+		baseRows.push({
+			entity_id: `mixed_entity_${i}`,
+			version_id: "global",
+			schema_key: "commit_benchmark_entity",
+			file_id: "commit_file",
+			plugin_key: "benchmark_plugin",
+			snapshot_content: JSON.stringify({
+				id: `mixed_entity_${i}`,
+				value: `base_${i}`,
+			}),
+			schema_version: "1.0",
+			untracked: false,
+		});
+	}
+	insertTransactionState({
+		lix: lix as any,
+		data: baseRows,
+		timestamp: timestamp({ lix }),
+	});
+	commit({ lix: { sqlite: lix.sqlite, db: lix.db as any, hooks: lix.hooks } });
 
-  // Prepare a mixed batch: 10 inserts, 10 updates, 10 deletes
-  const INSERTS = 10;
-  const UPDATES = 10;
-  const DELETES = 10;
-  const ops: any[] = [];
+	// Prepare a mixed batch: 10 inserts, 10 updates, 10 deletes
+	const INSERTS = 10;
+	const UPDATES = 10;
+	const DELETES = 10;
+	const ops: any[] = [];
 
-  // Inserts: new entities
-  for (let i = 0; i < INSERTS; i++) {
-    const id = `mixed_new_${i}`;
-    ops.push({
-      entity_id: id,
-      version_id: "global",
-      schema_key: "commit_benchmark_entity",
-      file_id: "commit_file",
-      plugin_key: "benchmark_plugin",
-      snapshot_content: JSON.stringify({ id, value: `insert_${i}` }),
-      schema_version: "1.0",
-      untracked: false,
-    });
-  }
+	// Inserts: new entities
+	for (let i = 0; i < INSERTS; i++) {
+		const id = `mixed_new_${i}`;
+		ops.push({
+			entity_id: id,
+			version_id: "global",
+			schema_key: "commit_benchmark_entity",
+			file_id: "commit_file",
+			plugin_key: "benchmark_plugin",
+			snapshot_content: JSON.stringify({ id, value: `insert_${i}` }),
+			schema_version: "1.0",
+			untracked: false,
+		});
+	}
 
-  // Updates: modify existing baseline entities
-  for (let i = 0; i < UPDATES; i++) {
-    const id = `mixed_entity_${i}`;
-    ops.push({
-      entity_id: id,
-      version_id: "global",
-      schema_key: "commit_benchmark_entity",
-      file_id: "commit_file",
-      plugin_key: "benchmark_plugin",
-      snapshot_content: JSON.stringify({ id, value: `updated_${i}` }),
-      schema_version: "1.0",
-      untracked: false,
-    });
-  }
+	// Updates: modify existing baseline entities
+	for (let i = 0; i < UPDATES; i++) {
+		const id = `mixed_entity_${i}`;
+		ops.push({
+			entity_id: id,
+			version_id: "global",
+			schema_key: "commit_benchmark_entity",
+			file_id: "commit_file",
+			plugin_key: "benchmark_plugin",
+			snapshot_content: JSON.stringify({ id, value: `updated_${i}` }),
+			schema_version: "1.0",
+			untracked: false,
+		});
+	}
 
-  // Deletes: remove other baseline entities
-  for (let i = 0; i < DELETES; i++) {
-    const id = `mixed_entity_${BASE_COUNT - 1 - i}`;
-    ops.push({
-      entity_id: id,
-      version_id: "global",
-      schema_key: "commit_benchmark_entity",
-      file_id: "commit_file",
-      plugin_key: "benchmark_plugin",
-      snapshot_content: null,
-      schema_version: "1.0",
-      untracked: false,
-    });
-  }
+	// Deletes: remove other baseline entities
+	for (let i = 0; i < DELETES; i++) {
+		const id = `mixed_entity_${BASE_COUNT - 1 - i}`;
+		ops.push({
+			entity_id: id,
+			version_id: "global",
+			schema_key: "commit_benchmark_entity",
+			file_id: "commit_file",
+			plugin_key: "benchmark_plugin",
+			snapshot_content: null,
+			schema_version: "1.0",
+			untracked: false,
+		});
+	}
 
-  insertTransactionState({ lix: lix as any, data: ops, timestamp: timestamp({ lix }) });
+	insertTransactionState({
+		lix: lix as any,
+		data: ops,
+		timestamp: timestamp({ lix }),
+	});
 
-  // Benchmark: single commit with mixed operations
-  commit({ lix: { sqlite: lix.sqlite, db: lix.db as any, hooks: lix.hooks } });
+	// Benchmark: single commit with mixed operations
+	commit({ lix: { sqlite: lix.sqlite, db: lix.db as any, hooks: lix.hooks } });
 });

--- a/packages/lix-sdk/src/state/vtable/commit.test.ts
+++ b/packages/lix-sdk/src/state/vtable/commit.test.ts
@@ -926,43 +926,47 @@ test("global version should move forward when mutations occur", async () => {
 });
 
 // https://github.com/opral/lix-sdk/issues/364#issuecomment-3218464923
-// 
+//
 // Verifies that working change set elements are NOT updated for the global version.
 // We intentionally assert no working elements are written for global's working commit.
 // This documents current behavior and makes it explicit until a future lazy design.
 test("does not update working change set elements for global version", async () => {
-  const lix = await openLix({});
+	const lix = await openLix({});
 
-  // Stage a tracked change in the global version
-  await lix.db
-    .insertInto("key_value_all")
-    .values({ key: "global_key", value: "global_value", lixcol_version_id: "global" })
-    .execute();
+	// Stage a tracked change in the global version
+	await lix.db
+		.insertInto("key_value_all")
+		.values({
+			key: "global_key",
+			value: "global_value",
+			lixcol_version_id: "global",
+		})
+		.execute();
 
-  // Resolve global version and its working commit
-  const globalVersion = await lix.db
-    .selectFrom("version")
-    .where("id", "=", "global")
-    .selectAll()
-    .executeTakeFirstOrThrow();
+	// Resolve global version and its working commit
+	const globalVersion = await lix.db
+		.selectFrom("version")
+		.where("id", "=", "global")
+		.selectAll()
+		.executeTakeFirstOrThrow();
 
-  const workingCommit = await lix.db
-    .selectFrom("commit")
-    .where("id", "=", globalVersion.working_commit_id)
-    .selectAll()
-    .executeTakeFirstOrThrow();
+	const workingCommit = await lix.db
+		.selectFrom("commit")
+		.where("id", "=", globalVersion.working_commit_id)
+		.selectAll()
+		.executeTakeFirstOrThrow();
 
-  // There should be no working change set element for the global working change set
-  const workingElements = await lix.db
-    .selectFrom("change_set_element_all")
-    .where("lixcol_version_id", "=", "global")
-    .where("change_set_id", "=", workingCommit.change_set_id)
-    .where("entity_id", "=", "global_key")
-    .where("schema_key", "=", "lix_key_value")
-    .selectAll()
-    .execute();
+	// There should be no working change set element for the global working change set
+	const workingElements = await lix.db
+		.selectFrom("change_set_element_all")
+		.where("lixcol_version_id", "=", "global")
+		.where("change_set_id", "=", workingCommit.change_set_id)
+		.where("entity_id", "=", "global_key")
+		.where("schema_key", "=", "lix_key_value")
+		.selectAll()
+		.execute();
 
-  expect(workingElements).toHaveLength(0);
+	expect(workingElements).toHaveLength(0);
 });
 
 /**

--- a/packages/lix-sdk/src/state/vtable/commit.ts
+++ b/packages/lix-sdk/src/state/vtable/commit.ts
@@ -41,24 +41,24 @@ export function commit(args: {
 	// Collect per-version snapshots once to avoid duplicate queries in this commit
 	const versionSnapshots = new Map<string, LixVersion>();
 
-    // Query all transaction changes
-    const allTransactionChanges = executeSync({
-        lix: args.lix,
-        query: db
-            .selectFrom("internal_transaction_state")
-            .select([
-                "id",
-                "entity_id",
-                "schema_key",
-                "schema_version",
-                "file_id",
-                "plugin_key",
-                sql`lixcol_version_id`.as("version_id"),
-                sql<string | null>`json(snapshot_content)`.as("snapshot_content"),
-                "created_at",
-                sql`lixcol_untracked`.as("untracked"),
-            ]),
-    });
+	// Query all transaction changes
+	const allTransactionChanges = executeSync({
+		lix: args.lix,
+		query: db
+			.selectFrom("internal_transaction_state")
+			.select([
+				"id",
+				"entity_id",
+				"schema_key",
+				"schema_version",
+				"file_id",
+				"plugin_key",
+				sql`lixcol_version_id`.as("version_id"),
+				sql<string | null>`json(snapshot_content)`.as("snapshot_content"),
+				"created_at",
+				sql`lixcol_untracked`.as("untracked"),
+			]),
+	});
 
 	// Separate tracked and untracked changes
 	const trackedChangesByVersion = new Map<string, any[]>();
@@ -505,7 +505,10 @@ export function commit(args: {
 				}
 
 				if (workingUntrackedBatch.length > 0) {
-					updateUntrackedState({ lix: args.lix, changes: workingUntrackedBatch });
+					updateUntrackedState({
+						lix: args.lix,
+						changes: workingUntrackedBatch,
+					});
 				}
 			}
 		}
@@ -694,11 +697,11 @@ export function commit(args: {
 		});
 	}
 
-    // Clear the transaction table after committing
-    executeSync({
-        lix: args.lix,
-        query: db.deleteFrom("internal_transaction_state"),
-    });
+	// Clear the transaction table after committing
+	executeSync({
+		lix: args.lix,
+		query: db.deleteFrom("internal_transaction_state"),
+	});
 
 	// Update cache entries for each version
 	for (const [version_id, meta] of versionMetadata) {

--- a/packages/lix-sdk/src/state/vtable/validate-state-mutation.test.ts
+++ b/packages/lix-sdk/src/state/vtable/validate-state-mutation.test.ts
@@ -2776,7 +2776,7 @@ test("should validate foreign keys that reference changes in internal_transactio
 		.executeTakeFirstOrThrow();
 
 	await lix.db.transaction().execute(async (trx) => {
-    // Insert a key-value entity which creates a change in internal_transaction_state
+		// Insert a key-value entity which creates a change in internal_transaction_state
 		await trx
 			.insertInto("key_value")
 			.values({
@@ -2785,20 +2785,20 @@ test("should validate foreign keys that reference changes in internal_transactio
 			})
 			.execute();
 
-        // Get the change ID that was just created in internal_transaction_state
-        const changes = await (trx as unknown as Kysely<LixInternalDatabaseSchema>)
-            .selectFrom("internal_transaction_state")
-            .select("id")
-            .where("entity_id", "=", "test_key_for_change_reference")
-            .where("schema_key", "=", "lix_key_value")
-            .execute();
+		// Get the change ID that was just created in internal_transaction_state
+		const changes = await (trx as unknown as Kysely<LixInternalDatabaseSchema>)
+			.selectFrom("internal_transaction_state")
+			.select("id")
+			.where("entity_id", "=", "test_key_for_change_reference")
+			.where("schema_key", "=", "lix_key_value")
+			.execute();
 
 		expect(changes).toHaveLength(1);
 		const changeId = changes[0]!.id;
 
-        // This should NOT throw an error because the change exists in internal_transaction_state
-        // But currently it will throw because validation only checks the "change" table (internal_change)
-        // which doesn't include internal_transaction_state
+		// This should NOT throw an error because the change exists in internal_transaction_state
+		// But currently it will throw because validation only checks the "change" table (internal_change)
+		// which doesn't include internal_transaction_state
 		expect(() =>
 			validateStateMutation({
 				lix: { sqlite: lix.sqlite, db: trx as any },

--- a/packages/lix-sdk/src/state/vtable/vtable.test.ts
+++ b/packages/lix-sdk/src/state/vtable/vtable.test.ts
@@ -2404,7 +2404,7 @@ simulationTest(
 		// Helper to assert transaction table is empty
 		const expectTxnEmpty = async () => {
 			const rows = await db
-                .selectFrom("internal_transaction_state")
+				.selectFrom("internal_transaction_state")
 				.selectAll()
 				.execute();
 			expectDeterministic(rows.length).toBe(0);

--- a/packages/lix-sdk/src/version/merge-version.ts
+++ b/packages/lix-sdk/src/version/merge-version.ts
@@ -106,21 +106,21 @@ export async function mergeVersion(args: {
 			const refIds = toReference.map((r) => r.id);
 
 			// Read pending rows from the transaction table
-            const pending = await intDbLocal
-                .selectFrom("internal_transaction_state")
-                .select([
-                    "id",
-                    "entity_id",
-                    "schema_key",
-                    "schema_version",
-                    "file_id",
-                    "plugin_key",
-                    sql`json(snapshot_content)`.as("snapshot_content"),
-                    "created_at",
-                ])
-                .where("lixcol_version_id", "=", sourceVersion.id)
-                .where("id", "in", refIds)
-                .execute();
+			const pending = await intDbLocal
+				.selectFrom("internal_transaction_state")
+				.select([
+					"id",
+					"entity_id",
+					"schema_key",
+					"schema_version",
+					"file_id",
+					"plugin_key",
+					sql`json(snapshot_content)`.as("snapshot_content"),
+					"created_at",
+				])
+				.where("lixcol_version_id", "=", sourceVersion.id)
+				.where("id", "in", refIds)
+				.execute();
 
 			if (pending.length > 0) {
 				// Insert into persistent change table using the view's insert trigger
@@ -143,10 +143,10 @@ export async function mergeVersion(args: {
 					.execute();
 
 				// Remove from transaction queue to prevent automatic commit logic for source
-                await intDbLocal
-                    .deleteFrom("internal_transaction_state")
-                    .where("id", "in", refIds)
-                    .execute();
+				await intDbLocal
+					.deleteFrom("internal_transaction_state")
+					.where("id", "in", refIds)
+					.execute();
 			}
 		}
 

--- a/packages/lix/plugins/prosemirror/example/src/App.tsx
+++ b/packages/lix/plugins/prosemirror/example/src/App.tsx
@@ -15,7 +15,7 @@ let lix;
 try {
 	lix = await openLix({
 		providePlugins: [prosemirrorPlugin],
-		storage: new OpfsStorage({ path: "example.lix" }),
+    storage: OpfsStorage.byName("example"),
 	});
 } catch (error) {
 	console.error("Failed to open Lix, cleaning OPFS and reloading:", error);

--- a/packages/md-app/src/helper/initializeLix.ts
+++ b/packages/md-app/src/helper/initializeLix.ts
@@ -44,7 +44,7 @@ export async function initializeLix(
 
 	if (lixFile) {
 		// Import existing file data if found
-        const storage = OpfsStorage.byId(lixId);
+		const storage = OpfsStorage.byId(lixId!);
 		lix = await openLix({
 			blob: lixFile,
 			providePlugins: [mdPlugin],
@@ -57,7 +57,7 @@ export async function initializeLix(
 		lix = await openLix({
 			blob: _newLixFile,
 			providePlugins: [mdPlugin],
-            storage: OpfsStorage.byId(lixId),
+			storage: OpfsStorage.byId(lixId),
 		});
 	}
 

--- a/packages/md-app/src/helper/initializeLix.ts
+++ b/packages/md-app/src/helper/initializeLix.ts
@@ -44,7 +44,7 @@ export async function initializeLix(
 
 	if (lixFile) {
 		// Import existing file data if found
-		const storage = new OpfsStorage({ path: `${lixId}.lix` });
+        const storage = OpfsStorage.byId(lixId);
 		lix = await openLix({
 			blob: lixFile,
 			providePlugins: [mdPlugin],
@@ -57,7 +57,7 @@ export async function initializeLix(
 		lix = await openLix({
 			blob: _newLixFile,
 			providePlugins: [mdPlugin],
-			storage: new OpfsStorage({ path: `${lixId}.lix` }),
+            storage: OpfsStorage.byId(lixId),
 		});
 	}
 

--- a/packages/md-app/src/helper/newLix.ts
+++ b/packages/md-app/src/helper/newLix.ts
@@ -6,7 +6,7 @@ export async function createNewLixFileInOpfs(): Promise<{ id: string }> {
 	await openLix({
 		blob: lixFile,
 		providePlugins: [mdPlugin],
-		storage: new OpfsStorage({ path: `${lixFile._lix.id}.lix` }),
+    storage: OpfsStorage.byId(lixFile._lix.id),
 	});
 
 	return { id: lixFile._lix.id };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1863,8 +1863,6 @@ importers:
         specifier: 2.1.8
         version: 2.1.8(@types/node@20.5.9)(@vitest/browser@2.1.8)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@20.5.9)(typescript@5.8.3))(sass-embedded@1.89.2)(terser@5.36.0)
 
-  inlang/packages/website/dist/server: {}
-
   inlang/packages/website/tailwind-color-plugin:
     dependencies:
       '@ctrl/tinycolor':


### PR DESCRIPTION
Closes https://github.com/opral/lix-sdk/issues/332

**Summary**

- Replace path-based OPFS API with explicit factories.
- Add name→id index and enforce id/name invariants.
- Make `open()` single‑flight to avoid race conditions.

**Key Changes**
- Factories: `OpfsStorage.byId(id)`, `OpfsStorage.byName(name)`, `OpfsStorage.list()`.
- Path API removal: `new OpfsStorage({ path })` is no longer supported.
- Index: `lix_opfs_storage.json` maps `name → id`; files persist as `<id>.lix`.
- Invariants:
  - byId throws if DB `lix_id` ≠ requested id.
  - byName does not mutate `lix_name` on existing files; updates index to DB’s `lix_id`.
- Concurrency: `open()` is single‑flight to prevent duplicate init/writes.
- Validation: Reject invalid ids/names (only `[A-Za-z0-9_-]` allowed).

**Migration**
- Replace `new OpfsStorage({ path: `${id}.lix` })` with:
  - `OpfsStorage.byId(id)` when you have an id
  - `OpfsStorage.byName(name)` when you want to open by name

