### PR TITLE
Refactor ID generation to use custom function

### DIFF
--- a/packages/lix/sdk/package.json
+++ b/packages/lix/sdk/package.json
@@ -60,7 +60,6 @@
 		"@sqlite.org/sqlite-wasm": "^3.50.4-build1",
 		"ajv": "^8.17.1",
 		"chevrotain": "^11.0.3",
-		"human-id": "^4.1.1",
 		"kysely": "^0.28.7",
 		"uuid": "^11.1.0"
 	},

--- a/packages/lix/sdk/src/engine/functions/generate-human-id.ts
+++ b/packages/lix/sdk/src/engine/functions/generate-human-id.ts
@@ -2,7 +2,7 @@ import type { Lix } from "../../lix/open-lix.js";
 import type { LixEngine } from "../boot.js";
 import { isDeterministicModeSync } from "../deterministic-mode/is-deterministic-mode.js";
 import { nextSequenceNumberSync } from "./sequence.js";
-import { humanId as _human } from "human-id";
+import { randomSync } from "./random.js";
 // Deterministic names for anonymous accounts
 const DETERMINISTIC_NAMES = [
 	"Plum",
@@ -57,6 +57,273 @@ const DETERMINISTIC_NAMES = [
 	"Coral",
 ];
 
+const RANDOM_ADJECTIVES = [
+	"amber",
+	"artful",
+	"blithe",
+	"bold",
+	"brisk",
+	"calm",
+	"cobalt",
+	"crisp",
+	"daring",
+	"deft",
+	"dusky",
+	"eager",
+	"electric",
+	"emerald",
+	"fabled",
+	"feathered",
+	"frosted",
+	"gentle",
+	"gilded",
+	"gleaming",
+	"glowing",
+	"honeyed",
+	"hushed",
+	"icy",
+	"illustrated",
+	"iridescent",
+	"jaunty",
+	"jovial",
+	"keen",
+	"lucid",
+	"luminous",
+	"magnetic",
+	"mellow",
+	"misty",
+	"nimble",
+	"northern",
+	"novel",
+	"opal",
+	"onyx",
+	"plucky",
+	"polished",
+	"prismatic",
+	"quaint",
+	"quivering",
+	"quiet",
+	"radiant",
+	"restful",
+	"rustic",
+	"shimmering",
+	"silken",
+	"spry",
+	"sunlit",
+	"tender",
+	"tranquil",
+	"verdant",
+	"verdigris",
+	"violet",
+	"whimsical",
+	"windborne",
+	"woven",
+	"zen",
+	"zesty",
+];
+
+const RANDOM_NOUNS = [
+	"acorn",
+	"anchor",
+	"aurora",
+	"banyan",
+	"beacon",
+	"blossom",
+	"boulder",
+	"bracken",
+	"breeze",
+	"brook",
+	"cairn",
+	"canopy",
+	"canyon",
+	"cascade",
+	"cedar",
+	"celeste",
+	"chisel",
+	"cinder",
+	"cirrus",
+	"comet",
+	"copper",
+	"coral",
+	"cosmos",
+	"crest",
+	"cricket",
+	"crystal",
+	"dahlia",
+	"delta",
+	"dune",
+	"echo",
+	"ember",
+	"falcon",
+	"feather",
+	"flare",
+	"flint",
+	"forest",
+	"frost",
+	"galaxy",
+	"glade",
+	"glacier",
+	"glow",
+	"grove",
+	"harbor",
+	"harvest",
+	"horizon",
+	"iris",
+	"isle",
+	"ivory",
+	"jade",
+	"juniper",
+	"lagoon",
+	"lark",
+	"lattice",
+	"lumen",
+	"marble",
+	"meadow",
+	"meteor",
+	"mirage",
+	"mist",
+	"nimbus",
+	"oak",
+	"obsidian",
+	"ocean",
+	"orbit",
+	"otter",
+	"pine",
+	"plume",
+	"prairie",
+	"quartz",
+	"quill",
+	"raven",
+	"reef",
+	"ripple",
+	"river",
+	"saffron",
+	"sapphire",
+	"shadow",
+	"shore",
+	"signal",
+	"solace",
+	"spark",
+	"sprout",
+	"starling",
+	"stone",
+	"summit",
+	"sunrise",
+	"sycamore",
+	"thimble",
+	"thistle",
+	"tide",
+	"timber",
+	"torrent",
+	"trill",
+	"vale",
+	"velvet",
+	"vessel",
+	"violet",
+	"willow",
+	"wind",
+	"wisp",
+	"zephyr",
+	"zenith",
+];
+
+const RANDOM_NUMERIC_SUFFIX_SIZE = 1000;
+const NUMERIC_PROBABILITY_BUCKET = 10;
+const NUMERIC_PROBABILITY_THRESHOLD = 3; // ≈30% chance to append a numeric suffix
+
+function drawRandomInt({
+	size,
+	engine,
+}: {
+	size: number;
+	engine?: Pick<LixEngine, "executeSync" | "hooks" | "runtimeCacheRef">;
+}): number {
+	if (size <= 0) {
+		throw new Error("Size must be positive to draw a random integer");
+	}
+
+	const entropy = 0x1_0000_0000;
+	if (size >= entropy) {
+		const fallback = engine ? randomSync({ engine }) : Math.random();
+		return Math.floor(fallback * size);
+	}
+
+	const limit = entropy - (entropy % size);
+	while (true) {
+		const source = engine ? randomSync({ engine }) : Math.random();
+		const sample = Math.floor(source * entropy);
+		if (sample < limit) {
+			return sample % size;
+		}
+	}
+}
+
+function formatWord(word: string, capitalize: boolean): string {
+	const lower = word.toLowerCase();
+	if (!capitalize) {
+		return lower;
+	}
+	return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+function randomName({
+	capitalize,
+	engine,
+	separator,
+}: {
+	capitalize: boolean;
+	engine?: Pick<LixEngine, "executeSync" | "hooks" | "runtimeCacheRef">;
+	separator: string;
+}): string {
+	const adjective =
+		RANDOM_ADJECTIVES[
+			drawRandomInt({ size: RANDOM_ADJECTIVES.length, engine })
+		]!;
+	const noun =
+		RANDOM_NOUNS[drawRandomInt({ size: RANDOM_NOUNS.length, engine })]!;
+
+	const components = [
+		formatWord(adjective, capitalize),
+		formatWord(noun, capitalize),
+	];
+
+	const shouldAppendNumber =
+		drawRandomInt({ size: NUMERIC_PROBABILITY_BUCKET, engine }) <
+		NUMERIC_PROBABILITY_THRESHOLD;
+	if (shouldAppendNumber) {
+		const suffix = drawRandomInt({
+			size: RANDOM_NUMERIC_SUFFIX_SIZE,
+			engine,
+		});
+		components.push(String(suffix));
+	}
+
+	if (separator === "") {
+		return components.join("");
+	}
+	return components.join(separator);
+}
+
+/**
+ * @internal
+ * Generates a human readable word for anonymous IDs using non-deterministic randomness.
+ *
+ * @example
+ * const lowercase = randomHumanIdWord({ capitalize: false });
+ */
+export function randomHumanIdWord(options?: {
+	capitalize?: boolean;
+	engine?: Pick<LixEngine, "executeSync" | "hooks" | "runtimeCacheRef">;
+	separator?: string;
+}): string {
+	const separator = options?.separator ?? "_";
+	return randomName({
+		capitalize: options?.capitalize ?? true,
+		engine: options?.engine,
+		separator,
+	});
+}
+
 // Expose vocabulary size for tests that assert cycling behavior
 export function deterministicHumanIdVocabularySize(): number {
 	return DETERMINISTIC_NAMES.length;
@@ -87,25 +354,18 @@ export function humanIdSync(args: {
 		const name = DETERMINISTIC_NAMES[sequence % DETERMINISTIC_NAMES.length]!;
 		return capitalize ? name : name.toLowerCase();
 	} else {
-		// In non-deterministic mode, use human-id library
-		const name = _human({
-			capitalize: capitalize,
-			adjectiveCount: 0,
-			separator: separator,
-		})
-			// Human ID has two words, remove the last one
-			.split(separator)[0]!
-			// Human ID uses plural, remove the last character to make it singular
-			.slice(0, -1);
-
-		return name;
+		return randomHumanIdWord({
+			capitalize,
+			engine: args.engine,
+			separator,
+		});
 	}
 }
 
 /**
  * Generate a human-readable ID.
  *
- * Deterministic in deterministic mode; otherwise uses random human-id.
+ * Deterministic in deterministic mode; otherwise selects from a curated random vocabulary.
  *
  * @example
  * const name = await humanId({ lix })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1854,8 +1854,6 @@ importers:
         specifier: 2.1.8
         version: 2.1.8(@types/node@20.5.9)(@vitest/browser@2.1.8)(happy-dom@18.0.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@20.5.9)(typescript@5.8.3))(sass-embedded@1.89.2)(terser@5.36.0)
 
-  inlang/packages/website/dist/server: {}
-
   inlang/packages/website/tailwind-color-plugin:
     dependencies:
       '@ctrl/tinycolor':
@@ -2915,9 +2913,6 @@ importers:
       chevrotain:
         specifier: ^11.0.3
         version: 11.0.3
-      human-id:
-        specifier: ^4.1.1
-        version: 4.1.1
       kysely:
         specifier: ^0.28.7
         version: 0.28.7


### PR DESCRIPTION
Replace the `human-id` library with a custom `randomHumanIdWord` function for generating IDs, enhancing control over ID formatting and randomness. This change simplifies dependencies and improves maintainability.