### PR TITLE
Remove Paraglide JS ecosystem comparison row

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/docs/comparison.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/comparison.md
@@ -17,7 +17,6 @@ If you are looking for a benchmark, check out the [interactive benchmark](/m/ger
 | **Pluralization**                                          | [✅ Yes](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/variants#pluralization) | [✅ Yes](https://www.i18next.com/translation-function/plurals)             | [✅ Yes](https://formatjs.github.io/docs/core-concepts/icu-syntax#plural-format)                                  |
 | **Framework agnostic (React, Svelte, Vue, ...)**           | ✅ Yes                                                                                    | [🟠 Wrappers needed](https://github.com/i18next/react-i18next)             | [🟠 Wrappers needed](https://formatjs.github.io/docs/react-intl/#the-react-intl-package)                          |
 | **Metaframework agnostic (NextJS, SvelteKit, Astro, ...)** | ✅ Yes                                                                                    | [🟠 Wrappers needed](https://github.com/i18next/next-i18next)              | ❌ Only supports plain JS or React ([source](https://formatjs.github.io/docs/react-intl/#the-react-intl-package)) |
-| **Ecosystem**                                              | [🌱 Growing based on open inlang file format](https://github.com/opral/inlang-sdk)        | [🟠 Cloud TMS service](https://www.i18next.com/#localization-as-a-service) | ❌ Only an i18n library                                                                                           |
 
 ## Advanced Features
 


### PR DESCRIPTION
## Summary
- remove the ecosystem comparison row that described Paraglide JS as a growing project to reflect its maturity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3f80584208326ad0f76171aa69f36