### PR TITLE
Update TanStack router link to official example

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/marketplace-manifest.json
+++ b/inlang/packages/paraglide/paraglide-js/marketplace-manifest.json
@@ -24,7 +24,7 @@
 		},
 		"Getting Started": {
 			"/sveltekit": "./examples/sveltekit/README.md",
-			"/tanstack-router": "https://github.com/juliomuhlbauer/tanstack-router-i18n-paraglide",
+			"/tanstack-router": "https://github.com/TanStack/router/tree/main/examples/react/i18n-paraglide",
 			"/tanstack-start": "https://github.com/juliomuhlbauer/tanstack-start-i18n-paraglide",
 			"/react-router": "./examples/react-router/README.md",
 			"/next-js": "./docs/getting-started/next-js.md",


### PR DESCRIPTION
## Summary
- Updated the Paraglide JS marketplace manifest to link to the official TanStack router example repository instead of the community-maintained repository

## Details
Changed the `/tanstack-router` link in the marketplace manifest from `https://github.com/juliomuhlbauer/tanstack-router-i18n-paraglide` to `https://github.com/TanStack/router/tree/main/examples/react/i18n-paraglide`

This points users to the official, maintained example in the TanStack router repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates marketplace manifest to point `/tanstack-router` to the official TanStack Router example URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 079a9ea70d49e43bd16e63b196d7d9c4578d9a9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->