### PR TITLE
fix: ensure that async custom setLocale funcs resolve with reload: false

### DIFF
--- a/.changeset/stupid-nails-fix.md
+++ b/.changeset/stupid-nails-fix.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix: ensure that async custom setLocale funcs resolve with reload: false


### PR DESCRIPTION
This is a follow up PR to https://github.com/opral/monorepo/pull/3692, specifically fixing the comments from Cursor review.