### PR TITLE
add `shouldRedirect` helper

### DIFF
--- a/.changeset/isomorphic-redirects.md
+++ b/.changeset/isomorphic-redirects.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+Add an isomorphic `shouldRedirect()` helper shared by the middleware and client routers, improve redirect typing, and document the new API in the URL strategy guide.

--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/type/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/type/-internal-.md
@@ -1,3 +1,85 @@
+## ShouldRedirectClientInput
+
+Defined in: runtime/should-redirect.js:14
+
+### Properties
+
+#### locale?
+
+> `optional` **locale**: `any`
+
+Defined in: runtime/should-redirect.js:17
+
+#### request?
+
+> `optional` **request**: `undefined`
+
+Defined in: runtime/should-redirect.js:15
+
+#### url?
+
+> `optional` **url**: `string` \| `URL`
+
+Defined in: runtime/should-redirect.js:16
+
+***
+
+## ShouldRedirectResult
+
+Defined in: runtime/should-redirect.js:21
+
+### Properties
+
+#### locale
+
+> **locale**: `any`
+
+Defined in: runtime/should-redirect.js:23
+
+#### redirectUrl
+
+> **redirectUrl**: `undefined` \| `URL`
+
+Defined in: runtime/should-redirect.js:24
+
+Destination URL when a redirect is required.
+
+#### shouldRedirect
+
+> **shouldRedirect**: `boolean`
+
+Defined in: runtime/should-redirect.js:22
+
+Indicates whether the consumer should perform a redirect.
+
+***
+
+## ShouldRedirectServerInput
+
+Defined in: runtime/should-redirect.js:9
+
+### Properties
+
+#### locale?
+
+> `optional` **locale**: `any`
+
+Defined in: runtime/should-redirect.js:12
+
+#### request
+
+> **request**: `Request`
+
+Defined in: runtime/should-redirect.js:10
+
+#### url?
+
+> `optional` **url**: `string` \| `URL`
+
+Defined in: runtime/should-redirect.js:11
+
+***
+
 ## CustomClientStrategyHandler
 
 > **CustomClientStrategyHandler**\<\> = `object`
@@ -86,7 +168,7 @@ Defined in: [runtime/variables.js:54](https://github.com/opral/monorepo/tree/mai
 
 ###### locale?
 
-[`Locale`](#locale)
+[`Locale`](#locale-3)
 
 ###### messageCalls?
 
@@ -106,11 +188,11 @@ Defined in: [runtime/variables.js:54](https://github.com/opral/monorepo/tree/mai
 
 #### getStore()
 
-> **getStore**(): `undefined` \| \{ `locale?`: [`Locale`](#locale); `messageCalls?`: `Set`\<`string`\>; `origin?`: `string`; \}
+> **getStore**(): `undefined` \| \{ `locale?`: [`Locale`](#locale-3); `messageCalls?`: `Set`\<`string`\>; `origin?`: `string`; \}
 
 ##### Returns
 
-`undefined` \| \{ `locale?`: [`Locale`](#locale); `messageCalls?`: `Set`\<`string`\>; `origin?`: `string`; \}
+`undefined` \| \{ `locale?`: [`Locale`](#locale-3); `messageCalls?`: `Set`\<`string`\>; `origin?`: `string`; \}
 
 ***
 
@@ -126,7 +208,7 @@ Defined in: [runtime/set-locale.js:34](https://github.com/opral/monorepo/tree/ma
 
 #### newLocale
 
-[`Locale`](#locale)
+[`Locale`](#locale-3)
 
 #### options?
 
@@ -137,6 +219,16 @@ Defined in: [runtime/set-locale.js:34](https://github.com/opral/monorepo/tree/ma
 ### Returns
 
 `void` \| `Promise`\<`void`\>
+
+***
+
+## ShouldRedirectInput
+
+> **ShouldRedirectInput**\<\> = [`ShouldRedirectServerInput`](#shouldredirectserverinput) \| [`ShouldRedirectClientInput`](#shouldredirectclientinput)
+
+Defined in: runtime/should-redirect.js:19
+
+### Type Parameters
 
 ***
 
@@ -1015,6 +1107,58 @@ setLocale('en');
 
 ```ts
 setLocale('en', { reload: false });
+```
+
+***
+
+## shouldRedirect()
+
+> **shouldRedirect**(`input?`): `Promise`\<[`ShouldRedirectResult`](#shouldredirectresult)\>
+
+Defined in: runtime/should-redirect.js:61
+
+Determines whether a redirect is required to align the current URL with the active locale.
+
+This helper mirrors the logic that powers `paraglideMiddleware`, but works in both server
+and client environments. It evaluates the configured strategies in order, computes the
+canonical localized URL, and reports when the current URL does not match.
+
+When called in the browser without arguments, the current `window.location.href` is used.
+
+### Parameters
+
+#### input?
+
+[`ShouldRedirectInput`](#shouldredirectinput) = `{}`
+
+### Returns
+
+`Promise`\<[`ShouldRedirectResult`](#shouldredirectresult)\>
+
+### Examples
+
+```ts
+// Client side usage (e.g. TanStack Router beforeLoad hook)
+async function beforeLoad({ location }) {
+  const decision = await shouldRedirect({ url: location.href });
+
+  if (decision.shouldRedirect) {
+    throw redirect({ to: decision.redirectUrl.href });
+  }
+}
+```
+
+```ts
+// Server side usage with a Request
+export async function handle(request) {
+  const decision = await shouldRedirect({ request });
+
+  if (decision.shouldRedirect) {
+    return Response.redirect(decision.redirectUrl, 307);
+  }
+
+  return render(request, decision.locale);
+}
 ```
 
 ***

--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/type/README.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/type/README.md
@@ -40,13 +40,13 @@ Defined in: [runtime/type.ts:8](https://github.com/opral/monorepo/tree/main/inla
 
 > **defineCustomClientStrategy**: [`defineCustomClientStrategy`](-internal-.md#definecustomclientstrategy)
 
-Defined in: [runtime/type.ts:37](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:38](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### defineCustomServerStrategy
 
 > **defineCustomServerStrategy**: [`defineCustomServerStrategy`](-internal-.md#definecustomserverstrategy)
 
-Defined in: [runtime/type.ts:36](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:37](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### deLocalizeHref
 
@@ -76,43 +76,43 @@ Defined in: [runtime/type.ts:13](https://github.com/opral/monorepo/tree/main/inl
 
 > **extractLocaleFromCookie**: [`extractLocaleFromCookie`](-internal-.md#extractlocalefromcookie)
 
-Defined in: [runtime/type.ts:31](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:32](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromHeader
 
 > **extractLocaleFromHeader**: [`extractLocaleFromHeader`](-internal-.md#extractlocalefromheader)
 
-Defined in: [runtime/type.ts:32](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:33](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromNavigator
 
 > **extractLocaleFromNavigator**: [`extractLocaleFromNavigator`](-internal-.md#extractlocalefromnavigator)
 
-Defined in: [runtime/type.ts:33](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:34](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromRequest
 
 > **extractLocaleFromRequest**: [`extractLocaleFromRequest`](-internal-.md#extractlocalefromrequest)
 
-Defined in: [runtime/type.ts:29](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:30](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromRequestAsync
 
 > **extractLocaleFromRequestAsync**: [`extractLocaleFromRequestAsync`](-internal-.md#extractlocalefromrequestasync)
 
-Defined in: [runtime/type.ts:30](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:31](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### extractLocaleFromUrl
 
 > **extractLocaleFromUrl**: [`extractLocaleFromUrl`](-internal-.md#extractlocalefromurl)
 
-Defined in: [runtime/type.ts:28](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:29](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### generateStaticLocalizedUrls
 
 > **generateStaticLocalizedUrls**: [`generateStaticLocalizedUrls`](-internal-.md#generatestaticlocalizedurls)
 
-Defined in: [runtime/type.ts:34](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:35](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### getLocale
 
@@ -192,6 +192,12 @@ Defined in: [runtime/type.ts:12](https://github.com/opral/monorepo/tree/main/inl
 
 Defined in: [runtime/type.ts:16](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
+#### shouldRedirect
+
+> **shouldRedirect**: [`shouldRedirect`](-internal-.md#shouldredirect-1)
+
+Defined in: [runtime/type.ts:28](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+
 #### strategy
 
 > **strategy**: [`strategy`](-internal-.md#strategy)
@@ -202,7 +208,7 @@ Defined in: [runtime/type.ts:7](https://github.com/opral/monorepo/tree/main/inla
 
 > **trackMessageCall**: [`trackMessageCall`](-internal-.md#trackmessagecall)
 
-Defined in: [runtime/type.ts:35](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
+Defined in: [runtime/type.ts:36](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts)
 
 #### urlPatterns
 

--- a/inlang/packages/paraglide/paraglide-js/docs/server-side-rendering.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/server-side-rendering.md
@@ -60,6 +60,11 @@ await compile({
 
 <doc-video src="https://youtu.be/RO_pMjSHgpI"></doc-video>
 
+<doc-callout type="tip">
+Client routers can reuse the same redirect logic via `shouldRedirect()`. See the
+[`url` strategy guide](./strategy.md#client-side-redirects) for an example.
+</doc-callout>
+
 
 ### Disabling Async Local Storage
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/create-runtime.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/create-runtime.ts
@@ -136,6 +136,8 @@ ${injectCode("./extract-locale-from-url.js")}
 
 ${injectCode("./localize-url.js")}
 
+${injectCode("./should-redirect.js")}
+
 ${injectCode("./localize-href.js")}
 
 ${injectCode("./track-message-call.js")}

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/should-redirect.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/should-redirect.js
@@ -1,0 +1,139 @@
+import { localizeUrl } from "./localize-url.js";
+import { getLocale } from "./get-locale.js";
+import { getUrlOrigin } from "./get-url-origin.js";
+import { extractLocaleFromRequestAsync } from "./extract-locale-from-request-async.js";
+import { assertIsLocale } from "./assert-is-locale.js";
+import { strategy } from "./variables.js";
+
+/**
+ * @typedef {object} ShouldRedirectServerInput
+ * @property {Request} request
+ * @property {string | URL} [url]
+ * @property {ReturnType<typeof assertIsLocale>} [locale]
+ *
+ * @typedef {object} ShouldRedirectClientInput
+ * @property {undefined} [request]
+ * @property {string | URL} [url]
+ * @property {ReturnType<typeof assertIsLocale>} [locale]
+ *
+ * @typedef {ShouldRedirectServerInput | ShouldRedirectClientInput} ShouldRedirectInput
+ *
+ * @typedef {object} ShouldRedirectResult
+ * @property {boolean} shouldRedirect - Indicates whether the consumer should perform a redirect.
+ * @property {ReturnType<typeof assertIsLocale>} locale - Locale resolved using the configured strategies.
+ * @property {URL | undefined} redirectUrl - Destination URL when a redirect is required.
+ */
+
+/**
+ * Determines whether a redirect is required to align the current URL with the active locale.
+ *
+ * This helper mirrors the logic that powers `paraglideMiddleware`, but works in both server
+ * and client environments. It evaluates the configured strategies in order, computes the
+ * canonical localized URL, and reports when the current URL does not match.
+ *
+ * When called in the browser without arguments, the current `window.location.href` is used.
+ *
+ * @example
+ * // Client side usage (e.g. TanStack Router beforeLoad hook)
+ * async function beforeLoad({ location }) {
+ *   const decision = await shouldRedirect({ url: location.href });
+ *
+ *   if (decision.shouldRedirect) {
+ *     throw redirect({ to: decision.redirectUrl.href });
+ *   }
+ * }
+ *
+ * @example
+ * // Server side usage with a Request
+ * export async function handle(request) {
+ *   const decision = await shouldRedirect({ request });
+ *
+ *   if (decision.shouldRedirect) {
+ *     return Response.redirect(decision.redirectUrl, 307);
+ *   }
+ *
+ *   return render(request, decision.locale);
+ * }
+ *
+ * @param {ShouldRedirectInput} [input]
+ * @returns {Promise<ShouldRedirectResult>}
+ */
+export async function shouldRedirect(input = {}) {
+	const locale = /** @type {ReturnType<typeof assertIsLocale>} */ (
+		await resolveLocale(input)
+	);
+
+	if (!strategy.includes("url")) {
+		return { shouldRedirect: false, locale, redirectUrl: undefined };
+	}
+
+	const currentUrl = resolveUrl(input);
+	const localizedUrl = localizeUrl(currentUrl.href, { locale });
+
+	const shouldRedirectToLocalizedUrl =
+		normalizeUrl(localizedUrl.href) !== normalizeUrl(currentUrl.href);
+
+	return {
+		shouldRedirect: shouldRedirectToLocalizedUrl,
+		locale,
+		redirectUrl: shouldRedirectToLocalizedUrl ? localizedUrl : undefined,
+	};
+}
+
+/**
+ * Resolves the locale either from the provided input or by using the configured strategies.
+ *
+ * @param {ShouldRedirectInput} input
+ * @returns {Promise<ReturnType<typeof assertIsLocale>>}
+ */
+async function resolveLocale(input) {
+	if (input.locale) {
+		return assertIsLocale(input.locale);
+	}
+
+	if (input.request) {
+		return extractLocaleFromRequestAsync(input.request);
+	}
+
+	return getLocale();
+}
+
+/**
+ * Resolves the current URL from the provided input or runtime context.
+ *
+ * @param {ShouldRedirectInput} input
+ * @returns {URL}
+ */
+function resolveUrl(input) {
+	if (input.request) {
+		return new URL(input.request.url);
+	}
+
+	if (input.url instanceof URL) {
+		return new URL(input.url.href);
+	}
+
+	if (typeof input.url === "string") {
+		return new URL(input.url, getUrlOrigin());
+	}
+
+	if (typeof window !== "undefined" && window?.location?.href) {
+		return new URL(window.location.href);
+	}
+
+	throw new Error(
+		"shouldRedirect() requires either a request, an absolute URL, or must run in a browser environment."
+	);
+}
+
+/**
+ * Normalize url for comparison by stripping the trailing slash.
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+function normalizeUrl(url) {
+	const urlObj = new URL(url);
+	urlObj.pathname = urlObj.pathname.replace(/\/$/, "");
+	return urlObj.href;
+}

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/should-redirect.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/should-redirect.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "vitest";
+import { createParaglide } from "../create-paraglide.js";
+import { newProject } from "@inlang/sdk";
+
+test("shouldRedirect redirects to the strategy-preferred locale on the server", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "fr"],
+			},
+		}),
+		strategy: ["cookie", "url"],
+		cookieName: "PARAGLIDE_LOCALE",
+		urlPatterns: [
+			{
+				pattern: "https://example.com/:path(.*)?",
+				localized: [
+					["en", "https://example.com/en/:path(.*)?"],
+					["fr", "https://example.com/fr/:path(.*)?"],
+				],
+			},
+		],
+	});
+
+	const request = new Request("https://example.com/en/dashboard", {
+		headers: {
+			cookie: "PARAGLIDE_LOCALE=fr",
+		},
+	});
+
+	const decision = await runtime.shouldRedirect({ request });
+
+	expect(decision.shouldRedirect).toBe(true);
+	expect(decision.redirectUrl?.href).toBe("https://example.com/fr/dashboard");
+	expect(decision.locale).toBe("fr");
+});
+
+test("shouldRedirect does nothing when the URL already matches", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "fr"],
+			},
+		}),
+		strategy: ["cookie", "url"],
+		cookieName: "PARAGLIDE_LOCALE",
+		urlPatterns: [
+			{
+				pattern: "https://example.com/:path(.*)?",
+				localized: [
+					["en", "https://example.com/en/:path(.*)?"],
+					["fr", "https://example.com/fr/:path(.*)?"],
+				],
+			},
+		],
+	});
+
+	const request = new Request("https://example.com/fr/dashboard", {
+		headers: {
+			cookie: "PARAGLIDE_LOCALE=fr",
+		},
+	});
+
+	const decision = await runtime.shouldRedirect({ request });
+
+	expect(decision.shouldRedirect).toBe(false);
+	expect(decision.redirectUrl).toBeUndefined();
+	expect(decision.locale).toBe("fr");
+});
+
+test("shouldRedirect falls back to the browser URL when no input is provided", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["url", "globalVariable"],
+		isServer: "false",
+		urlPatterns: undefined,
+	});
+
+	const originalWindow = globalThis.window;
+	try {
+		globalThis.window = {
+			location: {
+				href: "https://example.com/en/profile",
+				origin: "https://example.com",
+			},
+		} as any;
+
+		runtime.overwriteGetLocale(() => "de");
+
+		const decision = await runtime.shouldRedirect();
+
+		expect(decision.shouldRedirect).toBe(true);
+		expect(decision.redirectUrl?.href).toBe("https://example.com/de/profile");
+		expect(decision.locale).toBe("de");
+	} finally {
+		if (originalWindow === undefined) {
+			Reflect.deleteProperty(globalThis, "window");
+		} else {
+			globalThis.window = originalWindow;
+		}
+	}
+});
+
+test("shouldRedirect never suggests a redirect without the url strategy", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "fr"],
+			},
+		}),
+		strategy: ["cookie"],
+		cookieName: "PARAGLIDE_LOCALE",
+	});
+
+	const request = new Request("https://example.com/en/dashboard", {
+		headers: {
+			cookie: "PARAGLIDE_LOCALE=fr",
+		},
+	});
+
+	const decision = await runtime.shouldRedirect({ request });
+
+	expect(decision.shouldRedirect).toBe(false);
+	expect(decision.redirectUrl).toBeUndefined();
+	expect(decision.locale).toBe("fr");
+});

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/type.ts
@@ -25,6 +25,7 @@ export type Runtime = {
 	deLocalizeHref: typeof import("./localize-href.js").deLocalizeHref;
 	localizeUrl: typeof import("./localize-url.js").localizeUrl;
 	deLocalizeUrl: typeof import("./localize-url.js").deLocalizeUrl;
+	shouldRedirect: typeof import("./should-redirect.js").shouldRedirect;
 	extractLocaleFromUrl: typeof import("./extract-locale-from-url.js").extractLocaleFromUrl;
 	extractLocaleFromRequest: typeof import("./extract-locale-from-request.js").extractLocaleFromRequest;
 	extractLocaleFromRequestAsync: typeof import("./extract-locale-from-request-async.js").extractLocaleFromRequestAsync;

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/middleware.js
@@ -69,35 +69,34 @@ export async function paraglideMiddleware(request, resolve, callbacks) {
 		runtime.overwriteServerAsyncLocalStorage(createMockAsyncLocalStorage());
 	}
 
-	const locale = await runtime.extractLocaleFromRequestAsync(request);
+	const decision = await runtime.shouldRedirect({ request });
+	const locale = decision.locale;
 	const origin = new URL(request.url).origin;
 
 	// if the client makes a request to a URL that doesn't match
 	// the localizedUrl, redirect the client to the localized URL
 	if (
 		request.headers.get("Sec-Fetch-Dest") === "document" &&
-		runtime.strategy.includes("url")
+		decision.shouldRedirect &&
+		decision.redirectUrl
 	) {
-		const localizedUrl = runtime.localizeUrl(request.url, { locale });
-		if (normalizeURL(localizedUrl.href) !== normalizeURL(request.url)) {
-			// Create headers object with Vary header if preferredLanguage strategy is used
-			/** @type {Record<string, string>} */
-			const headers = {};
-			if (runtime.strategy.includes("preferredLanguage")) {
-				headers["Vary"] = "Accept-Language";
-			}
-
-			const response = new Response(null, {
-				status: 307,
-				headers: {
-					Location: localizedUrl.href,
-					...headers,
-				},
-			});
-
-			callbacks?.onRedirect(response);
-			return response;
+		// Create headers object with Vary header if preferredLanguage strategy is used
+		/** @type {Record<string, string>} */
+		const headers = {};
+		if (runtime.strategy.includes("preferredLanguage")) {
+			headers["Vary"] = "Accept-Language";
 		}
+
+		const response = new Response(null, {
+			status: 307,
+			headers: {
+				Location: decision.redirectUrl.href,
+				...headers,
+			},
+		});
+
+		callbacks?.onRedirect(response);
+		return response;
 	}
 
 	// If the strategy includes "url", we need to de-localize the URL
@@ -158,19 +157,6 @@ export async function paraglideMiddleware(request, resolve, callbacks) {
 	}
 
 	return response;
-}
-
-/**
- * Normalize url for comparison.
- * Strips trailing slash
- * @param {string} url
- * @returns {string} normalized url string
- */
-function normalizeURL(url) {
-	const urlObj = new URL(url);
-	// // strip trailing slash from pathname
-	urlObj.pathname = urlObj.pathname.replace(/\/$/, "");
-	return urlObj.href;
 }
 
 /**

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/server/runtime.d.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/server/runtime.d.ts
@@ -30,6 +30,7 @@ export declare const {
 	deLocalizeHref,
 	localizeUrl,
 	deLocalizeUrl,
+	shouldRedirect,
 	extractLocaleFromUrl,
 	extractLocaleFromRequest,
 	extractLocaleFromRequestAsync,


### PR DESCRIPTION
Add an isomorphic `shouldRedirect()` helper shared by the middleware and client routers, improve redirect typing, and document the new API in the URL strategy guide.
